### PR TITLE
Fix: Race conditions

### DIFF
--- a/.travis/build-rpm.sh
+++ b/.travis/build-rpm.sh
@@ -50,7 +50,7 @@ yum install -y -q cmake make gcc-c++ rpm-build
 yum install -y -q boost-devel $PYTHON-pytest log4cpp-devel doxygen CCfits-devel
 yum install -y -q graphviz $PYTHON-sphinx $PYTHON-sphinxcontrib-apidoc
 yum install -y -q gmock-devel gtest-devel
-yum install -y -q ${PYTHON}-devel boost-${PYTHON}-devel fftw-devel levmar-devel wcslib-devel
+yum install -y -q ${PYTHON}-devel boost-${PYTHON}-devel fftw-devel levmar-devel wcslib-devel blas-devel
 if [ "$ID" != "centos" ]; then
   yum install -y -q gsl-devel
 fi

--- a/SEImplementation/SEImplementation/CheckImages/CheckImages.h
+++ b/SEImplementation/SEImplementation/CheckImages/CheckImages.h
@@ -119,13 +119,7 @@ public:
     return *m_instance;
   }
 
-  void lock() {
-    m_access_mutex.lock();
-  }
-
-  void unlock() {
-    m_access_mutex.unlock();
-  }
+  std::mutex m_access_mutex;
 
 private:
   CheckImages();
@@ -167,8 +161,6 @@ private:
   boost::filesystem::path m_psf_filename;
 
   std::map<boost::filesystem::path, std::tuple<std::shared_ptr<Image<SeFloat>>, bool>> m_custom_images;
-
-  std::mutex m_access_mutex;
 };
 
 }

--- a/SEImplementation/src/lib/CheckImages/CheckImages.cpp
+++ b/SEImplementation/src/lib/CheckImages/CheckImages.cpp
@@ -229,7 +229,7 @@ CheckImages::getPsfImage(std::shared_ptr<const SourceXtractor::MeasurementImageF
 }
 
 void CheckImages::saveImages() {
-  lock();
+  std::lock_guard<std::mutex> lock(m_access_mutex);
 
   // if possible, save the background image
   if (m_background_image != nullptr && m_model_background_filename != "") {
@@ -276,8 +276,6 @@ void CheckImages::saveImages() {
       FitsWriter::writeFile(*std::get<0>(entry.second), filename.native());
     }
   }
-
-  unlock();
 }
 
 }

--- a/SEImplementation/src/lib/CheckImages/DetectionIdCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/DetectionIdCheckImage.cpp
@@ -31,7 +31,7 @@ namespace SourceXtractor {
 
 void DetectionIdCheckImage::handleMessage(const std::shared_ptr<SourceInterface>& source) {
   if (m_check_image) {
-    CheckImages::getInstance().lock();
+    std::lock_guard<std::mutex> lock(CheckImages::getInstance().m_access_mutex);
 
     auto coordinates = source->getProperty<PixelCoordinateList>();
 
@@ -42,8 +42,6 @@ void DetectionIdCheckImage::handleMessage(const std::shared_ptr<SourceInterface>
     for (auto& coord : coordinates.getCoordinateList()) {
       m_check_image->setValue(coord.m_x, coord.m_y, source_id);
     }
-
-    CheckImages::getInstance().unlock();
   }
 }
 

--- a/SEImplementation/src/lib/CheckImages/GroupIdCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/GroupIdCheckImage.cpp
@@ -36,7 +36,7 @@ void GroupIdCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface
     // get the ID of the group
     auto group_id = group->getProperty<GroupInfo>().getGroupId();
 
-    CheckImages::getInstance().lock();
+    std::lock_guard<std::mutex> lock(CheckImages::getInstance().m_access_mutex);
 
     for (auto& source : *group) {
       auto& coordinates = source.getProperty<PixelCoordinateList>();
@@ -46,8 +46,6 @@ void GroupIdCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface
         m_check_image->setValue(coord.m_x, coord.m_y, group_id);
       }
     }
-
-    CheckImages::getInstance().unlock();
   }
 }
 

--- a/SEImplementation/src/lib/CheckImages/MoffatCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/MoffatCheckImage.cpp
@@ -46,13 +46,12 @@ void MoffatCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface>
         continue;
       }
 
-      CheckImages::getInstance().lock();
+      std::lock_guard<std::mutex> lock(CheckImages::getInstance().m_access_mutex);
       for (int y=0; y<m_check_image->getHeight(); y++) {
         for (int x=0; x<m_check_image->getWidth(); x++) {
           m_check_image->setValue(x, y, m_check_image->getValue(x, y) + model.getValue(x - 0.5, y - 0.5));
         }
       }
-      CheckImages::getInstance().unlock();
     }
   }
 }

