### PR TITLE
Bug #1240: Add a proper PythonModule

### DIFF
--- a/SEImplementation/CMakeLists.txt
+++ b/SEImplementation/CMakeLists.txt
@@ -47,6 +47,8 @@ endif()
 #                     PUBLIC_HEADERS ElementsExamples)
 #===============================================================================
 
+file(GLOB SE_PYTHON_SRC src/lib/PythonConfig/*.cpp)
+list(REMOVE_ITEM SE_PYTHON_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/PythonConfig/PythonModule.cpp)
 
 elements_add_library(SEImplementation
             src/lib/Background/*.cpp
@@ -54,13 +56,13 @@ elements_add_library(SEImplementation
             src/lib/Segmentation/*.cpp
             src/lib/Grouping/*.cpp
             src/lib/Configuration/*.cpp
-            src/lib/PythonConfig/*.cpp
             src/lib/Output/*.cpp
            	src/lib/Measurement/*.cpp
            	src/lib/CoordinateSystem/*.cpp
            	src/lib/CheckImages/*.cpp
             src/lib/Plugin/*/*.cpp
             src/lib/Deblending/*.cpp
+			${SE_PYTHON_SRC}
             LINK_LIBRARIES ElementsKernel Configuration SEUtils SEFramework ModelFitting Table WCSLIB Boost PythonLibs PythonInterp Configuration
             INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS}
             PUBLIC_HEADERS SEImplementation)
@@ -68,7 +70,14 @@ elements_add_library(SEImplementation
 elements_add_executable(tt src/program/tt.cpp
                      LINK_LIBRARIES SEImplementation)
 
-            
+#===============================================================================
+# SEImplementation has a part that needs to be reachable from Python.
+#===============================================================================
+elements_add_python_module(SExtractorPy
+		src/lib/PythonConfig/PythonModule.cpp
+		LINK_LIBRARIES SEImplementation
+		INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS}
+)
 
 #===============================================================================
 # Declare the executables here

--- a/SEImplementation/python/sextractorxx/config/aperture.py
+++ b/SEImplementation/python/sextractorxx/config/aperture.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function
 from .measurement_images import MeasurementImage, MeasurementGroup
 
-import libSEImplementation as cpp
+import _SExtractorPy as cpp
 
 apertures_for_image = {}
 

--- a/SEImplementation/python/sextractorxx/config/measurement_images.py
+++ b/SEImplementation/python/sextractorxx/config/measurement_images.py
@@ -4,7 +4,7 @@ import os
 import re
 from astropy.io import fits
 
-import libSEImplementation as cpp
+import _SExtractorPy as cpp
 
 measurement_images = {}
 

--- a/SEImplementation/python/sextractorxx/config/model_fitting.py
+++ b/SEImplementation/python/sextractorxx/config/model_fitting.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function
 
 from enum import Enum
 
-import libSEImplementation as cpp
+import _SExtractorPy as cpp
 from .measurement_images import MeasurementGroup
 
 class RangeType(Enum):

--- a/SEImplementation/src/lib/PythonConfig/PythonModule.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PythonModule.cpp
@@ -13,7 +13,7 @@ namespace bp = boost::python;
 
 namespace SExtractor {
 
-BOOST_PYTHON_MODULE(libSEImplementation) {
+BOOST_PYTHON_MODULE(_SExtractorPy) {
   
   bp::class_<ObjectInfo>("ObjectInfo", bp::init<SourceInterface&>())
       .def("get_centroid_x", &ObjectInfo::getCentroidX)


### PR DESCRIPTION
This fixes the import issue on a default installation.
Symlinking is actually more convoluted, as it needs to be relative to
the installation directory, plus you need to trick Elements somehow
to include it into the generated .spec file.