### PR TITLE
Default to first known model fitting engine

### DIFF
--- a/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
@@ -38,8 +38,13 @@ LegacyModelFittingConfig::LegacyModelFittingConfig(long manager_id) : Configurat
 auto LegacyModelFittingConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
   std::string default_engine;
-  if (!known_engines.empty())
+
+  if (std::find(known_engines.begin(), known_engines.end(), "levmar") != known_engines.end()) {
+    default_engine = "levmar";
+  }
+  else if (!known_engines.empty()) {
     default_engine = known_engines.front();
+  }
 
   return {{"Model Fitting",
       {

--- a/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "SEImplementation/Configuration/LegacyModelFittingConfig.h"
+#include "ModelFitting/Engine/LeastSquareEngineManager.h"
 
 using namespace Euclid::Configuration;
 namespace po = boost::program_options;
@@ -35,11 +36,16 @@ LegacyModelFittingConfig::LegacyModelFittingConfig(long manager_id) : Configurat
 }
 
 auto LegacyModelFittingConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
+  auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
+  std::string default_engine;
+  if (!known_engines.empty())
+    default_engine = known_engines.front();
+
   return {{"Model Fitting",
       {
         {MFIT_MAX_ITERATIONS.c_str(), po::value<int>()->default_value(1000),
          "Maximum number of iterations allowed for model fitting"},
-        {MFIT_ENGINE.c_str(), po::value<std::string>()->default_value("levmar"),
+        {MFIT_ENGINE.c_str(), po::value<std::string>()->default_value(default_engine),
          "Least squares engine"}
       }
   }};

--- a/SEImplementation/tests/src/Plugin/MoffatModelFitting/MoffatModelFitting_test.cpp
+++ b/SEImplementation/tests/src/Plugin/MoffatModelFitting/MoffatModelFitting_test.cpp
@@ -43,6 +43,7 @@
 #include "SEFramework/Property/DetectionFrame.h"
 
 #include "SEImplementation/Plugin/Psf/PsfPluginConfig.h"
+#include "ModelFitting/Engine/LeastSquareEngineManager.h"
 
 using namespace SourceXtractor;
 
@@ -63,7 +64,8 @@ struct MoffatModelFittingFixture {
   std::shared_ptr<MoffatModelFittingTask> model_fitting_task;
 
   MoffatModelFittingFixture() {
-    model_fitting_task = std::make_shared<MoffatModelFittingTask>("levmar", 100);
+    auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
+    model_fitting_task = std::make_shared<MoffatModelFittingTask>(known_engines.front(), 100);
   }
 };
 


### PR DESCRIPTION
The least squares engine defaults to "levmar", but sourcextractor may be compiled with gsl and without levmar (i.e. eden 2.1). It makes sense to pick as a default whichever engine there is. If there are multiple, then the first one.