### PR TITLE
renamed the executable to sextractor++

### DIFF
--- a/SEMain/CMakeLists.txt
+++ b/SEMain/CMakeLists.txt
@@ -45,7 +45,7 @@ elements_add_library(SEMain src/lib/*.cpp
 #                        LINK_LIBRARIES Boost ElementsExamples
 #                        INCLUDE_DIRS Boost ElementsExamples)
 #===============================================================================
-elements_add_executable(SExtractor src/program/SExtractor.cpp
+elements_add_executable(sextractor++ src/program/SExtractor.cpp
                      LINK_LIBRARIES SEMain SEUtils SEFramework SEImplementation)
 
 elements_add_executable(TestImage src/program/TestImage.cpp


### PR DESCRIPTION
Emmanuel suggested we rename the executable to make it clear this is the ++ version, also removing the uppercase letters seems more convenient.