### PR TITLE
ExternalFlags fixes (config check and mutex to prevent core dumps)

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/ExternalFlag/ExternalFlagTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/ExternalFlag/ExternalFlagTaskFactory.h
@@ -23,7 +23,8 @@ namespace SExtractor {
 class ExternalFlagTaskFactory : public TaskFactory {
   
 public:
-  
+  static const char propertyName[];
+
   virtual ~ExternalFlagTaskFactory() = default;
 
   void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const override;
@@ -40,6 +41,8 @@ private:
   std::map<PropertyId, ExternalFlagConfig::FlagInfo> m_flag_info_map;
   std::vector<std::pair<std::string, unsigned int>> m_instance_names;
   
+  bool m_is_output_requested = false;
+
 }; /* End of ExternalFlagTaskFactory class */
 
 } /* namespace SExtractor */

--- a/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagPlugin.cpp
@@ -37,9 +37,7 @@ void ExternalFlagPlugin::registerPlugin(PluginAPI& plugin_api) {
           "Flags provided from input images"
   );
 
-  // External flags are always in the output if there is configuration for
-  // producing them
-  plugin_api.getOutputRegistry().enableOutput<ExternalFlag>("ExternalFlags");
+  plugin_api.getOutputRegistry().enableOutput<ExternalFlag>(ExternalFlagTaskFactory::propertyName);
 }
 
 std::string ExternalFlagPlugin::getIdString() const {
@@ -47,7 +45,3 @@ std::string ExternalFlagPlugin::getIdString() const {
 }
 
 }
-
-
-
-

--- a/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagTask.cpp
+++ b/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagTask.cpp
@@ -4,8 +4,13 @@
  * @author nikoapos
  */
 
+#include <mutex>
+
 #include "SEFramework/Property/DetectionFrame.h"
+
 #include "SEImplementation/Property/PixelCoordinateList.h"
+#include "SEImplementation/Measurement/MultithreadedMeasurement.h"
+
 #include "SEImplementation/Plugin/ExternalFlag/ExternalFlagTask.h"
 
 namespace SExtractor {
@@ -18,6 +23,8 @@ ExternalFlagTask<Combine>::ExternalFlagTask(std::shared_ptr<FlagImage> flag_imag
 
 template<typename Combine>
 void ExternalFlagTask<Combine>::computeProperties(SourceInterface &source) const {
+  std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
+
   const auto& detection_frame = source.getProperty<DetectionFrame>();
   const auto& detection_image = detection_frame.getFrame()->getOriginalImage();
 

--- a/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagTaskFactory.cpp
@@ -4,6 +4,8 @@
  * @author nikoapos
  */
 
+#include "SEImplementation/Configuration/OutputConfig.h"
+
 #include "SEImplementation/Plugin/ExternalFlag/ExternalFlagConfig.h"
 #include "SEImplementation/Plugin/ExternalFlag/ExternalFlag.h"
 #include "SEImplementation/Plugin/ExternalFlag/ExternalFlagTask.h"
@@ -11,8 +13,11 @@
 
 namespace SExtractor {
 
+const char ExternalFlagTaskFactory::propertyName[] = "ExternalFlags";
+
 void ExternalFlagTaskFactory::reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const {
   manager.registerConfiguration<ExternalFlagConfig>();
+  manager.registerConfiguration<OutputConfig>();
 }
 
 
@@ -50,10 +55,18 @@ void ExternalFlagTaskFactory::configure(Euclid::Configuration::ConfigManager& ma
     
     m_flag_info_map[property_id] = pair.second;
   }
+
+  auto& output_config = manager.getConfiguration<OutputConfig>();
+  auto& output_properties = output_config.getOutputProperties();
+  m_is_output_requested = std::find(output_properties.begin(), output_properties.end(), propertyName)
+      != output_properties.end();
 }
 
 void ExternalFlagTaskFactory::registerPropertyInstances(OutputRegistry& output_registry) {
   output_registry.registerPropertyInstances<ExternalFlag>(m_instance_names);
+  if (m_is_output_requested && m_instance_names.size() <= 0) {
+    throw Elements::Exception() << "Requested property ExternalFlag is not configured to produce any output";
+  }
 }
 
 } // SExtractor namespace


### PR DESCRIPTION
Checks that if ExternalFlags output is requested something will be output.
Added a mutex to remove random core dumps.

Issue #118 