### PR TITLE
fixed errors when flux is less than zero

### DIFF
--- a/SEImplementation/src/lib/PythonConfig/ObjectInfo.cpp
+++ b/SEImplementation/src/lib/PythonConfig/ObjectInfo.cpp
@@ -23,11 +23,11 @@ SeFloat ObjectInfo::getCentroidY() const {
 }
 
 SeFloat ObjectInfo::getIsoFlux() const {
-  return m_source.get().getProperty<IsophotalFlux>().getFlux();
+  return std::max<double>(m_source.get().getProperty<IsophotalFlux>().getFlux(), 0.0001);
 }
 
 SeFloat ObjectInfo::getRadius() const {
-  return m_source.get().getProperty<ShapeParameters>().getEllipseA() / 2.0;
+  return std::max<double>(m_source.get().getProperty<ShapeParameters>().getEllipseA() / 2.0, 0.01);
 }
 
 SeFloat ObjectInfo::getAngle() const {


### PR DESCRIPTION
puts some reasonable minimum values on initial conditions to avoid situations where they are initialized to something <= 0