### PR TITLE
Intercept unicode strings

### DIFF
--- a/SEImplementation/SEImplementation/PythonConfig/PyOutputWrapper.h
+++ b/SEImplementation/SEImplementation/PythonConfig/PyOutputWrapper.h
@@ -56,7 +56,7 @@ public:
 
   // These do something!
   bool writable() const;
-  int write(const std::string&);
+  int write(const boost::python::object&);
   void writelines(const boost::python::list&);
 
 private:

--- a/SEImplementation/src/lib/PythonConfig/PyOutputWrapper.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PyOutputWrapper.cpp
@@ -129,8 +129,7 @@ int PyOutputWrapper::write(const bp::object& obj) {
 
 void PyOutputWrapper::writelines(const bp::list& lines) {
   for (int i = 0; i < bp::len(lines); ++i) {
-    bp::str line = bp::extract<bp::str>(lines[i]);
-    m_logger.info() << line;
+    write(lines[i]);
   }
 }
 

--- a/SEImplementation/src/lib/PythonConfig/PyOutputWrapper.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PyOutputWrapper.cpp
@@ -19,13 +19,14 @@
  * @author Alejandro Alvarez Ayllon
  */
 
-#include <codecvt>
+#include <boost/locale/encoding_utf.hpp>
 #include <boost/python.hpp>
 #include "SEImplementation/PythonConfig/PyOutputWrapper.h"
 
 namespace SourceXtractor {
 
 namespace bp = boost::python;
+using boost::locale::conv::utf_to_utf;
 
 PyOutputWrapper::PyOutputWrapper(Elements::Logging& logger) : closed(false), m_logger(logger) {}
 
@@ -104,8 +105,7 @@ int PyOutputWrapper::write(const bp::object& obj) {
   }
   else if (unicode_extractor.check()) {
     std::wstring unicode = unicode_extractor;
-    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> cv;
-    str = cv.to_bytes(unicode);
+    str = utf_to_utf<char>(unicode.c_str(), unicode.c_str() + unicode.size());
   }
   else {
     std::string obj_type_name = bp::extract<std::string>(obj.attr("__class__").attr("__name__"));


### PR DESCRIPTION
Be more user-friendly when stdout or stderr get something other than a
string or an unicode string