### PR TITLE
Fix build for Euclid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(ElementsProject)
 #---------------------------------------------------------------
 
 # Declare project name and version
-elements_project(SourceXtractorPlusPlus 0.6.1 USE Alexandria 2.14.1 Elements 5.8)
+elements_project(SourceXtractorPlusPlus 0.7 USE Alexandria 2.14.1 Elements 5.8)

--- a/ModelFitting/CMakeLists.txt
+++ b/ModelFitting/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT LEVMAR_FOUND)
     add_definitions(-DWITHOUT_LEVMAR)
     message(WARNING "
 Levmar library not found, compiling without Levmar support!
-This will generate a version of sextractor++ without model fitting")
+This will generate a version of sourcextractor++ without model fitting")
 else ()
     set (LEVMAR Levmar)
 endif ()

--- a/ModelFitting/CMakeLists.txt
+++ b/ModelFitting/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(Levmar)
 #    ModelFitting is the library name
 #    src/lib/*.cpp are the source files
 if (NOT LEVMAR_FOUND)
+    set(WITHOUT_LEVMAR ON PARENT_SCOPE)
     add_definitions(-DWITHOUT_LEVMAR)
     message(WARNING "
 Levmar library not found, compiling without Levmar support!

--- a/SEImplementation/CMakeLists.txt
+++ b/SEImplementation/CMakeLists.txt
@@ -142,9 +142,11 @@ elements_add_unit_test(JacobianGroup_test tests/src/Plugin/Jacobian/JacobianGrou
 elements_add_unit_test(JacobianSource_test tests/src/Plugin/Jacobian/JacobianSourceTask_test.cpp
 		             LINK_LIBRARIES SEImplementation
 		             TYPE Boost)
-elements_add_unit_test(MoffatModelFitting_test tests/src/Plugin/MoffatModelFitting/MoffatModelFitting_test.cpp 
+if (NOT WITHOUT_LEVMAR)
+elements_add_unit_test(MoffatModelFitting_test tests/src/Plugin/MoffatModelFitting/MoffatModelFitting_test.cpp
                      LINK_LIBRARIES SEImplementation
                      TYPE Boost)
+endif()
 elements_add_unit_test(PsfTask_test tests/src/Plugin/Psf/PsfTask_test.cpp
                      LINK_LIBRARIES SEImplementation
                      TYPE Boost)


### PR DESCRIPTION
* Levmar is not available in EDEN (yet), so we need to disable the Moffat test in that case
* CODEEN imposes the restriction that minor versions should be odd on develop

Closes #162