### PR TITLE
changed source ids to start at one,

### DIFF
--- a/SEImplementation/SEImplementation/Property/SourceId.h
+++ b/SEImplementation/SEImplementation/Property/SourceId.h
@@ -54,7 +54,7 @@ private:
   unsigned int m_source_id, m_detection_id;
 
   static unsigned int getNewId() {
-    static unsigned int s_id  = 0;
+    static unsigned int s_id  = 1;
     return s_id++;
   }
 


### PR DESCRIPTION
 to prevent the first source from being invisible on the segmentation map

A simple change but it could have an impact if people are relying on the ids, so I put it in its own pull request.
