### PR TITLE
Change configuration types to get them logged

### DIFF
--- a/SEImplementation/SEImplementation/Configuration/LegacyModelFittingConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/LegacyModelFittingConfig.h
@@ -24,12 +24,12 @@ public:
 
   void initialize(const UserValues& args) override;
 
-  unsigned int getMaxIterations() const {
+  int getMaxIterations() const {
     return m_max_iterations;
   }
 
 private:
-  unsigned int m_max_iterations;
+  int m_max_iterations;
 
 };
 

--- a/SEImplementation/SEImplementation/Configuration/MemoryConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/MemoryConfig.h
@@ -23,17 +23,17 @@ public:
   void initialize(const UserValues& args) override;
 
   // maximum memory allocated to ImageTiles in megabytes
-  unsigned int getTileMaxMemory() const {
+  int getTileMaxMemory() const {
     return m_max_memory;
   }
 
-  unsigned int getTileSize() const {
+  int getTileSize() const {
     return m_tile_size;
   }
 
 private:
-  unsigned int m_max_memory;
-  unsigned int m_tile_size;
+  int m_max_memory;
+  int m_tile_size;
 };
 
 

--- a/SEImplementation/src/lib/Configuration/BackgroundConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/BackgroundConfig.cpp
@@ -24,9 +24,9 @@ BackgroundConfig::BackgroundConfig(long manager_id) :
 
 std::map<std::string, Configuration::OptionDescriptionList> BackgroundConfig::getProgramOptions() {
   return { {"Detection image", {
-      {BACKGROUND_VALUE.c_str(), po::value<SeFloat>(),
+      {BACKGROUND_VALUE.c_str(), po::value<double>(),
           "Background value to be subtracted from the detection image."},
-      {THRESHOLD_VALUE.c_str(), po::value<SeFloat>()->default_value((1.5)),
+      {THRESHOLD_VALUE.c_str(), po::value<double>()->default_value((1.5)),
           "Detection threshold above the background."},
   }}};
 }
@@ -34,11 +34,11 @@ std::map<std::string, Configuration::OptionDescriptionList> BackgroundConfig::ge
 void BackgroundConfig::initialize(const UserValues& args) {
   if (args.find(BACKGROUND_VALUE) != args.end()) {
     m_background_level_absolute = true;
-    m_background_level = args.find(BACKGROUND_VALUE)->second.as<SeFloat>();
+    m_background_level = args.find(BACKGROUND_VALUE)->second.as<double>();
   }
   if (args.find(THRESHOLD_VALUE) != args.end()) {
     m_detection_threshold_absolute = true;
-    m_detection_threshold = args.find(THRESHOLD_VALUE)->second.as<SeFloat>();
+    m_detection_threshold = args.find(THRESHOLD_VALUE)->second.as<double>();
   }
 }
 

--- a/SEImplementation/src/lib/Configuration/CleaningConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/CleaningConfig.cpp
@@ -28,13 +28,16 @@ std::map<std::string, Configuration::OptionDescriptionList> CleaningConfig::getP
   return { {"Cleaning", {
       {USE_CLEANING.c_str(), po::bool_switch(),
          "Enables the cleaning of sources (removes false detections near bright objects)"},
-      {CLEANING_MINAREA.c_str(), po::value<unsigned int>()->default_value(3), "min. # of pixels above threshold"}
+      {CLEANING_MINAREA.c_str(), po::value<int>()->default_value(3), "min. # of pixels above threshold"}
   }}};
 }
 
 void CleaningConfig::initialize(const UserValues& args) {
-  auto min_area = args.at(CLEANING_MINAREA).as<unsigned int>();
+  auto min_area = args.at(CLEANING_MINAREA).as<int>();
   if (args.at(USE_CLEANING).as<bool>()) {
+    if (min_area <= 0) {
+        throw Elements::Exception() << "Invalid " << CLEANING_MINAREA << " value: " << min_area;
+    }
     getDependency<DeblendStepConfig>().addDeblendStepCreator(
         [min_area](std::shared_ptr<SourceFactory> source_factory) {
           return std::make_shared<Cleaning>(source_factory, min_area);

--- a/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
@@ -19,14 +19,17 @@ LegacyModelFittingConfig::LegacyModelFittingConfig(long manager_id) : Configurat
 
 auto LegacyModelFittingConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return { {"Model Fitting", {
-      {MFIT_MAX_ITERATIONS.c_str(), po::value<unsigned int>()->default_value(1000), "Maximum number of iterations allowed for model fitting"},
+      {MFIT_MAX_ITERATIONS.c_str(), po::value<int>()->default_value(1000), "Maximum number of iterations allowed for model fitting"},
   }}};
 
   return {};
 }
 
 void LegacyModelFittingConfig::initialize(const UserValues& args) {
-  m_max_iterations = args.at(MFIT_MAX_ITERATIONS).as<unsigned int>();
+  m_max_iterations = args.at(MFIT_MAX_ITERATIONS).as<int>();
+  if (m_max_iterations <= 0) {
+    throw Elements::Exception() << "Invalid " << MFIT_MAX_ITERATIONS << " value: " << m_max_iterations;
+  }
 }
 
 } /* namespace SExtractor */

--- a/SEImplementation/src/lib/Configuration/MemoryConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MemoryConfig.cpp
@@ -20,16 +20,22 @@ MemoryConfig::MemoryConfig(long manager_id) : Configuration(manager_id) {
 
 auto MemoryConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return { {"Memory usage", {
-      {MAX_TILE_MEMORY.c_str(), po::value<unsigned int>()->default_value(512), "Maximum memory used for image tiles cache in megabytes"},
-      {TILE_SIZE.c_str(), po::value<unsigned int>()->default_value(256), "Image tiles size in pixels"},
+      {MAX_TILE_MEMORY.c_str(), po::value<int>()->default_value(512), "Maximum memory used for image tiles cache in megabytes"},
+      {TILE_SIZE.c_str(), po::value<int>()->default_value(256), "Image tiles size in pixels"},
   }}};
 
   return {};
 }
 
 void MemoryConfig::initialize(const UserValues& args) {
-  m_max_memory = args.at(MAX_TILE_MEMORY).as<unsigned int>();
-  m_tile_size = args.at(TILE_SIZE).as<unsigned int>();
+  m_max_memory = args.at(MAX_TILE_MEMORY).as<int>();
+  m_tile_size = args.at(TILE_SIZE).as<int>();
+  if (m_max_memory <= 0) {
+    throw Elements::Exception() << "Invalid " << MAX_TILE_MEMORY << " value: " << m_max_memory;
+  }
+  if (m_tile_size <= 0) {
+    throw Elements::Exception() << "Invalid " << TILE_SIZE << " value: " << m_tile_size;
+  }
 }
 
 } /* namespace SExtractor */

--- a/SEImplementation/src/lib/Configuration/MultiThresholdPartitionConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MultiThresholdPartitionConfig.cpp
@@ -30,8 +30,8 @@ MultiThresholdPartitionConfig::MultiThresholdPartitionConfig(long manager_id) : 
 auto MultiThresholdPartitionConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return { {"Multi-thresholding", {
       {MTHRESH_USE.c_str(), po::bool_switch(), "activates multithreshold partitioning"},
-      {MTHRESH_THRESHOLDS_NB.c_str(), po::value<unsigned int>()->default_value(32), "# of thresholds"},
-      {MTHRESH_MIN_AREA.c_str(), po::value<unsigned int>()->default_value(3), "min area in pixels to consider partitioning"},
+      {MTHRESH_THRESHOLDS_NB.c_str(), po::value<int>()->default_value(32), "# of thresholds"},
+      {MTHRESH_MIN_AREA.c_str(), po::value<int>()->default_value(3), "min area in pixels to consider partitioning"},
       {MTHRESH_MIN_CONTRAST.c_str(), po::value<double>()->default_value(0.005), "min contrast of for partitioning"}
   }}};
 
@@ -40,9 +40,16 @@ auto MultiThresholdPartitionConfig::getProgramOptions() -> std::map<std::string,
 
 void MultiThresholdPartitionConfig::initialize(const UserValues& args) {
   if (args.at(MTHRESH_USE).as<bool>()) {
-    auto threshold_nb = args.at(MTHRESH_THRESHOLDS_NB).as<unsigned int>();
-    auto min_area = args.at(MTHRESH_MIN_AREA).as<unsigned int>();
+    auto threshold_nb = args.at(MTHRESH_THRESHOLDS_NB).as<int>();
+    auto min_area = args.at(MTHRESH_MIN_AREA).as<int>();
     auto min_contrast = args.at(MTHRESH_MIN_CONTRAST).as<double>();
+
+    if (min_area <= 0) {
+        throw Elements::Exception() << "Invalid " << MTHRESH_MIN_AREA << " value: " << min_area;
+    }
+    if (threshold_nb <= 0) {
+        throw Elements::Exception() << "Invalid " << MTHRESH_THRESHOLDS_NB << " value: " << threshold_nb;
+    }
 
     getDependency<PartitionStepConfig>().addPartitionStepCreator(
       [=](std::shared_ptr<SourceFactory> source_factory) {


### PR DESCRIPTION
Add sanity checks when only a positive value is expected. In any case,
boost will cast negatives on config values to unsigned without
complains, so a check would be needed anyway even if keeping unsigned
int.