### PR TITLE
Take FLXSCALE into account

### DIFF
--- a/SEFramework/SEFramework/Image/FitsImageSource.h
+++ b/SEFramework/SEFramework/Image/FitsImageSource.h
@@ -44,12 +44,6 @@ public:
 
     m_width = naxes[0];
     m_height = naxes[1];
-
-//    // Read FITS keywords
-//    double gain = 1, saturate = 0, flux_scale = 1;
-//    readFitsKeyword("GAIN", gain);
-//    readFitsKeyword("SATURATE", saturate);
-//    readFitsKeyword("FLXSCALE", flux_scale);
   }
 
   FitsImageSource(const std::string &filename, int width, int height,

--- a/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
@@ -3,6 +3,7 @@
  * @date 06/06/16
  * @author mschefer
  */
+#include <SEFramework/Image/MultiplyImage.h>
 #include "Configuration/ConfigManager.h"
 
 #include "SEFramework/Image/FitsReader.h"
@@ -54,11 +55,13 @@ void DetectionImageConfig::initialize(const UserValues& args) {
   m_detection_image = BufferedImage<DetectionImage::PixelType>::create(fits_image_source);
   m_coordinate_system = std::make_shared<WCS>(args.find(DETECTION_IMAGE)->second.as<std::string>());
 
-  double detection_image_gain = 0, detection_image_saturate = 0;
+  double detection_image_gain = 0, detection_image_saturate = 0, flux_scale = 0;
   fits_image_source->readFitsKeyword("GAIN", detection_image_gain);
   fits_image_source->readFitsKeyword("SATURATE", detection_image_saturate);
-  //fits_image_source->readFitsKeyword("GAIN", m_gain);
-  //fits_image_source->readFitsKeyword("SATURATE", m_saturation);
+
+  if (fits_image_source->readFitsKeyword("FLXSCALE", flux_scale) && flux_scale != 0) {
+    m_detection_image = MultiplyImage<DetectionImage::PixelType>::create(m_detection_image, flux_scale);
+  }
 
   if (args.find(DETECTION_IMAGE_GAIN) != args.end()) {
     m_gain = args.find(DETECTION_IMAGE_GAIN)->second.as<double>();

--- a/SEImplementation/src/lib/Configuration/MeasurementImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MeasurementImageConfig.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * @file MeasurementImageConfig.cpp
  * @author Nikolaos Apostolakos <nikoapos@gmail.com>
  */
@@ -54,11 +54,9 @@ void validateImagePaths(const PyMeasurementImage& image) {
 std::shared_ptr<MeasurementImage> createMeasurementImage(const PyMeasurementImage& py_image) {
   auto fits_image_source = std::make_shared<FitsImageSource<DetectionImage::PixelType>>(py_image.file);
   std::shared_ptr<MeasurementImage> image = BufferedImage<DetectionImage::PixelType>::create(fits_image_source);
-//  std::cout << "XXw: " << image->getWidth() << " h: " << image->getHeight() << "\n";
-//  std::cout << "flux_scale " << py_image.flux_scale << "\n";
-//  if (py_image.flux_scale != 1.) {
-//    image = MultiplyImage<MeasurementImage::PixelType>::create(image, py_image.flux_scale);
-//  }
+  if (py_image.flux_scale != 1.) {
+    image = MultiplyImage<MeasurementImage::PixelType>::create(image, py_image.flux_scale);
+  }
   return image;
 }
 


### PR DESCRIPTION
In the following images it can be seen that there is a bias before the change, solved after:

![beforefix](https://user-images.githubusercontent.com/1410577/54440457-068c2080-473b-11e9-940d-11a07732a3cb.png)

![postfix](https://user-images.githubusercontent.com/1410577/54440458-0855e400-473b-11e9-826b-06b498e38dd7.png)
