### PR TITLE
Update dependency to Alexandria 2.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(ElementsProject)
 #---------------------------------------------------------------
 
 # Declare project name and version
-elements_project(SExtractorxx 0.1 USE Alexandria 2.10 Elements 5.8)
+elements_project(SExtractorxx 0.1 USE Alexandria 2.14 Elements 5.8)


### PR DESCRIPTION
Alexandria 2.14 includes a fix related to NdArrays with one single element. See #110.