### PR TITLE
Add sanity checks to the Python configuration

### DIFF
--- a/SEImplementation/python/sextractorxx/config/measurement_images.py
+++ b/SEImplementation/python/sextractorxx/config/measurement_images.py
@@ -232,6 +232,8 @@ def load_fits_images(image_list, psf_list=None, weight_list=None):
     :param weight_list: A list of relative paths to the weight files (optional)
     :return: A ImageGroup representing the images
     """
+    if len(image_list) == 0:
+        raise ValueError('An empty list passed to load_fits_images')
     if psf_list is None:
         psf_list = [None] * len(image_list)
     else:

--- a/SEImplementation/python/sextractorxx/config/model_fitting.py
+++ b/SEImplementation/python/sextractorxx/config/model_fitting.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function
 from enum import Enum
 
 import libSEImplementation as cpp
-
+from .measurement_images import MeasurementGroup
 
 class RangeType(Enum):
     LINEAR = 1
@@ -161,6 +161,8 @@ def _set_model_to_frames(group, model):
 
 
 def add_model(group, model):
+    if not isinstance(group, MeasurementGroup):
+        raise TypeError('Models can only be added on MeasurementGroup, got {}'.format(type(group)))
     if not hasattr(group, 'models'):
         group.models = []
     group.models.append(model)


### PR DESCRIPTION
1. Fail if load_fits_images receive an empty list
        Safeguard for when glob returns []
2. add_model can only be applied to MeasurementGroup
        Before it could be applied to ImageGroup, which should not be
        allowed