### PR TITLE
Fix/head files

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent
-filter=-whitespace,-build/header_guard,-build/namespaces,-build/c++11
+filter=-whitespace,-build/header_guard,-build/namespaces,-build/c++11,-build/include_what_you_use,runtime/references
 linelength=120

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -24,12 +24,14 @@
 #ifndef _SEFRAMEWORK_IMAGE_FITSIMAGESOURCE_H_
 #define _SEFRAMEWORK_IMAGE_FITSIMAGESOURCE_H_
 
+#include <vector>
+#include <iostream>
+
+#include <boost/lexical_cast.hpp>
+
 #include "SEFramework/CoordinateSystem/CoordinateSystem.h"
 #include "SEFramework/Image/ImageSource.h"
 #include "SEFramework/FITS/FitsFileManager.h"
-
-#include <iostream>
-#include <boost/lexical_cast.hpp>
 
 
 namespace SourceXtractor {
@@ -74,7 +76,7 @@ public:
   void saveTile(ImageTile<T>& tile) override;
 
   template <typename TT>
-  bool readFitsKeyword(const std::string& header_keyword, TT& out_value) {
+  bool readFitsKeyword(const std::string& header_keyword, TT& out_value) const {
     auto i = m_header.find(header_keyword);
     if (i != m_header.end()) {
       out_value = boost::lexical_cast<TT>(i->second);
@@ -87,10 +89,13 @@ public:
     return m_hdu_number;
   }
 
+  std::unique_ptr<std::vector<char>> getFitsHeaders(int& number_of_records) const;
+
 private:
 
   void switchHdu(fitsfile* fptr, int hdu_number) const;
 
+  std::map<std::string, std::string> loadFitsHeader(fitsfile *fptr);
   void loadHeadFile();
 
   int getDataType() const;

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -24,8 +24,9 @@
 #ifndef _SEFRAMEWORK_IMAGE_FITSIMAGESOURCE_H_
 #define _SEFRAMEWORK_IMAGE_FITSIMAGESOURCE_H_
 
+#include <memory>
 #include <vector>
-#include <iostream>
+#include <map>
 
 #include <boost/lexical_cast.hpp>
 

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -265,14 +265,22 @@ std::unique_ptr<std::vector<char>> FitsImageSource<T>::getFitsHeaders(int& numbe
     auto key = record.first;
 
     std::string record_string(key);
-    if (record_string.size() < 8) {
+    if (record_string.size() > 8) {
+      throw Elements::Exception() << "FITS keyword longer than 8 characters";
+    } else if (record_string.size() < 8) {
       record_string += std::string(8 - record_string.size(), ' ');
     }
 
     record_string += "= " +  m_header.at(key);
 
+    if (record_string.size() > 80) {
+      throw Elements::Exception() << "FITS record longer than 80 characters";
+    }
 
-    record_string += std::string(80 - record_string.size(), ' ');
+
+    if (record_string.size() < 80) {
+      record_string += std::string(80 - record_string.size(), ' ');
+    }
 
     records += record_string;
     number_of_records++;

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -232,9 +232,8 @@ void FitsImageSource<T>::loadHeadFile() {
       std::string line;
       std::getline(file, line);
 
-      line = boost::regex_replace(line, boost::regex("\\s*#.*"), std::string(""));
-      line = boost::regex_replace(line, boost::regex("\\s*$"), std::string(""));
-
+      static boost::regex regex_blank_line("\\s*$");
+      line = boost::regex_replace(line, regex_blank_line, std::string(""));
       if (line.size() == 0) {
         continue;
       }
@@ -243,10 +242,14 @@ void FitsImageSource<T>::loadHeadFile() {
         current_hdu++;
       }
       else if (current_hdu == m_hdu_number) {
+        static boost::regex regex("([^=]+)=([^\\/]*)(.*)");
         boost::smatch sub_matches;
-        if (boost::regex_match(line, sub_matches, boost::regex("(.+)=(.+)")) && sub_matches.size() == 3) {
+        if (boost::regex_match(line, sub_matches, regex) && sub_matches.size() >= 3) {
           auto keyword = boost::to_upper_copy(sub_matches[1].str());
-          m_header[keyword] = sub_matches[2];
+          auto value = sub_matches[2].str();
+          boost::trim(keyword);
+          boost::trim(value);
+          m_header[keyword] = value;
         }
       }
     }

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -21,16 +21,19 @@
  *      Author: mschefer
  */
 
-#include "SEFramework/FITS/FitsImageSource.h"
-#include <ElementsKernel/Exception.h>
 #include <iomanip>
 #include <fstream>
+#include <string>
+
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
+#include <ElementsKernel/Exception.h>
+
+#include "SEFramework/FITS/FitsImageSource.h"
 
 namespace SourceXtractor {
 

--- a/SEImplementation/SEImplementation/CoordinateSystem/WCS.h
+++ b/SEImplementation/SEImplementation/CoordinateSystem/WCS.h
@@ -24,7 +24,9 @@
 #ifndef _SEIMPLEMENTATION_COORDINATESYSTEM_WCS_H_
 #define _SEIMPLEMENTATION_COORDINATESYSTEM_WCS_H_
 
+
 #include "SEFramework/CoordinateSystem/CoordinateSystem.h"
+#include "SEFramework/FITS/FitsImageSource.h"
 
 namespace wcslib {
 struct wcsprm;
@@ -34,7 +36,7 @@ namespace SourceXtractor {
 
 class WCS : public CoordinateSystem {
 public:
-  WCS(const std::string& fits_file_path, int hdu_number = 1);
+  WCS(const FitsImageSource<SeFloat>& fits_image_source);
   virtual ~WCS();
 
   WorldCoordinate imageToWorld(ImageCoordinate image_coordinate) const override;

--- a/SEImplementation/SEImplementation/CoordinateSystem/WCS.h
+++ b/SEImplementation/SEImplementation/CoordinateSystem/WCS.h
@@ -24,6 +24,8 @@
 #ifndef _SEIMPLEMENTATION_COORDINATESYSTEM_WCS_H_
 #define _SEIMPLEMENTATION_COORDINATESYSTEM_WCS_H_
 
+#include <memory>
+#include <map>
 
 #include "SEFramework/CoordinateSystem/CoordinateSystem.h"
 #include "SEFramework/FITS/FitsImageSource.h"
@@ -36,7 +38,7 @@ namespace SourceXtractor {
 
 class WCS : public CoordinateSystem {
 public:
-  WCS(const FitsImageSource<SeFloat>& fits_image_source);
+  explicit WCS(const FitsImageSource<SeFloat>& fits_image_source);
   virtual ~WCS();
 
   WorldCoordinate imageToWorld(ImageCoordinate image_coordinate) const override;

--- a/SEImplementation/python/sourcextractor/config/measurement_images.py
+++ b/SEImplementation/python/sourcextractor/config/measurement_images.py
@@ -184,18 +184,18 @@ class MeasurementImage(cpp.MeasurementImage):
             
             with open(header_file) as f:
                 for line in f:
-                    line = re.sub("\\s*#.*", "", line)
                     line = re.sub("\\s*$", "", line)
-                    
                     if line == "":
                         continue
                     
                     if line.upper() == "END":
                         current_hdu += 1
                     elif current_hdu == hdu:
-                        m = re.match("(.+)=(.+)", line)
+                        m = re.match("([^=]+)=([^\\/]*)(.*)", line)
                         if m:
-                            self.meta[m.group(1)] = m.group(2)
+                            keyword = m.group(1).strip().upper()
+                            value = m.group(2).strip()
+                            self.meta[keyword] = value
 
     def __str__(self):
         """

--- a/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
@@ -73,7 +73,7 @@ void DetectionImageConfig::initialize(const UserValues& args) {
   m_detection_image_path = args.find(DETECTION_IMAGE)->second.as<std::string>();
   auto fits_image_source = std::make_shared<FitsImageSource<DetectionImage::PixelType>>(m_detection_image_path);
   m_detection_image = BufferedImage<DetectionImage::PixelType>::create(fits_image_source);
-  m_coordinate_system = std::make_shared<WCS>(args.find(DETECTION_IMAGE)->second.as<std::string>(), fits_image_source->getHDU());
+  m_coordinate_system = std::make_shared<WCS>(*fits_image_source);
 
   double detection_image_gain = 0, detection_image_saturate = 0;
   fits_image_source->readFitsKeyword("GAIN", detection_image_gain);

--- a/SEImplementation/src/lib/CoordinateSystem/WCS.cpp
+++ b/SEImplementation/src/lib/CoordinateSystem/WCS.cpp
@@ -21,6 +21,10 @@
  *      Author: mschefer
  */
 
+#include <mutex>
+
+#include <boost/algorithm/string/trim.hpp>
+
 #include <fitsio.h>
 
 namespace wcslib {
@@ -35,9 +39,8 @@ namespace wcslib {
 
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Logging.h"
+
 #include "SEImplementation/CoordinateSystem/WCS.h"
-#include <boost/algorithm/string/trim.hpp>
-#include <mutex>
 
 namespace SourceXtractor {
 


### PR DESCRIPTION
Allows ascii .head files to override WCS coordinates and the parser should now be more compatible with actual head files generated by astromatic software.