### PR TITLE
get rid of SourceGroupInterface's custom iterator

### DIFF
--- a/SEFramework/SEFramework/Source/SimpleSourceGroup.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceGroup.h
@@ -73,55 +73,10 @@ protected:
   
 private:
   
-  class iter;
-  std::list<std::shared_ptr<SourceInterface>> m_sources;
+  std::list<SourceWrapper> m_sources;
   PropertyHolder m_property_holder;
   
 }; /* End of SimpleSourceGroup class */
-
-
-class SimpleSourceGroup::iter : public SourceGroupInterface::IteratorImpl {
-  
-public:
-  iter(std::list<std::shared_ptr<SourceInterface>>::iterator wrapped_it)
-          : m_wrapped_it(wrapped_it) {
-  }
-
-  virtual ~iter() = default;
-  
-  SourceInterface& dereference() const override {
-    return const_cast<SourceInterface&>(**m_wrapped_it);
-  }
-  
-  void increment() override {
-    ++m_wrapped_it;
-  }
-  
-  void decrement() override {
-    --m_wrapped_it;
-  }
-  
-  bool equal(const IteratorImpl& other) const override {
-      try {
-        auto& other_iter = dynamic_cast<const iter&>(other);
-        return this->m_wrapped_it == other_iter.m_wrapped_it;
-      } catch (...) {
-        return false;
-      }
-  }
-
-  std::shared_ptr<IteratorImpl> clone() const override {
-    return std::make_shared<iter>(m_wrapped_it);
-  }
-
-
-private:
-  
-  std::list<std::shared_ptr<SourceInterface>>::iterator m_wrapped_it;
-  
-  friend SimpleSourceGroup::iterator SimpleSourceGroup::removeSource(SimpleSourceGroup::iterator);
-  
-};
 
 } /* namespace SourceXtractor */
 

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
@@ -81,9 +81,8 @@ protected:
 
 private:
   
-  class iter;
   class EntangledSource;
-  std::list<EntangledSource> m_sources;
+  std::list<SourceWrapper> m_sources;
   PropertyHolder m_property_holder;
   std::shared_ptr<TaskProvider> m_task_provider;
   
@@ -115,58 +114,7 @@ private:
   
   friend void SourceGroupWithOnDemandProperties::clearGroupProperties();
   friend void SourceGroupWithOnDemandProperties::merge(const SourceGroupInterface&);
-  
-};
 
-
-class SourceGroupWithOnDemandProperties::iter : public SourceGroupInterface::IteratorImpl {
-  
-public:
-  
-  iter(std::list<EntangledSource>::iterator m_entangled_it)
-          : m_entangled_it(m_entangled_it) {
-  }
-
-  virtual ~iter() = default;
-  
-  // Note to developers
-  // The std::set provides only constant iterator, because modifying its entries
-  // might mean that their ordering (which is used internally) might change. In
-  // our case we have no such problem, because the ordering of the EntangledSource
-  // is based on the pointer address of the encapsulated Source. This allows
-  // for the following const casts, so if the user iterates over a non-const
-  // SourceGroup he will get Sources on which he can call the setProperty().
-  SourceInterface& dereference() const override {
-    return const_cast<EntangledSource&>(*m_entangled_it);
-  }
-  
-  void increment() override {
-    ++m_entangled_it;
-  }
-  
-  void decrement() override {
-    --m_entangled_it;
-  }
-  
-  bool equal(const IteratorImpl& other) const override {
-    try {
-      auto& other_iter = dynamic_cast<const iter&>(other);
-      return this->m_entangled_it == other_iter.m_entangled_it;
-    } catch (...) {
-      return false;
-    }
-  }
-
-  std::shared_ptr<IteratorImpl> clone() const override {
-    return std::make_shared<iter>(m_entangled_it);
-  }
-
-private:
-  
-  std::list<EntangledSource>::iterator m_entangled_it;
-  
-  friend SourceGroupWithOnDemandProperties::iterator SourceGroupWithOnDemandProperties::removeSource(SourceGroupWithOnDemandProperties::iterator);
-  
 };
 
 } /* namespace SourceXtractor */

--- a/SEFramework/SEFramework/Source/SourceInterface.h
+++ b/SEFramework/SEFramework/Source/SourceInterface.h
@@ -73,19 +73,11 @@ public:
     setIndexedProperty<PropertyType>(0, std::forward<Args>(args)...);
   }
 