--- a/SEImplementation/src/lib/CheckImages/SourceIdCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/SourceIdCheckImage.cpp
@@ -31,7 +31,7 @@ namespace SourceXtractor {
 
 void SourceIdCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface>& group) {
   if (m_check_image) {
-    CheckImages::getInstance().lock();
+    std::lock_guard<std::mutex> lock(CheckImages::getInstance().m_access_mutex);
     for (auto& source : *group) {
       auto coordinates = source.getProperty<PixelCoordinateList>();
 
@@ -43,7 +43,6 @@ void SourceIdCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterfac
         m_check_image->setValue(coord.m_x, coord.m_y, source_id);
       }
     }
-    CheckImages::getInstance().unlock();
   }
 }
 

--- a/SEImplementation/src/lib/CoordinateSystem/WCS.cpp
+++ b/SEImplementation/src/lib/CoordinateSystem/WCS.cpp
@@ -77,6 +77,11 @@ WCS::~WCS() {
 }
 
 WorldCoordinate WCS::imageToWorld(ImageCoordinate image_coordinate) const {
+  // wcsprm is in/out, since its member lin is modified by wcsp2s
+  wcslib::wcsprm wcs_copy{*m_wcs};
+  wcs_copy.lin.flag = -1;
+  lincpy(true, &m_wcs->lin, &wcs_copy.lin);
+  linset(&wcs_copy.lin);
 
   // +1 as fits standard coordinates start at 1
   double pc_array[2] {image_coordinate.m_x + 1, image_coordinate.m_y + 1};
@@ -86,19 +91,27 @@ WorldCoordinate WCS::imageToWorld(ImageCoordinate image_coordinate) const {
   double phi, theta;
 
   int status = 0;
-  wcsp2s(m_wcs.get(), 1, 1, pc_array, ic_array, &phi, &theta, wc_array, &status);
+  wcsp2s(&wcs_copy, 1, 1, pc_array, ic_array, &phi, &theta, wc_array, &status);
+  linfree(&wcs_copy.lin);
 
   return WorldCoordinate(wc_array[0], wc_array[1]);
 }
 
 ImageCoordinate WCS::worldToImage(WorldCoordinate world_coordinate) const {
+  // wcsprm is in/out, since its member lin is modified by wcss2p
+  wcslib::wcsprm wcs_copy{*m_wcs};
+  wcs_copy.lin.flag = -1;
+  lincpy(true, &m_wcs->lin, &wcs_copy.lin);
+  linset(&wcs_copy.lin);
+
   double pc_array[2] {0, 0};
   double ic_array[2] {0, 0};
   double wc_array[2] {world_coordinate.m_alpha, world_coordinate.m_delta};
   double phi, theta;
 
   int status = 0;
-  wcss2p(m_wcs.get(), 1, 1, wc_array, &phi, &theta, ic_array, pc_array, &status);
+  wcss2p(&wcs_copy, 1, 1, wc_array, &phi, &theta, ic_array, pc_array, &status);
+  linfree(&wcs_copy.lin);
 
   return ImageCoordinate(pc_array[0] - 1, pc_array[1] - 1); // -1 as fits standard coordinates start at 1
 }

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
@@ -372,7 +372,7 @@ void FlexibleModelFittingTask::updateCheckImages(SourceGroupInterface& group,
 
       auto debug_image = CheckImages::getInstance().getModelFittingImage(frame);
       if (debug_image) {
-        CheckImages::getInstance().lock();
+        std::lock_guard<std::mutex> lock(CheckImages::getInstance().m_access_mutex);
         for (int x = 0; x < final_stamp->getWidth(); x++) {
           for (int y = 0; y < final_stamp->getHeight(); y++) {
             auto x_coord = stamp_rect.getTopLeft().m_x + x;
@@ -382,8 +382,6 @@ void FlexibleModelFittingTask::updateCheckImages(SourceGroupInterface& group,
           }
         }
       }
-
-      CheckImages::getInstance().unlock();
     }
     frame_id++;
   }


### PR DESCRIPTION
It seems the mutex that was in place for levmar was protecting us from race conditions when doing WCS operations. Because of the last improvements that allow us to use levmar multi-threaded,  the WCS code is not protected anymore.

Because of this race condition, some memory areas could be overwritten when doing translations between pixel <-> world coordinates, which caused completely bogus transformation matrices, coordinates and the like (even some NaN could enter the computations at this stage).

The crashes ultimately came thanks to few asserts that are around the code that triggered because of these errors: nonsense stamp sizes, wrong matrix inverses, etc.

IMHO, it could be that this caused also the random long fitting times: if the coordinate transformation is wrong, but not catastrophically so, that would probably confuse levmar.

@mkuemmel, I have succeeded on running your model configuration without any complains from [thread sanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) and no crashes. You can try this branch and see if your issues are gone.