### PR TITLE
Add FindBoostPython.cmake

### DIFF
--- a/SEImplementation/CMakeLists.txt
+++ b/SEImplementation/CMakeLists.txt
@@ -33,11 +33,7 @@ find_package(WCSLIB REQUIRED)
 
 find_package(PythonInterp ${PYTHON_EXPLICIT_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_EXPLICIT_VERSION} REQUIRED)
-if(PYTHON_EXPLICIT_VERSION VERSION_LESS 3)
-	find_package(Boost REQUIRED COMPONENTS python)
-else()
-	find_package(Boost REQUIRED COMPONENTS python3)
-endif()
+find_package(BoostPython ${PYTHON_EXPLICIT_VERSION})
 
 #===============================================================================
 # Declare the library dependencies here
@@ -64,8 +60,8 @@ elements_add_library(SEImplementation
             src/lib/Plugin/*/*.cpp
             src/lib/Deblending/*.cpp
 			${SE_PYTHON_SRC}
-            LINK_LIBRARIES ElementsKernel Configuration SEUtils SEFramework ModelFitting Table WCSLIB Boost PythonLibs PythonInterp Configuration
-            INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS}
+            LINK_LIBRARIES ElementsKernel Configuration SEUtils SEFramework ModelFitting Table WCSLIB BoostPython PythonLibs PythonInterp Configuration
+            INCLUDE_DIRS ${BoostPython_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS}
             PUBLIC_HEADERS SEImplementation)
             
 elements_add_executable(tt src/program/tt.cpp

--- a/SEUtils/CMakeLists.txt
+++ b/SEUtils/CMakeLists.txt
@@ -23,11 +23,7 @@ elements_depends_on_subdirs(ElementsKernel)
 #===============================================================================
 
 find_package(PythonLibs ${PYTHON_EXPLICIT_VERSION} REQUIRED)
-if(PYTHON_EXPLICIT_VERSION VERSION_LESS 3)
-    find_package(Boost REQUIRED COMPONENTS python)
-else()
-    find_package(Boost REQUIRED COMPONENTS python3)
-endif()
+find_package(BoostPython ${PYTHON_EXPLICIT_VERSION})
 find_package(GMock)
 
 #===============================================================================
@@ -39,8 +35,8 @@ find_package(GMock)
 #                     PUBLIC_HEADERS ElementsExamples)
 #===============================================================================
 elements_add_library(SEUtils src/lib/*.cpp
-                     LINK_LIBRARIES ElementsKernel Boost PythonLibs
-                     INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS}
+                     LINK_LIBRARIES ElementsKernel BoostPython PythonLibs
+                     INCLUDE_DIRS ${BoostPython_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS}
                      PUBLIC_HEADERS SEUtils)
 
 #===============================================================================

--- a/cmake/modules/FindBoostPython.cmake
+++ b/cmake/modules/FindBoostPython.cmake
@@ -1,0 +1,38 @@
+# Normally, finding a boost component should rely on
+#   find_package(Boost REQUIRED COMPONENTS python)
+# But the packaging is now always the same: sometimes it will be python3,
+# others python37, python2, python27, or just python
+# (i.e. python3 for Fedora < 30, but python37 for Fedora >= 30 and MacOSX via Homebrew)
+# We wrap all this in this module
+#
+# Defines:
+#   BoostPython_FOUND
+#   BoostPython_INCLUDE_DIRS
+#   BoostPython_LIBRARIES
+
+if (NOT BoostPython_FOUND)
+    find_package(PythonInterp ${PYTHON_EXPLICIT_VERSION} REQUIRED)
+
+    # Explicit versions
+    set (_BOOST_PYTHON_LIST "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}" "python${PYTHON_VERSION_MAJOR}")
+
+    # Only for python2, without suffix
+    if (BoostPython_FIND_VERSION VERSION_LESS 3)
+        list (APPEND _BOOST_PYTHON_LIST "python")
+    endif ()
+
+    # Pick the most restrictive
+    foreach (_BOOST_PYTHON IN LISTS _BOOST_PYTHON_LIST)
+        find_package(Boost COMPONENTS "${_BOOST_PYTHON}")
+        if (Boost_FOUND)
+            set (BoostPython_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
+            set (BoostPython_LIBRARIES ${Boost_LIBRARIES})
+            set (BoostPython_FOUND TRUE)
+            break ()
+        endif ()
+    endforeach ()
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(BoostPython DEFAULT_MSG BoostPython_INCLUDE_DIRS)
+    mark_as_advanced(BoostPython_FOUND BoostPython_INCLUDE_DIRS BoostPython_LIBRARIES)
+endif ()


### PR DESCRIPTION
Depending on the distribution, the boost-python library may have
different suffixes (3, 37, 2, none).

This file consolidates in one place looking for whatever is available
that matches PYTHON_EXPLICIT_VERSION, if defined