-protected:
-  
   /// Returns a reference to the requested property. The property may be computed if needed
   /// Throws a PropertyNotFoundException if the property cannot be provided.
   virtual const Property& getProperty(const PropertyId& property_id) const = 0;
   virtual void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) = 0;
-  
-  // The following method allow the specific implementations of the interface
-  // to call the protected getProperty of instances of an unknown sub-type.
-  const Property& getPropertyFromInterface(const SourceInterface& source, const PropertyId& property_id) const {
-    return source.getProperty(property_id);
-  }
-  
+
 }; /* End of SourceInterface class */
 
 } /* namespace SourceXtractor */

--- a/SEFramework/src/lib/Source/EntangledSource.cpp
+++ b/SEFramework/src/lib/Source/EntangledSource.cpp
@@ -52,7 +52,7 @@ const Property& SourceGroupWithOnDemandProperties::EntangledSource::getProperty(
   try {
     // Try to get the the property from the encapsulated Source
     // if it cannot provide it, this will throw a PropertyNotFoundException
-    return getPropertyFromInterface(*m_source, property_id);
+    return m_source->getProperty(property_id);
   } catch (PropertyNotFoundException& e) {
     // Getting this exception means the property must be computed at the group level
 

--- a/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
+++ b/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
@@ -24,42 +24,44 @@
 namespace SourceXtractor {
 
 SimpleSourceGroup::iterator SimpleSourceGroup::begin() {
-  return iterator(std::unique_ptr<IteratorImpl>(new iter{m_sources.begin()}));
+  return m_sources.begin();
 }
 
 SimpleSourceGroup::iterator SimpleSourceGroup::end() {
-  return iterator(std::unique_ptr<IteratorImpl>(new iter{m_sources.end()}));
+  return m_sources.end();
 }
 
 SimpleSourceGroup::const_iterator SimpleSourceGroup::cbegin() {
-  return const_iterator(std::unique_ptr<IteratorImpl>(new iter{m_sources.begin()}));
+  return m_sources.cbegin();
 }
 
 SimpleSourceGroup::const_iterator SimpleSourceGroup::cend() {
-  return const_iterator(std::unique_ptr<IteratorImpl>(new iter{m_sources.end()}));
+  return m_sources.cend();
 }
 
 SimpleSourceGroup::const_iterator SimpleSourceGroup::begin() const {
-  return const_iterator(std::unique_ptr<IteratorImpl>(new iter{const_cast<SimpleSourceGroup*>(this)->m_sources.begin()}));
+  return m_sources.cbegin();
 }
 
 SimpleSourceGroup::const_iterator SimpleSourceGroup::end() const {
-  return const_iterator(std::unique_ptr<IteratorImpl>(new iter{const_cast<SimpleSourceGroup*>(this)->m_sources.end()}));
+  return m_sources.cend();
 }
 
 void SimpleSourceGroup::addSource(std::shared_ptr<SourceInterface> source) {
-  m_sources.push_back(source);
+  m_sources.emplace_back(SourceWrapper(source));
 }
 
 SourceGroupInterface::iterator SimpleSourceGroup::removeSource(iterator pos) {
-  iter& iter_impl = dynamic_cast<iter&>(pos.getImpl());
-  auto next_wrapped_it = m_sources.erase(iter_impl.m_wrapped_it);
-  return iterator(std::unique_ptr<IteratorImpl>(new iter{next_wrapped_it}));
+  auto next_iter = m_sources.erase(pos);
+  return next_iter;
 }
 
 void SimpleSourceGroup::merge(const SourceGroupInterface& other) {
   auto& other_group = dynamic_cast<const SimpleSourceGroup&>(other);
-  addAllSources(other_group.m_sources);
+  for (auto& source : other_group.m_sources) {
+    this->m_sources.emplace_back(source);
+  }
+  m_property_holder.clear();
 }
 
 const Property& SimpleSourceGroup::getProperty(const PropertyId& property_id) const {


### PR DESCRIPTION
I propose this as an alternative to @ayllon pull request #207 

We keep all the interfaces and we don't need a weird custom iterator.

I have also made a change in SourceInterface to remove the "protected" status of the actual interface, in my opinion it's wrong to define an interface with protected methods even if the use of the templated methods instead is encouraged.
