### PR TITLE
should fix more fits header and .head files issues

### DIFF
--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -46,7 +46,7 @@ std::map<std::string, std::string> FitsImageSource<T>::loadFitsHeader(fitsfile *
 
   fits_read_record(fptr, keynum, record, &status);
   while (status == 0 && strncmp(record, "END", 3) != 0) {
-    static boost::regex regex("([^=]+)=([^\\/]*)(.*)");
+    static boost::regex regex("([^=]{8})=([^\\/]*)(.*)");
     std::string record_str(record);
 
     boost::smatch sub_matches;
@@ -245,7 +245,7 @@ void FitsImageSource<T>::loadHeadFile() {
         current_hdu++;
       }
       else if (current_hdu == m_hdu_number) {
-        static boost::regex regex("([^=]+)=([^\\/]*)(.*)");
+        static boost::regex regex("([^=]{1,8})=([^\\/]*)(.*)");
         boost::smatch sub_matches;
         if (boost::regex_match(line, sub_matches, regex) && sub_matches.size() >= 3) {
           auto keyword = boost::to_upper_copy(sub_matches[1].str());

--- a/SEImplementation/python/sourcextractor/config/measurement_images.py
+++ b/SEImplementation/python/sourcextractor/config/measurement_images.py
@@ -197,7 +197,7 @@ class MeasurementImage(cpp.MeasurementImage):
                     if line.upper() == "END":
                         current_hdu += 1
                     elif current_hdu == hdu:
-                        m = re.match("([^=]+)=([^\\/]*)(.*)", line)
+                        m = re.match("([^=]{1,8})=([^\\/]*)(.*)", line)
                         if m:
                             keyword = m.group(1).strip().upper()
                             value = m.group(2).strip()


### PR DESCRIPTION
When loading fits file headers, now checks keywords to be exactly 8 characters (including spaces for padding if shorter) followed by a = at position 9

When loading .head files, check for 1-8 characters (possibly spaces) followed by a = (so we are slightly more flexible, while still compatible with pure fits headers)
