### PR TITLE
Keep external plugins alive until exit

### DIFF
--- a/SEFramework/SEFramework/Plugin/PluginManager.h
+++ b/SEFramework/SEFramework/Plugin/PluginManager.h
@@ -90,14 +90,22 @@ public:
 private:
   std::string m_plugin_path;
   std::vector<std::string> m_plugin_list;
-#if USE_BOOST_DLL
-  std::vector<boost::dll::shared_library> m_loaded_plugins;
-#endif
-  
+
   std::shared_ptr<TaskFactoryRegistry> m_task_factory_registry;
   std::shared_ptr<OutputRegistry> m_output_registry;
   long m_config_manager_id;
 
+#if USE_BOOST_DLL
+  /// @details
+  /// Unfortunately, plugins can register themselves in multiple places:
+  /// OutputRegistry, TaskRegistry, ConfigurationManager...
+  /// For the former two we could somehow handle the lifetime better, but the later
+  /// comes for Alexandria, and does not allow to unregister, nor override the registration methods.
+  /// We need to make sure the external plugins survive all those classes, or on destruction
+  /// the process will segfault when trying to call the virtual destructor that is on an unloaded
+  /// library.
+  static std::vector<boost::dll::shared_library> s_loaded_plugins;
+#endif
   static std::vector<std::unique_ptr<Plugin>> s_static_plugins;
 };
 

--- a/SEFramework/src/lib/Plugin/PluginManager.cpp
+++ b/SEFramework/src/lib/Plugin/PluginManager.cpp
@@ -45,6 +45,8 @@ std::vector<std::unique_ptr<Plugin>> PluginManager::s_static_plugins;
 static Elements::Logging logger = Elements::Logging::getLogger("PluginManager");
 
 #if USE_BOOST_DLL
+std::vector<boost::dll::shared_library> PluginManager::s_loaded_plugins;
+
 static std::vector<boost::filesystem::path> getPluginPaths(
                 const std::string& plugin_path_str,
                 const std::vector<std::string>& plugin_list) {
@@ -95,8 +97,7 @@ void PluginManager::loadPlugins() {
 
     plugin->registerPlugin(*this);
 
-    // keep the library loaded while PluginManager still exists
-    m_loaded_plugins.push_back(lib);
+    s_loaded_plugins.push_back(lib);
   }
 #endif
 }


### PR DESCRIPTION
I have tried doing things more properly, and, even though it is possible to handle the lifetime more properly within SourceXtractor, the ConfigurationManager comes from Alexandria, and it causes problem as well when it is destroyed after unloading the plugins.

Which it is, since the ConfigurationManager is contained within a static vector.

Maybe at some point I'll have a look at the ConfigurationManager and check if it can handle gracefully the unloading of an already registered Configuration, but until then we need to fix the crashing.

Fixes #160 