### PR TITLE
change the sign of angle default value...

### DIFF
--- a/SEImplementation/src/lib/PythonConfig/ObjectInfo.cpp
+++ b/SEImplementation/src/lib/PythonConfig/ObjectInfo.cpp
@@ -47,7 +47,7 @@ SeFloat ObjectInfo::getRadius() const {
 }
 
 SeFloat ObjectInfo::getAngle() const {
-  return -m_source.get().getProperty<ShapeParameters>().getEllipseTheta();
+  return m_source.get().getProperty<ShapeParameters>().getEllipseTheta();
 }
 
 SeFloat ObjectInfo::getAspectRatio() const {


### PR DESCRIPTION
Changed the sign of get_angle() default angle value for model fitting to match changes in the model fitting module and be more consistent overall

The compact models in model fitting now use CCW angles which should be our standard (see issue #218 )
