### PR TITLE
Automatically guess first image HDU

### DIFF
--- a/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
@@ -73,7 +73,7 @@ void DetectionImageConfig::initialize(const UserValues& args) {
   m_detection_image_path = args.find(DETECTION_IMAGE)->second.as<std::string>();
   auto fits_image_source = std::make_shared<FitsImageSource<DetectionImage::PixelType>>(m_detection_image_path);
   m_detection_image = BufferedImage<DetectionImage::PixelType>::create(fits_image_source);
-  m_coordinate_system = std::make_shared<WCS>(args.find(DETECTION_IMAGE)->second.as<std::string>());
+  m_coordinate_system = std::make_shared<WCS>(args.find(DETECTION_IMAGE)->second.as<std::string>(), fits_image_source->getHDU());
 
   double detection_image_gain = 0, detection_image_saturate = 0;
   fits_image_source->readFitsKeyword("GAIN", detection_image_gain);


### PR DESCRIPTION
Useful when the detection image is on an extension (i.e. compressed
image)
It is similar to what is already implemented on the Python side: pick the first HDU with an image on it.

I have added two tests to the test suite, one with a [compressed detection image](https://github.com/astrorama/SourceXtractor-litmus/blob/04faa34eae50c109958562477f73195071b3c28f/tests/single_frame/test_compressed.py),
and another with a set of [compressed measurement images](https://github.com/astrorama/SourceXtractor-litmus/blob/04faa34eae50c109958562477f73195071b3c28f/tests/multi_frame/test_multi_compressed.py)