### PR TITLE
Handle MoffatEvaluator as a property

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h
+++ b/SEImplementation/SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h
@@ -21,27 +21,33 @@
  *      Author: mschefer
  */
 
-#ifndef _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELFITTINGUTILS_H_
-#define _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELFITTINGUTILS_H_
+#ifndef _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELEVALUATOR_H_
+#define _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELEVALUATOR_H_
 
 #include "ModelFitting/Models/ExtendedModel.h"
 #include "SEFramework/Source/SourceInterface.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
 
 namespace SourceXtractor {
 
-class MoffatModelEvaluator {
+class MoffatModelEvaluator: public Property {
 public:
-  MoffatModelEvaluator(const SourceInterface& source);
+  MoffatModelEvaluator(const MoffatModelFitting& model);
   double getValue(double x, double y) const {
     return m_model->getValue(x, y);
   }
 
+  unsigned getIterations() const {
+    return m_iterations;
+  }
+
 private:
   std::shared_ptr<ModelFitting::ExtendedModel> m_model;
+  unsigned m_iterations;
 };
 
 //ModelFitting::ExtendedModel createMoffatModel();
 
 }
 
-#endif /* _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELFITTINGUTILS_H_ */
+#endif /* _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELEVALUATOR_H_ */

--- a/SEImplementation/SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluatorTask.h
+++ b/SEImplementation/SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluatorTask.h
@@ -1,0 +1,45 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*
+ * MoffatModelFittingUtils.h
+ *
+ *  Created on: 2019 M02 20
+ *      Author: mschefer
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELEVALUATORTASK_H_
+#define _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELEVALUATORTASK_H_
+
+#include "ModelFitting/Models/ExtendedModel.h"
+#include "SEFramework/Source/SourceInterface.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
+
+namespace SourceXtractor {
+
+class MoffatModelEvaluatorTask: public SourceTask {
+public:
+
+  void computeProperties(SourceInterface& source) const override {
+    source.setProperty<MoffatModelEvaluator>(source.getProperty<MoffatModelFitting>());
+  }
+
+private:
+};
+
+}
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_MOFFATMODELFITTING_MOFFATMODELEVALUATORTASK_H_ */

--- a/SEImplementation/src/lib/CheckImages/MoffatCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/MoffatCheckImage.cpp
@@ -28,7 +28,7 @@
 #include "SEImplementation/CheckImages/CheckImages.h"
 
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
-#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingUtils.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h"
 
 #include "SEImplementation/CheckImages/MoffatCheckImage.h"
 
@@ -40,17 +40,16 @@ void MoffatCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface>
   if (m_check_image) {
 
     for (auto& source : *group) {
-      auto& model = source.getProperty<MoffatModelFitting>();
+      auto& model = source.getProperty<MoffatModelEvaluator>();
 
       if (model.getIterations() == 0) {
         continue;
       }
 
-      MoffatModelEvaluator evaluator(source);
       CheckImages::getInstance().lock();
       for (int y=0; y<m_check_image->getHeight(); y++) {
         for (int x=0; x<m_check_image->getWidth(); x++) {
-          m_check_image->setValue(x, y, m_check_image->getValue(x, y) + evaluator.getValue(x-0.5, y-0.5));
+          m_check_image->setValue(x, y, m_check_image->getValue(x, y) + model.getValue(x - 0.5, y - 0.5));
         }
       }
       CheckImages::getInstance().unlock();

--- a/SEImplementation/src/lib/Deblending/Cleaning.cpp
+++ b/SEImplementation/src/lib/Deblending/Cleaning.cpp
@@ -30,7 +30,7 @@
 #include "SEImplementation/Property/PixelCoordinateList.h"
 
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
-#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingUtils.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h"
 
 #include "SEImplementation/Plugin/DetectionFramePixelValues/DetectionFramePixelValues.h"
 
@@ -97,7 +97,7 @@ bool Cleaning::shouldClean(SourceInterface& source, SourceGroupInterface& group)
       continue;
     }
 
-    MoffatModelEvaluator model(*it);
+    auto &model = it->getProperty<MoffatModelEvaluator>();
     int i = 0;
     for (auto pixel : pixel_list) {
       auto pixel_value = model.getValue(pixel.m_x, pixel.m_y);
@@ -126,7 +126,7 @@ SourceGroupInterface::iterator Cleaning::findMostInfluentialSource(
 
   // iterate through all other sources in the group
   for (size_t i = 0; i < candidates.size(); i++) {
-    MoffatModelEvaluator model(*candidates[i]);
+    auto &model = candidates[i]->getProperty<MoffatModelEvaluator>();
     for (auto pixel : pixel_list) {
       auto pixel_value = model.getValue(pixel.m_x, pixel.m_y);
       total_influence_of_sources[i] += pixel_value;

--- a/SEImplementation/src/lib/Grouping/MoffatCriteria.cpp
+++ b/SEImplementation/src/lib/Grouping/MoffatCriteria.cpp
@@ -23,7 +23,7 @@
 
 #include "SEImplementation/Grouping/MoffatCriteria.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
-#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingUtils.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h"
 
 #include "SEImplementation/Plugin/PixelCentroid/PixelCentroid.h"
 #include "SEImplementation/Plugin/PeakValue/PeakValue.h"
@@ -33,15 +33,13 @@ namespace SourceXtractor {
 using namespace ModelFitting;
 
 bool MoffatCriteria::doesImpact(const SourceInterface& impactor, const SourceInterface& impactee) const {
-  auto& model = impactor.getProperty<MoffatModelFitting>();
-  if (model.getIterations() == 0) {
+  auto& extended_model = impactor.getProperty<MoffatModelEvaluator>();
+  if (extended_model.getIterations() == 0) {
     return false;
   }
 
   auto& centroid = impactee.getProperty<PixelCentroid>();
   auto max_value = impactee.getProperty<PeakValue>().getMaxValue();
-
-  MoffatModelEvaluator extended_model(impactor);
 
   double model_value = extended_model.getValue(centroid.getCentroidX(), centroid.getCentroidY());
 

--- a/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelEvaluator.cpp
+++ b/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelEvaluator.cpp
@@ -28,14 +28,14 @@
 #include "ModelFitting/Models/FlattenedMoffatComponent.h"
 
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
-#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingUtils.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h"
 
 namespace SourceXtractor {
 
 using namespace ModelFitting;
 
-MoffatModelEvaluator::MoffatModelEvaluator(const SourceInterface& source) {
-  auto& model = source.getProperty<MoffatModelFitting>();
+MoffatModelEvaluator::MoffatModelEvaluator(const MoffatModelFitting& model) {
+  m_iterations = model.getIterations();
 
   ManualParameter x(model.getX());
   ManualParameter y(model.getY());

--- a/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingPlugin.cpp
@@ -21,6 +21,7 @@
  *      Author: mschefer
  */
 
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingPlugin.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingTaskFactory.h"
@@ -33,6 +34,7 @@ static StaticPlugin<MoffatModelFittingPlugin> simple_modelfitting_plugin;
 
 void MoffatModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
   plugin_api.getTaskFactoryRegistry().registerTaskFactory<MoffatModelFittingTaskFactory, MoffatModelFitting>();
+  plugin_api.getTaskFactoryRegistry().registerTaskFactory<MoffatModelFittingTaskFactory, MoffatModelEvaluator>();
 
   plugin_api.getOutputRegistry().registerColumnConverter<MoffatModelFitting, double>(
           "smf_x",

--- a/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingTaskFactory.cpp
@@ -23,9 +23,11 @@
 
 #include <iostream>
 
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluator.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFitting.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingTaskFactory.h"
 #include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelFittingTask.h"
+#include "SEImplementation/Plugin/MoffatModelFitting/MoffatModelEvaluatorTask.h"
 #include "SEImplementation/Configuration/LegacyModelFittingConfig.h"
 
 namespace SourceXtractor {
@@ -33,6 +35,8 @@ namespace SourceXtractor {
 std::shared_ptr<Task> MoffatModelFittingTaskFactory::createTask(const PropertyId& property_id) const {
   if (property_id == PropertyId::create<MoffatModelFitting>()) {
     return std::make_shared<MoffatModelFittingTask>(m_max_iterations);
+  } else if (property_id == PropertyId::create<MoffatModelEvaluator>()) {
+    return std::make_shared<MoffatModelEvaluatorTask>();
   } else {
     return nullptr;
   }


### PR DESCRIPTION
The cost of creating this class is not trivial, as it performs
allocations of ManualParameter, Frame, and family (with shared pointers, at that).

I spotted this profiling @mkuemmel data using the Moffat grouping and cleaning. Note that for a small number of sources, this is negligible, but there is a point where it start hitting considerably, since the grouping has a quadratic complexity (which may be something to look into?).

For instance, when around 15% of the lines are done, the allocation of MoffatModelEvaluator consumes almost 25% of the time.

**EDIT:** 41.5% the constructor once we are up to 44% of the lines. So you can see the progression...