### PR TITLE
Search for plugins on the default directories too

### DIFF
--- a/SEFramework/SEFramework/Plugin/PluginManager.h
+++ b/SEFramework/SEFramework/Plugin/PluginManager.h
@@ -88,7 +88,7 @@ public:
   }
 
 private:
-  std::string m_plugin_path;
+  boost::filesystem::path m_plugin_path;
   std::vector<std::string> m_plugin_list;
 
   std::shared_ptr<TaskFactoryRegistry> m_task_factory_registry;

--- a/SEFramework/SEFramework/Plugin/PluginManager.h
+++ b/SEFramework/SEFramework/Plugin/PluginManager.h
@@ -30,6 +30,7 @@
 #if USE_BOOST_DLL
 #include <boost/dll/shared_library.hpp>
 #endif
+#include <boost/filesystem/path.hpp>
 
 #include <memory>
 #include <vector>

--- a/SEFramework/src/lib/Plugin/PluginManager.cpp
+++ b/SEFramework/src/lib/Plugin/PluginManager.cpp
@@ -46,33 +46,6 @@ static Elements::Logging logger = Elements::Logging::getLogger("PluginManager");
 
 #if USE_BOOST_DLL
 std::vector<boost::dll::shared_library> PluginManager::s_loaded_plugins;
-
-static std::vector<boost::filesystem::path> getPluginPaths(
-                const std::string& plugin_path_str,
-                const std::vector<std::string>& plugin_list) {
-  std::vector<boost::filesystem::path> plugin_paths;
-
-  if (plugin_path_str != "") {
-    boost::filesystem::path plugin_path(plugin_path_str);
-    if (boost::filesystem::is_directory(plugin_path)) {
-      for (auto& plugin_name : plugin_list) {
-        auto full_path = plugin_path / boost::filesystem::path(plugin_name);
-        full_path += boost::dll::shared_library::suffix();
-
-        if (boost::filesystem::exists(full_path)) {
-          logger.info() << "Loading plugin from file: " << full_path;
-          plugin_paths.emplace_back(full_path);
-        } else {
-          logger.warn() << "Failed to load plugins from " << full_path << " - file not found";
-        }
-      }
-    } else {
-      logger.warn() << "The " << plugin_path << " is not a directory. No plugins will be loaded";
-    }
-  }
-
-  return plugin_paths;
-}
 #endif
 
 void PluginManager::loadPlugins() {
@@ -82,23 +55,35 @@ void PluginManager::loadPlugins() {
   }
 
 #if USE_BOOST_DLL
+  typedef std::shared_ptr<Plugin> (pluginapi_create_t)();
+
   // load dynamic plugins
-  auto plugin_paths = getPluginPaths(m_plugin_path, m_plugin_list);
-  for (auto& plugin_path : plugin_paths) {
-    typedef std::shared_ptr<Plugin> (pluginapi_create_t)();
-    std::function<pluginapi_create_t> creator;
+  auto load_mode = boost::dll::load_mode::append_decorations | boost::dll::load_mode::search_system_folders;
+  for (auto& plugin_name : m_plugin_list) {
+    boost::dll::shared_library lib;
 
-    boost::dll::shared_library lib(plugin_path);
-    creator = lib.get_alias<pluginapi_create_t>("create_plugin");
+    // Try on the explicit path first
+    if (!m_plugin_path.empty()) {
+      auto full_path = m_plugin_path / plugin_name;
+      try {
+        lib.load(full_path, load_mode);
+      } catch (const boost::system::system_error&) {
+        // ignore
+      }
+    }
+    // Try on the system path. This time, propagate the failure
+    if (!lib.is_loaded()) {
+      lib.load(plugin_name, load_mode);
+    }
 
+    auto creator = lib.get_alias<pluginapi_create_t>("create_plugin");
     auto plugin = creator();
     auto id_string = plugin->getIdString();
     logger.info() << "Registering plugin " << id_string;
-
     plugin->registerPlugin(*this);
-
     s_loaded_plugins.push_back(lib);
   }
+
 #endif
 }
 


### PR DESCRIPTION
For instance, LD_LIBRARY_PATH, as set by Elements.
Fully rely on boost::dll to do the decoration of the library name.
Fixes #157