### PR TITLE
Fixed IsophotalFlux for gain=0.0

### DIFF
--- a/SEImplementation/src/lib/Plugin/IsophotalFlux/IsophotalFluxTask.cpp
+++ b/SEImplementation/src/lib/Plugin/IsophotalFlux/IsophotalFluxTask.cpp
@@ -49,7 +49,8 @@ void IsophotalFluxTask::computeProperties(SourceInterface& source) const {
 
   // Add variance from gain
   SeFloat gain = detection_frame.getFrame()->getGain();
-  total_variance += total_flux / gain;
+  if (gain >0.0)
+    total_variance += total_flux / gain;
 
   auto flux_error = sqrt(total_variance);
 


### PR DESCRIPTION
The default gain value is 0.0 (== inf gain). In the property
IsophotalFlux the flux error is corrected for the gain, which becomes
inf when gain=0.0. Now the correction is only done for gain>0.0.