### PR TITLE
Use the same model sizes as sextractor 2

### DIFF
--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingModel.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingModel.cpp
@@ -33,6 +33,9 @@ namespace SExtractor {
 
 using namespace ModelFitting;
 
+static const double MODEL_MIN_SIZE = 4.0;
+static const double MODEL_SIZE_FACTOR = 1.2;
+
 // Reference for Sersic related quantities:
 // See https://ned.ipac.caltech.edu/level5/March05/Graham/Graham2.html
 
@@ -112,9 +115,8 @@ void FlexibleModelFittingExponentialModel::addForSource(FlexibleModelFittingPara
   std::vector<std::unique_ptr<ModelComponent>> sersic_component;
   sersic_component.emplace_back(new SersicModelComponent(make_unique<OldSharp>(), *i0, n, *k));
 
-  // FIXME this seems too arbitrary, what can we do that's better? use REff * constant?
   auto& boundaries = source.getProperty<PixelBoundaries>();
-  int size = 2 * std::max(boundaries.getWidth(), boundaries.getHeight());
+  int size = std::max(MODEL_MIN_SIZE, MODEL_SIZE_FACTOR * std::max(boundaries.getWidth(), boundaries.getHeight()));
 
   auto minus_angle = std::make_shared<DependentParameter<BasicParameter>>(
       [](double angle) { return -angle; },
@@ -164,9 +166,8 @@ void FlexibleModelFittingDevaucouleursModel::addForSource(FlexibleModelFittingPa
   std::vector<std::unique_ptr<ModelComponent>> sersic_component;
   sersic_component.emplace_back(new SersicModelComponent(make_unique<OldSharp>(), *i0, n, *k));
 
-  // FIXME this seems too arbitrary, what can we do that's better? use REff * constant?
   auto& boundaries = source.getProperty<PixelBoundaries>();
-  int size = 2 * std::max(boundaries.getWidth(), boundaries.getHeight());
+  int size = std::max(MODEL_MIN_SIZE, MODEL_SIZE_FACTOR * std::max(boundaries.getWidth(), boundaries.getHeight()));
 
   auto minus_angle = std::make_shared<DependentParameter<BasicParameter>>(
       [](double angle) { return -angle; },
@@ -220,9 +221,8 @@ void FlexibleModelFittingSersicModel::addForSource(FlexibleModelFittingParameter
   manager.storeParameter(i0);
   manager.storeParameter(k);
 
-  // FIXME this seems too arbitrary, what can we do that's better? use REff * constant?
   auto& boundaries = source.getProperty<PixelBoundaries>();
-  int size = 2 * std::max(boundaries.getWidth(), boundaries.getHeight());
+  int size = std::max(MODEL_MIN_SIZE, MODEL_SIZE_FACTOR * std::max(boundaries.getWidth(), boundaries.getHeight()));
 
   extended_models.emplace_back(
       std::move(sersic_component), x_scale, *manager.getParameter(source, m_aspect_ratio), *manager.getParameter(source, m_angle),


### PR DESCRIPTION
Computes the model raster size using 1.2 * the source largest bounding box dimension instead of 2. This is the factor used by sextractor 2 and it will help performance on large sources.
