### PR TITLE
renamed default configuration file to match executable

### DIFF
--- a/SEMain/conf/sourcextractor++.conf
+++ b/SEMain/conf/sourcextractor++.conf
@@ -1,5 +1,6 @@
 ###############################################################################
 #
-# Configuration file for the <SExtractor> executable 
+# Configuration file for the <sourcextractor++> executable 
 #
 ###############################################################################
+#


### PR DESCRIPTION
I checked and unfortunately there is no override at the option level. The local configuration will still take precedence over the default but any option in the default will be ignored in that case.

This solves the default configuration not found warning when compiling from source, I can't test the RPM version on my Ubuntu.
