### PR TITLE
Added a SNR plugin computed from isophotal flux

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/NDetectedPixels/NDetectedPixelsPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/NDetectedPixels/NDetectedPixelsPlugin.h
@@ -49,7 +49,6 @@ public:
   virtual ~NDetectedPixelsPlugin() = default;
   virtual void registerPlugin(PluginAPI& plugin_api) {
     plugin_api.getTaskFactoryRegistry().registerTaskFactory<NDetectedPixelsTaskFactory, NDetectedPixels>();
-    //plugin_api.getOutputRegistry().registerColumnConverter<NDetectedPixels, int>(
     plugin_api.getOutputRegistry().registerColumnConverter<NDetectedPixels, int64_t>(
             "n_detected_pixels",
             [](const NDetectedPixels& prop){

--- a/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatio.h
+++ b/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatio.h
@@ -1,0 +1,47 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file SNRRatio.h
+ *
+ * @date Jan 29, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_SNRRATIO_H_
+#define _SEIMPLEMENTATION_PLUGIN_SNRRATIO_H_
+
+#include "SEUtils/Types.h"
+#include "SEFramework/Property/Property.h"
+
+namespace SourceXtractor {
+class SNRRatio : public Property {
+public:
+  virtual ~SNRRatio() = default;
+
+  SNRRatio(SeFloat snrratio) : m_snrratio(snrratio) {}
+
+  SeFloat getSNRRatio() const {
+    return m_snrratio;
+  }
+
+private:
+  SeFloat m_snrratio;
+}; // end of SNRRatio class
+} // namespace SourceXtractor
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_SNRRATIO_H_*/

--- a/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioPlugin.h
@@ -1,0 +1,57 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file SNRRatioPlugin.h
+ *
+ * @date Apr 29, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_SNRRATIOPLUGIN_H_
+#define _SEIMPLEMENTATION_PLUGIN_SNRRATIOPLUGIN_H_
+
+#include "SNRRatio.h"
+#include "SEFramework/Plugin/Plugin.h"
+#include "SEImplementation/Plugin/SNRRatio/SNRRatioTaskFactory.h"
+
+namespace SourceXtractor {
+class SNRRatioPlugin : public Plugin {
+public:
+  virtual ~SNRRatioPlugin() = default;
+
+  virtual void registerPlugin(PluginAPI& plugin_api) {
+    plugin_api.getTaskFactoryRegistry().registerTaskFactory<SNRRatioTaskFactory, SNRRatio>();
+    plugin_api.getOutputRegistry().registerColumnConverter<SNRRatio, float>(
+      "snrratio",
+      [](const SNRRatio& prop) {
+        return prop.getSNRRatio();
+      },
+      "[]",
+      "The object signal-to-noise ratio"
+    );
+    plugin_api.getOutputRegistry().enableOutput<SNRRatio>("SNRRatio");
+  }
+
+  virtual std::string getIdString() const {
+    return "snrratio";
+  }
+
+private:
+}; // end of SNRRatioPlugin class
+}  // namespace SourceXtractor
+#endif /* _SEIMPLEMENTATION_PLUGIN_SNRRATIOPLUGIN_H_ */

--- a/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioSourceTask.h
+++ b/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioSourceTask.h
@@ -1,0 +1,52 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file SNRRatioSourceTask.h
+ *
+ * @date Apr 29, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_SNRRATIOSOURCETASK_H_
+#define _SEIMPLEMENTATION_PLUGIN_SNRRATIOSOURCETASK_H_
+
+#include "SEFramework/Task/SourceTask.h"
+#include "SEImplementation/Plugin/SNRRatio/SNRRatio.h"
+#include "SEImplementation/Plugin/IsophotalFlux/IsophotalFlux.h"
+
+namespace SourceXtractor {
+class SNRRatioSourceTask : public SourceTask {
+public:
+  virtual ~SNRRatioSourceTask() = default;
+
+  virtual void computeProperties(SourceInterface& source) const {
+    // get the input quantities
+    const auto& iso_flux = source.getProperty<IsophotalFlux>().getFlux();
+    const auto& iso_flux_error = source.getProperty<IsophotalFlux>().getFluxError();
+
+    // compute and store the property
+    SeFloat snr_ratio = iso_flux / iso_flux_error;
+    source.setProperty<SNRRatio>(snr_ratio);
+  };
+private:
+}; // End of SNRRatioSourceTask class
+} // namespace SourceXtractor
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_SNRRATIOSOURCETASK_H_ */
+
+

--- a/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioTaskFactory.h
@@ -1,0 +1,48 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file SNRRatioTaskFactory.h
+ *
+ * @date Jan 29, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+#ifndef _SEIMPLEMENTATION_PLUGIN_SNRRATIOTASKFACTORY_H_
+#define _SEIMPLEMENTATION_PLUGIN_SNRRATIOTASKFACTORY_H_
+
+#include "SEFramework/Task/TaskFactory.h"
+#include "SEImplementation/Plugin/SNRRatio/SNRRatioSourceTask.h"
+
+namespace SourceXtractor {
+class SNRRatioTaskFactory : public TaskFactory {
+public:
+  SNRRatioTaskFactory() {}
+
+  virtual ~SNRRatioTaskFactory() = default;
+
+  // TaskFactory implementation
+  virtual std::shared_ptr<Task> createTask(const PropertyId& property_id) const {
+    if (property_id == PropertyId::create<SNRRatio>()) {
+      return std::make_shared<SNRRatioSourceTask>();
+    }
+    else {
+      return nullptr;
+    }
+  }
+}; // end of SNRRatioTaskFactory class
+}  // namespace SourceXtractor
+#endif /* _SEIMPLEMENTATION_PLUGIN_SNRRATIOTASKFACTORY_H_ */

--- a/SEImplementation/src/lib/Plugin/SNRRatio/SNRRatioPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/SNRRatio/SNRRatioPlugin.cpp
@@ -1,0 +1,30 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file SNRRatioPlugin.cpp
+ *
+ * @date Jan 29, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#include "SEFramework/Plugin/StaticPlugin.h"
+#include "SEImplementation/Plugin/SNRRatio/SNRRatioPlugin.h"
+
+namespace SourceXtractor {
+static StaticPlugin<SNRRatioPlugin> snrratio;
+}


### PR DESCRIPTION
Another plugin from @mkuemmel branch.
From what I have seen, sextractor uses a "Gaussian Window" for the computation of the SNR. Is this SNR based on the isophotal flux enough for psfex?