### PR TITLE
Fix for wcslib 7.2

### DIFF
--- a/SEImplementation/SEImplementation/CoordinateSystem/WCS.h
+++ b/SEImplementation/SEImplementation/CoordinateSystem/WCS.h
@@ -26,9 +26,7 @@
 
 #include "SEFramework/CoordinateSystem/CoordinateSystem.h"
 
-namespace wcslib {
 struct wcsprm;
-}
 
 namespace SourceXtractor {
 
@@ -43,7 +41,7 @@ public:
   std::map<std::string, std::string> getFitsHeaders() const override;
 
 private:
-  std::unique_ptr<wcslib::wcsprm, std::function<void(wcslib::wcsprm*)>> m_wcs;
+  std::unique_ptr<wcsprm, std::function<void(wcsprm*)>> m_wcs;
 };
 
 }

--- a/SEImplementation/src/lib/CoordinateSystem/WCS.cpp
+++ b/SEImplementation/src/lib/CoordinateSystem/WCS.cpp
@@ -23,15 +23,11 @@
 
 #include <fitsio.h>
 
-namespace wcslib {
-
 #include <wcslib/wcs.h>
 #include <wcslib/wcshdr.h>
 #include <wcslib/wcsfix.h>
 #include <wcslib/wcsprintf.h>
 #include <wcslib/getwcstab.h>
-
-}
 
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Logging.h"
@@ -42,8 +38,6 @@ namespace wcslib {
 namespace SourceXtractor {
 
 static auto logger = Elements::Logging::getLogger("WCS");
-
-using namespace wcslib;
 
 decltype(&lincpy) safe_lincpy = &lincpy;
 
@@ -106,7 +100,7 @@ WCS::~WCS() {
 
 WorldCoordinate WCS::imageToWorld(ImageCoordinate image_coordinate) const {
   // wcsprm is in/out, since its member lin is modified by wcsp2s
-  wcslib::wcsprm wcs_copy = *m_wcs;
+  wcsprm wcs_copy = *m_wcs;
   wcs_copy.lin.flag = -1;
   safe_lincpy(true, &m_wcs->lin, &wcs_copy.lin);
   linset(&wcs_copy.lin);
@@ -127,7 +121,7 @@ WorldCoordinate WCS::imageToWorld(ImageCoordinate image_coordinate) const {
 
 ImageCoordinate WCS::worldToImage(WorldCoordinate world_coordinate) const {
   // wcsprm is in/out, since its member lin is modified by wcss2p
-  wcslib::wcsprm wcs_copy = *m_wcs;
+  wcsprm wcs_copy = *m_wcs;
   wcs_copy.lin.flag = -1;
   safe_lincpy(true, &m_wcs->lin, &wcs_copy.lin);
   linset(&wcs_copy.lin);


### PR DESCRIPTION
Wrapping wcslib in its own namespace causes some types from the standard
libraries to end there too. Include guards likely prevent a later
inclusion, so the compilation fails because they will not be anymore in
the std namespace.