### PR TITLE
Interpolate image with uninterpolated variance map

### DIFF
--- a/SEFramework/SEFramework/Frame/Frame.h
+++ b/SEFramework/SEFramework/Frame/Frame.h
@@ -78,7 +78,7 @@ public:
     if (m_interpolation_gap > 0) {
       if (m_interpolated_image == nullptr) {
         const_cast<Frame<T>*>(this)->m_interpolated_image = BufferedImage<T>::create(
-          std::make_shared<InterpolatedImageSource<T>>(getOriginalImage(), getUnfilteredVarianceMap(),
+          std::make_shared<InterpolatedImageSource<T>>(getOriginalImage(), getOriginalVarianceMap(),
                                                        getVarianceThreshold(), m_interpolation_gap)
         );
       }
@@ -131,7 +131,7 @@ public:
     }
   }
 
-  std::shared_ptr<WeightImage> getUninterpolatedVarianceMap() const {
+  std::shared_ptr<WeightImage> getOriginalVarianceMap() const {
     return m_variance_map;
   }
 


### PR DESCRIPTION
The image should be interpolated with the original, unfiltered and non-interpolated variance map.
Otherwise, bad rows/columns in the variance map are interpolated, so bad rows/columns in the image are not.

As an example, an extract of the segmentation map before the fix (interpolating with the interpolated variance), overlaying two detected sources, when there is only one:

![interpolated_before](https://user-images.githubusercontent.com/1410577/60327139-6d041a00-998b-11e9-9f47-2d32117438e1.png)

After the fix, the same source is correctly detected as a single one:

![interpolated_after](https://user-images.githubusercontent.com/1410577/60327145-7097a100-998b-11e9-8de1-7d1d070edea0.png)

As a convenient side effect, the memory consumption per tile is lower now. For a 64 MiB cache, the runtime in seconds:

| Tile size     -> | 256  | 128 | 64 | 30 |
|-------------------|-------|------|-----|-----|
| Before            | 988  | 11  | 13  | 19  |
| With this fix    | 38    | 11   | 14  | 19 |
