### PR TITLE
Feature: Vignet plugin

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/Vignet/Vignet.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/Vignet.h
@@ -1,0 +1,58 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */    
+
+/**
+ * @file Vignet.h
+ *
+ * @date Jan 17, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNET_H_
+#define _SEIMPLEMENTATION_PLUGIN_VIGNET_H_
+
+#include "SEUtils/Types.h"
+#include "SEFramework/Property/Property.h"
+
+namespace SourceXtractor {
+class Vignet : public Property {
+public:
+  virtual ~Vignet() = default;
+  Vignet(std::vector<SeFloat> vignet) : m_vignet(vignet) {}
+  const std::vector<SeFloat> &getVignet () const {
+    return m_vignet;
+  }
+private:
+  std::vector<SeFloat> m_vignet;
+}; // end of Vignet class
+} // namespace SourceXtractor
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNET_H_*/

--- a/SEImplementation/SEImplementation/Plugin/Vignet/Vignet.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/Vignet.h
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */
 
 /**
  * @file Vignet.h

--- a/SEImplementation/SEImplementation/Plugin/Vignet/Vignet.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/Vignet.h
@@ -27,7 +27,7 @@
  *  
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */    
+ */
 
 /**
  * @file Vignet.h
@@ -41,18 +41,23 @@
 
 #include "SEUtils/Types.h"
 #include "SEFramework/Property/Property.h"
+#include "SEFramework/Image/VectorImage.h"
 
 namespace SourceXtractor {
 class Vignet : public Property {
 public:
   virtual ~Vignet() = default;
-  Vignet(std::vector<SeFloat> vignet) : m_vignet(vignet) {}
-  const std::vector<SeFloat> &getVignet () const {
-    return m_vignet;
+
+  Vignet(const std::shared_ptr<VectorImage<DetectionImage::PixelType>> vignet) : m_vignet(vignet) {}
+
+  const VectorImage<DetectionImage::PixelType>& getVignet() const {
+    return *m_vignet;
   }
+
 private:
-  std::vector<SeFloat> m_vignet;
+  std::shared_ptr<VectorImage<DetectionImage::PixelType>> m_vignet;
 }; // end of Vignet class
+
 } // namespace SourceXtractor
 
 #endif /* _SEIMPLEMENTATION_PLUGIN_VIGNET_H_*/

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetArray.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetArray.h
@@ -30,18 +30,33 @@ class VignetArray: public Property {
 public:
   VignetArray(const std::vector<std::reference_wrapper<const Vignet>>& vignets) {
     const auto& representative = vignets.front().get().getVignet();
-    std::vector<size_t> shape{
-      vignets.size(), static_cast<size_t>(representative.getWidth()), static_cast<size_t>(representative.getHeight())
-    };
-    m_vignets = Euclid::make_unique<Euclid::NdArray::NdArray<DetectionImage::PixelType>>(shape);
 
-    for (size_t v = 0; v < vignets.size(); ++v) {
-      const auto& img = vignets[v].get().getVignet();
-      assert (img.getWidth() == representative.getWidth());
-      assert (img.getHeight() == representative.getHeight());
-      for (int x = 0; x < img.getWidth(); ++x) {
-        for (int y = 0; y < img.getHeight(); ++y) {
-          m_vignets->at(v, x, y) = img.getValue(x, y);
+    if (vignets.size() > 1) {
+      std::vector<size_t> shape{
+        vignets.size(), static_cast<size_t>(representative.getWidth()), static_cast<size_t>(representative.getHeight())
+      };
+      m_vignets = Euclid::make_unique<Euclid::NdArray::NdArray<DetectionImage::PixelType>>(shape);
+
+      for (size_t v = 0; v < vignets.size(); ++v) {
+        const auto& img = vignets[v].get().getVignet();
+        assert (img.getWidth() == representative.getWidth());
+        assert (img.getHeight() == representative.getHeight());
+        for (int x = 0; x < img.getWidth(); ++x) {
+          for (int y = 0; y < img.getHeight(); ++y) {
+            m_vignets->at(v, x, y) = img.getValue(x, y);
+          }
+        }
+      }
+    }
+    else {
+      std::vector<size_t> shape{
+        static_cast<size_t>(representative.getWidth()), static_cast<size_t>(representative.getHeight())
+      };
+      m_vignets = Euclid::make_unique<Euclid::NdArray::NdArray<DetectionImage::PixelType>>(shape);
+
+      for (int x = 0; x < representative.getWidth(); ++x) {
+        for (int y = 0; y < representative.getHeight(); ++y) {
+          m_vignets->at(x, y) = representative.getValue(x, y);
         }
       }
     }

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetArray.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetArray.h
@@ -1,0 +1,60 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETARRAY_H_
+#define _SEIMPLEMENTATION_PLUGIN_VIGNETARRAY_H_
+
+#include <NdArray/NdArray.h>
+#include <AlexandriaKernel/memory_tools.h>
+#include "SEFramework/Image/Image.h"
+#include "SEFramework/Property/Property.h"
+#include "SEImplementation/Plugin/Vignet/Vignet.h"
+
+namespace SourceXtractor {
+
+class VignetArray: public Property {
+public:
+  VignetArray(const std::vector<std::reference_wrapper<const Vignet>>& vignets) {
+    const auto& representative = vignets.front().get().getVignet();
+    std::vector<size_t> shape{
+      vignets.size(), static_cast<size_t>(representative.getWidth()), static_cast<size_t>(representative.getHeight())
+    };
+    m_vignets = Euclid::make_unique<Euclid::NdArray::NdArray<DetectionImage::PixelType>>(shape);
+
+    for (size_t v = 0; v < vignets.size(); ++v) {
+      const auto& img = vignets[v].get().getVignet();
+      assert (img.getWidth() == representative.getWidth());
+      assert (img.getHeight() == representative.getHeight());
+      for (int x = 0; x < img.getWidth(); ++x) {
+        for (int y = 0; y < img.getHeight(); ++y) {
+          m_vignets->at(v, x, y) = img.getValue(x, y);
+        }
+      }
+    }
+  }
+
+  const Euclid::NdArray::NdArray<DetectionImage::PixelType>& getVignets() const {
+    return *m_vignets;
+  }
+
+private:
+  std::unique_ptr<Euclid::NdArray::NdArray<DetectionImage::PixelType>> m_vignets;
+};
+
+} // end of namespace SourceXtractor
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETARRAY_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetArraySourceTask.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetArraySourceTask.h
@@ -15,36 +15,25 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/**
- * @file VignetSourceTask.h
- *
- * @date Jan. 23, 2020
- * @author mkuemmel@usm.lmu.de
- */
-
-#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
-#define _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETARRAYSOURCETASK_H_
+#define _SEIMPLEMENTATION_PLUGIN_VIGNETARRAYSOURCETASK_H_
 
 #include "SEFramework/Task/SourceTask.h"
 
 namespace SourceXtractor {
-class VignetSourceTask : public SourceTask {
+
+class VignetArraySourceTask: public SourceTask {
 public:
-  VignetSourceTask(unsigned instance, std::array<int, 2> vignet_size, double vignet_default_pixval) :
-    m_instance(instance),
-    m_vignet_size(vignet_size),
-    m_vignet_default_pixval((SeFloat) vignet_default_pixval) {};
+  virtual ~VignetArraySourceTask() = default;
 
-  virtual ~VignetSourceTask() = default;
+  VignetArraySourceTask(const std::vector<unsigned> images);
 
-  virtual void computeProperties(SourceInterface& source) const;
+  void computeProperties(SourceInterface& source) const override;
 
 private:
-  unsigned m_instance;
-  std::array<int, 2> m_vignet_size;
-  SeFloat m_vignet_default_pixval;
-}; // End of VignetSourceTask class
+  std::vector<unsigned> m_images;
+};
 
-} // namespace SourceXtractor
+} // end of namespace SourceXtractor
 
-#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_ */
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETARRAYSOURCETASK_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetConfig.h
@@ -1,0 +1,59 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/* 
+ * @file BackgroundConfiguration.h
+ * @author nikoapos
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETCONFIG_H
+#define _SEIMPLEMENTATION_PLUGIN_VIGNETCONFIG_H
+
+#include "Configuration/Configuration.h"
+#include "SEFramework/Image/Image.h"
+
+namespace SourceXtractor {
+
+class VignetConfig : public Euclid::Configuration::Configuration {
+  
+public:
+  
+  VignetConfig(long manager_id);
+  
+  virtual ~VignetConfig() = default;
+
+  std::map<std::string, Configuration::OptionDescriptionList> getProgramOptions() override;
+  
+  void initialize(const UserValues& args) override;
+  
+  std::string getVignetSize() const {
+    return m_vignet_size;
+  }
+
+  double getVignetDefaultPixval() const {
+    return m_vignet_default_pixval;
+  }
+
+private:
+  std::string m_vignet_size;
+  double      m_vignet_default_pixval;
+
+};
+
+} /* namespace SourceXtractor */
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETCONFIG_H */
+

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetConfig.h
@@ -28,18 +28,18 @@
 namespace SourceXtractor {
 
 class VignetConfig : public Euclid::Configuration::Configuration {
-  
+
 public:
-  
+
   VignetConfig(long manager_id);
-  
+
   virtual ~VignetConfig() = default;
 
   std::map<std::string, Configuration::OptionDescriptionList> getProgramOptions() override;
-  
+
   void initialize(const UserValues& args) override;
-  
-  std::string getVignetSize() const {
+
+  const std::array<int, 2>& getVignetSize() const {
     return m_vignet_size;
   }
 
@@ -48,8 +48,8 @@ public:
   }
 
 private:
-  std::string m_vignet_size;
-  double      m_vignet_default_pixval;
+  std::array<int, 2> m_vignet_size;
+  double m_vignet_default_pixval;
 
 };
 

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
@@ -29,6 +29,7 @@
 #include "SEFramework/Plugin/Plugin.h"
 #include "SEImplementation/Plugin/Vignet/VignetTaskFactory.h"
 #include "Vignet.h"
+#include "VignetArray.h"
 
 namespace SourceXtractor {
 
@@ -40,19 +41,16 @@ public:
   virtual ~VignetPlugin() = default;
 
   virtual void registerPlugin(PluginAPI& plugin_api) {
-    plugin_api.getTaskFactoryRegistry().registerTaskFactory<VignetTaskFactory, Vignet>();
-    plugin_api.getOutputRegistry().registerColumnConverter<Vignet, NdArray<DetectionImage::PixelType >>(
+    plugin_api.getTaskFactoryRegistry().registerTaskFactory<VignetTaskFactory, Vignet, VignetArray>();
+    plugin_api.getOutputRegistry().registerColumnConverter<VignetArray, NdArray<DetectionImage::PixelType >>(
       "vignet",
-      [](const Vignet& prop) {
-        const auto& vignette = prop.getVignet();
-        return NdArray<DetectionImage::PixelType>(
-          std::vector<size_t>{static_cast<size_t>(vignette.getWidth()), static_cast<size_t>(vignette.getHeight())},
-          vignette.getData());
+      [](const VignetArray& prop) {
+        return prop.getVignets();
       },
       "[]",
       "The object vignet data"
     );
-    plugin_api.getOutputRegistry().enableOutput<Vignet>("Vignet");
+    plugin_api.getOutputRegistry().enableOutput<VignetArray>("Vignet");
   }
 
   virtual std::string getIdString() const {

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
@@ -27,7 +27,7 @@
  *  
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */    
+ */
 
 /**
  * @file VignetPlugin.h
@@ -39,30 +39,42 @@
 #ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETPLUGIN_H_
 #define _SEIMPLEMENTATION_PLUGIN_VIGNETPLUGIN_H_
 
+#include <NdArray/NdArray.h>
 #include "SEFramework/Plugin/Plugin.h"
 #include "SEImplementation/Plugin/Vignet/VignetTaskFactory.h"
 #include "Vignet.h"
 
 namespace SourceXtractor {
+
+template<typename T>
+using NdArray = Euclid::NdArray::NdArray<T>;
+
 class VignetPlugin : public Plugin {
 public:
   virtual ~VignetPlugin() = default;
+
   virtual void registerPlugin(PluginAPI& plugin_api) {
     plugin_api.getTaskFactoryRegistry().registerTaskFactory<VignetTaskFactory, Vignet>();
-    plugin_api.getOutputRegistry().registerColumnConverter<Vignet, std::vector<SeFloat>>(
-            "vignet",
-            [](const Vignet& prop){
-              return prop.getVignet();
-            },
-            "[]",
-            "The object vignet data"
+    plugin_api.getOutputRegistry().registerColumnConverter<Vignet, NdArray<DetectionImage::PixelType >>(
+      "vignet",
+      [](const Vignet& prop) {
+        const auto& vignette = prop.getVignet();
+        return NdArray<DetectionImage::PixelType>(
+          std::vector<size_t>{static_cast<size_t>(vignette.getWidth()), static_cast<size_t>(vignette.getHeight())},
+          vignette.getData());
+      },
+      "[]",
+      "The object vignet data"
     );
     plugin_api.getOutputRegistry().enableOutput<Vignet>("Vignet");
   }
+
   virtual std::string getIdString() const {
     return "Vignet";
   }
+
 private:
 }; // end of VignetPlugin class
+
 }  // namespace SourceXtractor
 #endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETPLUGIN_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
@@ -1,0 +1,68 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */    
+
+/**
+ * @file VignetPlugin.h
+ *
+ * @date Jan 17, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETPLUGIN_H_
+#define _SEIMPLEMENTATION_PLUGIN_VIGNETPLUGIN_H_
+
+#include "SEFramework/Plugin/Plugin.h"
+#include "SEImplementation/Plugin/Vignet/VignetTaskFactory.h"
+#include "Vignet.h"
+
+namespace SourceXtractor {
+class VignetPlugin : public Plugin {
+public:
+  virtual ~VignetPlugin() = default;
+  virtual void registerPlugin(PluginAPI& plugin_api) {
+    plugin_api.getTaskFactoryRegistry().registerTaskFactory<VignetTaskFactory, Vignet>();
+    plugin_api.getOutputRegistry().registerColumnConverter<Vignet, std::vector<SeFloat>>(
+            "vignet",
+            [](const Vignet& prop){
+              return prop.getVignet();
+            },
+            "[]",
+            "The object vignet data"
+    );
+    plugin_api.getOutputRegistry().enableOutput<Vignet>("Vignet");
+  }
+  virtual std::string getIdString() const {
+    return "Vignet";
+  }
+private:
+}; // end of VignetPlugin class
+}  // namespace SourceXtractor
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETPLUGIN_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */
 
 /**
  * @file VignetPlugin.h

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
@@ -40,12 +40,6 @@
 #define _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
 
 #include "SEFramework/Task/SourceTask.h"
-#include "SEFramework/Property/DetectionFrame.h"
-#include "SEImplementation/Plugin/PixelCentroid/PixelCentroid.h"
-#include "SEImplementation/Property/PixelCoordinateList.h"
-#include "SEImplementation/Plugin/Vignet/Vignet.h"
-#include "SEImplementation/Plugin/ShapeParameters/ShapeParameters.h"
-#include "SEImplementation/Measurement/MultithreadedMeasurement.h"
 
 namespace SourceXtractor {
 class VignetSourceTask : public SourceTask {
@@ -56,64 +50,8 @@ public:
 
   virtual ~VignetSourceTask() = default;
 
-  virtual void computeProperties(SourceInterface& source) const {
-    std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
+  virtual void computeProperties(SourceInterface& source) const;
 
-    // get the detection, the variance and the threshold frames
-    const auto& sub_image = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
-    const auto& var_image = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
-    const auto& var_threshold = source.getProperty<DetectionFrame>().getFrame()->getVarianceThreshold();
-    const auto& thresh_image = source.getProperty<DetectionFrame>().getFrame()->getThresholdedImage();
-
-	// get the object pixel data
-    const auto& pixel_coords = source.getProperty<PixelCoordinateList>().getCoordinateList();
-
-    // get the central pixel coord
-    const int x_pix = (int) (source.getProperty<PixelCentroid>().getCentroidX() + 0.5);
-    const int y_pix = (int) (source.getProperty<PixelCentroid>().getCentroidY() + 0.5);
-
-    // get the sub-image boundaries
-    int x_start = x_pix - m_vignet_size[0] / 2;
-    int y_start = y_pix - m_vignet_size[1] / 2;
-    int x_end = x_start + m_vignet_size[0];
-    int y_end = y_start + m_vignet_size[1];
-
-    // create and fill the vignet vector
-    std::vector<SeFloat> vignet_vector(m_vignet_size[0] * m_vignet_size[1], m_vignet_default_pixval);
-    int index = 0;
-    for (int iy = y_start; iy < y_end; iy++) {
-      for (int ix = x_start; ix < x_end; ix++, index++) {
-
-        // skip pixels outside of the image
-        if (ix < 0 || iy < 0 || ix >= sub_image->getWidth() || iy >= sub_image->getHeight())
-          continue;
-
-        // skip masked pixels
-        if (var_image->getValue(ix, iy) < var_threshold && thresh_image->getValue(ix, iy) <= 0.0)
-          vignet_vector[index] = sub_image->getValue(ix, iy);
-      }
-    }
-
-    // go over all pixel coordinates
-    for (auto one_coord: pixel_coords) {
-    	// skip coordinates outside of the vignet
-    	if (one_coord.m_y < y_start || one_coord.m_x < x_start || one_coord.m_y >= y_end || one_coord.m_x >= x_end)
-    		continue;
-
-    	// compute the vector index
-    	index = (one_coord.m_y-y_start)*m_vignet_size[0] + one_coord.m_x-x_start;
-    	if (index <0 || index >= (int)vignet_vector.size())
-    		//lets leave that sanity check in
-    		throw Elements::Exception() << "Invalid index: " << index << " for vector of size: " << vignet_vector.size();
-    	else
-    		// insert the pixel value (again)
-    		vignet_vector[(one_coord.m_y-y_start)*m_vignet_size[0]+one_coord.m_x-x_start] = sub_image->getValue(one_coord.m_x, one_coord.m_y);
-   }
-
-    // set the property
-    source.setProperty<Vignet>(
-      VectorImage<DetectionImage::PixelType>::create(m_vignet_size[0], m_vignet_size[1], std::move(vignet_vector)));
-  };
 private:
   std::array<int, 2> m_vignet_size;
   SeFloat m_vignet_default_pixval;

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
@@ -1,0 +1,101 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */    
+
+/**
+ * @file VignetSourceTask.h
+ *
+ * @date Jan. 23, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
+#define _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
+
+#include "SEFramework/Task/SourceTask.h"
+#include "SEFramework/Property/DetectionFrame.h"
+#include "SEImplementation/Plugin/PixelCentroid/PixelCentroid.h"
+#include "SEImplementation/Plugin/Vignet/Vignet.h"
+#include "SEImplementation/Plugin/ShapeParameters/ShapeParameters.h"
+#include "SEImplementation/Measurement/MultithreadedMeasurement.h"
+
+namespace SourceXtractor {
+class VignetSourceTask : public SourceTask {
+public:
+  VignetSourceTask(std::vector<int> vignet_size, double vignet_default_pixval):
+    m_vignet_size(vignet_size),
+    m_vignet_default_pixval((SeFloat)vignet_default_pixval) {};
+
+  virtual ~VignetSourceTask() = default;
+
+  virtual void computeProperties(SourceInterface& source) const {
+    std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
+
+    // get the detection and the variance frames
+    const auto& sub_image     = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
+    const auto& var_image     = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
+    const auto& var_threshold = source.getProperty<DetectionFrame>().getFrame()->getVarianceThreshold();
+
+    // get the central pixel coord
+    const int x_pix = (int)(source.getProperty<PixelCentroid>().getCentroidX()+0.5);
+    const int y_pix = (int)(source.getProperty<PixelCentroid>().getCentroidY()+0.5);
+
+    // get the sub-image boundaries
+    int x_start = x_pix-m_vignet_size[0]/2;
+    int y_start = y_pix-m_vignet_size[1]/2;
+    int x_end   = x_start+ m_vignet_size[0];
+    int y_end   = y_start+ m_vignet_size[1];
+
+    // create and fill the vignet vector
+    std::vector<SeFloat> vignet_vector(m_vignet_size[0]*m_vignet_size[1], m_vignet_default_pixval);
+    int index=0;
+    for (int iy=y_start; iy<y_end; iy++){
+      for (int ix=x_start; ix<x_end; ix++, index++){
+
+        // skip pixels outside of the image
+        if (ix<0 || iy<0 || ix>=sub_image->getWidth() || iy>=sub_image->getHeight())
+          continue;
+
+        // skip masked pixels
+        if (var_image->getValue(ix, iy)<var_threshold)
+          vignet_vector[index] =  sub_image->getValue(ix, iy);
+      }
+    }
+
+    // set the property
+    source.setProperty<Vignet>(vignet_vector);
+};
+private:
+  std::vector<int> m_vignet_size;
+  SeFloat  m_vignet_default_pixval;
+}; // End of VignetSourceTask class
+} // namespace SourceXtractor
+
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
@@ -27,7 +27,7 @@
  *  
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */    
+ */
 
 /**
  * @file VignetSourceTask.h
@@ -49,9 +49,9 @@
 namespace SourceXtractor {
 class VignetSourceTask : public SourceTask {
 public:
-  VignetSourceTask(std::vector<int> vignet_size, double vignet_default_pixval):
+  VignetSourceTask(std::array<int, 2> vignet_size, double vignet_default_pixval) :
     m_vignet_size(vignet_size),
-    m_vignet_default_pixval((SeFloat)vignet_default_pixval) {};
+    m_vignet_default_pixval((SeFloat) vignet_default_pixval) {};
 
   virtual ~VignetSourceTask() = default;
 
@@ -59,43 +59,45 @@ public:
     std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
 
     // get the detection and the variance frames
-    const auto& sub_image     = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
-    const auto& var_image     = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
+    const auto& sub_image = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
+    const auto& var_image = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
     const auto& var_threshold = source.getProperty<DetectionFrame>().getFrame()->getVarianceThreshold();
 
     // get the central pixel coord
-    const int x_pix = (int)(source.getProperty<PixelCentroid>().getCentroidX()+0.5);
-    const int y_pix = (int)(source.getProperty<PixelCentroid>().getCentroidY()+0.5);
+    const int x_pix = (int) (source.getProperty<PixelCentroid>().getCentroidX() + 0.5);
+    const int y_pix = (int) (source.getProperty<PixelCentroid>().getCentroidY() + 0.5);
 
     // get the sub-image boundaries
-    int x_start = x_pix-m_vignet_size[0]/2;
-    int y_start = y_pix-m_vignet_size[1]/2;
-    int x_end   = x_start+ m_vignet_size[0];
-    int y_end   = y_start+ m_vignet_size[1];
+    int x_start = x_pix - m_vignet_size[0] / 2;
+    int y_start = y_pix - m_vignet_size[1] / 2;
+    int x_end = x_start + m_vignet_size[0];
+    int y_end = y_start + m_vignet_size[1];
 
     // create and fill the vignet vector
-    std::vector<SeFloat> vignet_vector(m_vignet_size[0]*m_vignet_size[1], m_vignet_default_pixval);
-    int index=0;
-    for (int iy=y_start; iy<y_end; iy++){
-      for (int ix=x_start; ix<x_end; ix++, index++){
+    std::vector<SeFloat> vignet_vector(m_vignet_size[0] * m_vignet_size[1], m_vignet_default_pixval);
+    int index = 0;
+    for (int iy = y_start; iy < y_end; iy++) {
+      for (int ix = x_start; ix < x_end; ix++, index++) {
 
         // skip pixels outside of the image
-        if (ix<0 || iy<0 || ix>=sub_image->getWidth() || iy>=sub_image->getHeight())
+        if (ix < 0 || iy < 0 || ix >= sub_image->getWidth() || iy >= sub_image->getHeight())
           continue;
 
         // skip masked pixels
-        if (var_image->getValue(ix, iy)<var_threshold)
-          vignet_vector[index] =  sub_image->getValue(ix, iy);
+        if (var_image->getValue(ix, iy) < var_threshold)
+          vignet_vector[index] = sub_image->getValue(ix, iy);
       }
     }
 
     // set the property
-    source.setProperty<Vignet>(vignet_vector);
-};
+    source.setProperty<Vignet>(
+      VectorImage<DetectionImage::PixelType>::create(m_vignet_size[0], m_vignet_size[1], std::move(vignet_vector)));
+  };
 private:
-  std::vector<int> m_vignet_size;
-  SeFloat  m_vignet_default_pixval;
+  std::array<int, 2> m_vignet_size;
+  SeFloat m_vignet_default_pixval;
 }; // End of VignetSourceTask class
+
 } // namespace SourceXtractor
 
 #endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetSourceTask.h
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */
 
 /**
  * @file VignetSourceTask.h

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */    
 
 /**
  * @file VignetTaskFactory.h
@@ -46,6 +32,7 @@ namespace SourceXtractor {
 class VignetTaskFactory : public TaskFactory {
 public:
   VignetTaskFactory() {}
+
   virtual ~VignetTaskFactory() = default;
 
   void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const {
@@ -56,21 +43,7 @@ public:
 
     // get the input parameter
     auto vignet_config = manager.getConfiguration<VignetConfig>();
-
-    // convert to int vector;
-    // double a single paramter if necessary
-    m_vignet_size = stringToIntVec(vignet_config.getVignetSize(), std::string(","));
-    if (m_vignet_size.size()<1){
-      throw Elements::Exception() << "Can not convert to 'int': '" << vignet_config.getVignetSize();
-    }
-    else if (m_vignet_size.size()<2){
-      m_vignet_size.push_back(m_vignet_size[0]);
-    }
-
-    // make sure there are positive numbers
-    if (m_vignet_size[0] < 1 || m_vignet_size[1] <1)
-      throw Elements::Exception() << "Vignet size must be positive: " << vignet_config.getVignetSize();
-
+    m_vignet_size = vignet_config.getVignetSize();
     m_vignet_default_pixval = vignet_config.getVignetDefaultPixval();
   };
 
@@ -79,16 +52,15 @@ public:
     if (property_id == PropertyId::create<Vignet>()) {
       return std::make_shared<VignetSourceTask>(m_vignet_size, m_vignet_default_pixval);
     }
-    else{
+    else {
       return nullptr;
     }
   }
-private:
-  std::vector<int> stringToIntVec(const std::string inString, const std::string delimiters);
-  std::vector<std::string> stringSplit(const std::string inString, const std::string delimiters);
 
-  std::vector<int> m_vignet_size;
-  double      m_vignet_default_pixval;
+private:
+  std::array<int, 2> m_vignet_size;
+  double m_vignet_default_pixval;
 }; // end of VignetTaskFactory class
+
 }  // namespace SourceXtractor
 #endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETTASKFACTORY_H_ */

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
@@ -25,9 +25,6 @@
 #define _SEIMPLEMENTATION_PLUGIN_VIGNETTASKFACTORY_H_
 
 #include "SEFramework/Task/TaskFactory.h"
-#include "SEImplementation/Plugin/Vignet/Vignet.h"
-#include "SEImplementation/Plugin/Vignet/VignetConfig.h"
-#include "SEImplementation/Plugin/Vignet/VignetSourceTask.h"
 
 namespace SourceXtractor {
 class VignetTaskFactory : public TaskFactory {
@@ -36,31 +33,17 @@ public:
 
   virtual ~VignetTaskFactory() = default;
 
-  void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const {
-    manager.registerConfiguration<VignetConfig>();
-  };
+  void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const override;
 
-  void configure(Euclid::Configuration::ConfigManager& manager) {
-
-    // get the input parameter
-    auto vignet_config = manager.getConfiguration<VignetConfig>();
-    m_vignet_size = vignet_config.getVignetSize();
-    m_vignet_default_pixval = vignet_config.getVignetDefaultPixval();
-  };
+  void configure(Euclid::Configuration::ConfigManager& manager) override;
 
   // TaskFactory implementation
-  virtual std::shared_ptr<Task> createTask(const PropertyId& property_id) const {
-    if (property_id == PropertyId::create<Vignet>()) {
-      return std::make_shared<VignetSourceTask>(m_vignet_size, m_vignet_default_pixval);
-    }
-    else {
-      return nullptr;
-    }
-  }
+  std::shared_ptr<Task> createTask(const PropertyId& property_id) const override;
 
 private:
   std::array<int, 2> m_vignet_size;
   double m_vignet_default_pixval;
+  std::vector<unsigned> m_images;
 }; // end of VignetTaskFactory class
 
 }  // namespace SourceXtractor

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
@@ -25,6 +25,7 @@
 #define _SEIMPLEMENTATION_PLUGIN_VIGNETTASKFACTORY_H_
 
 #include "SEFramework/Task/TaskFactory.h"
+#include "SEImplementation/Plugin/Vignet/Vignet.h"
 #include "SEImplementation/Plugin/Vignet/VignetConfig.h"
 #include "SEImplementation/Plugin/Vignet/VignetSourceTask.h"
 

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetTaskFactory.h
@@ -1,0 +1,94 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */    
+
+/**
+ * @file VignetTaskFactory.h
+ *
+ * @date Jan 17, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETTASKFACTORY_H_
+#define _SEIMPLEMENTATION_PLUGIN_VIGNETTASKFACTORY_H_
+
+#include "SEFramework/Task/TaskFactory.h"
+#include "SEImplementation/Plugin/Vignet/VignetConfig.h"
+#include "SEImplementation/Plugin/Vignet/VignetSourceTask.h"
+
+namespace SourceXtractor {
+class VignetTaskFactory : public TaskFactory {
+public:
+  VignetTaskFactory() {}
+  virtual ~VignetTaskFactory() = default;
+
+  void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const {
+    manager.registerConfiguration<VignetConfig>();
+  };
+
+  void configure(Euclid::Configuration::ConfigManager& manager) {
+
+    // get the input parameter
+    auto vignet_config = manager.getConfiguration<VignetConfig>();
+
+    // convert to int vector;
+    // double a single paramter if necessary
+    m_vignet_size = stringToIntVec(vignet_config.getVignetSize(), std::string(","));
+    if (m_vignet_size.size()<1){
+      throw Elements::Exception() << "Can not convert to 'int': '" << vignet_config.getVignetSize();
+    }
+    else if (m_vignet_size.size()<2){
+      m_vignet_size.push_back(m_vignet_size[0]);
+    }
+
+    // make sure there are positive numbers
+    if (m_vignet_size[0] < 1 || m_vignet_size[1] <1)
+      throw Elements::Exception() << "Vignet size must be positive: " << vignet_config.getVignetSize();
+
+    m_vignet_default_pixval = vignet_config.getVignetDefaultPixval();
+  };
+
+  // TaskFactory implementation
+  virtual std::shared_ptr<Task> createTask(const PropertyId& property_id) const {
+    if (property_id == PropertyId::create<Vignet>()) {
+      return std::make_shared<VignetSourceTask>(m_vignet_size, m_vignet_default_pixval);
+    }
+    else{
+      return nullptr;
+    }
+  }
+private:
+  std::vector<int> stringToIntVec(const std::string inString, const std::string delimiters);
+  std::vector<std::string> stringSplit(const std::string inString, const std::string delimiters);
+
+  std::vector<int> m_vignet_size;
+  double      m_vignet_default_pixval;
+}; // end of VignetTaskFactory class
+}  // namespace SourceXtractor
+#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETTASKFACTORY_H_ */

--- a/SEImplementation/SEImplementation/Property/PixelCoordinateList.h
+++ b/SEImplementation/SEImplementation/Property/PixelCoordinateList.h
@@ -22,6 +22,7 @@
 #ifndef _SEIMPLEMENTATION_PIXELCOORDINATELIST_H
 #define _SEIMPLEMENTATION_PIXELCOORDINATELIST_H
 
+#include <algorithm>
 #include "SEUtils/PixelCoordinate.h"
 #include "SEFramework/Property/Property.h"
 
@@ -39,6 +40,10 @@ public:
   
   const std::vector<PixelCoordinate>& getCoordinateList() const {
     return m_coordinate_list;
+  }
+
+  bool contains(const PixelCoordinate& coord) const {
+    return std::find(m_coordinate_list.begin(), m_coordinate_list.end(), coord) != m_coordinate_list.end();
   }
   
 private:

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetArraySourceTask.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetArraySourceTask.cpp
@@ -15,36 +15,21 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/**
- * @file VignetSourceTask.h
- *
- * @date Jan. 23, 2020
- * @author mkuemmel@usm.lmu.de
- */
-
-#ifndef _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
-#define _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_
-
-#include "SEFramework/Task/SourceTask.h"
+#include "SEImplementation/Plugin/Vignet/Vignet.h"
+#include "SEImplementation/Plugin/Vignet/VignetArray.h"
+#include "SEImplementation/Plugin/Vignet/VignetArraySourceTask.h"
 
 namespace SourceXtractor {
-class VignetSourceTask : public SourceTask {
-public:
-  VignetSourceTask(unsigned instance, std::array<int, 2> vignet_size, double vignet_default_pixval) :
-    m_instance(instance),
-    m_vignet_size(vignet_size),
-    m_vignet_default_pixval((SeFloat) vignet_default_pixval) {};
 
-  virtual ~VignetSourceTask() = default;
+VignetArraySourceTask::VignetArraySourceTask(const std::vector<unsigned> images): m_images{images} {
+}
 
-  virtual void computeProperties(SourceInterface& source) const;
+void VignetArraySourceTask::computeProperties(SourceInterface& source) const {
+  std::vector<std::reference_wrapper<const Vignet>> vignets;
+  for (auto img_idx : m_images) {
+    vignets.emplace_back(source.getProperty<Vignet>(img_idx));
+  }
+  source.setProperty<VignetArray>(vignets);
+}
 
-private:
-  unsigned m_instance;
-  std::array<int, 2> m_vignet_size;
-  SeFloat m_vignet_default_pixval;
-}; // End of VignetSourceTask class
-
-} // namespace SourceXtractor
-
-#endif /* _SEIMPLEMENTATION_PLUGIN_VIGNETSOURCETASK_H_ */
+} // end of namespace SourceXtractor

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetConfig.cpp
@@ -1,0 +1,57 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/* 
+ * @file VignetConfig.cpp
+ * @author mkuemmel
+ */
+
+#include "SEFramework/Image/ProcessedImage.h"
+#include "SEImplementation/Plugin/Vignet/VignetConfig.h"
+
+using namespace Euclid::Configuration;
+namespace po = boost::program_options;
+
+namespace SourceXtractor {
+
+static const std::string VIGNET_SIZE {"vignet-size" };
+static const std::string VIGNET_DEFAULT_PIXVAL {"vignet-default-pixval" };
+
+VignetConfig::VignetConfig(long manager_id) :
+    Configuration(manager_id),
+    m_vignet_size(),
+    m_vignet_default_pixval() {
+}
+
+std::map<std::string, Configuration::OptionDescriptionList> VignetConfig::getProgramOptions() {
+  return { {"Vignet output", {
+      {VIGNET_SIZE.c_str(), po::value<std::string>()->default_value(std::string("15,15")),
+          "X- and Y-size of the vignet."},
+      {VIGNET_DEFAULT_PIXVAL.c_str(), po::value<double>()->default_value(-1.0E30),
+          "Default pixel value for the vignet data"},
+  }}};
+}
+
+void VignetConfig::initialize(const UserValues& args) {
+  if (args.find(VIGNET_SIZE) != args.end()) {
+    m_vignet_size = args.find(VIGNET_SIZE)->second.as<std::string>();
+  }
+  if (args.find(VIGNET_DEFAULT_PIXVAL) != args.end()) {
+    m_vignet_default_pixval = args.find(VIGNET_DEFAULT_PIXVAL)->second.as<double>();
+  }
+}
+
+} // SourceXtractor namespace

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetConfig.cpp
@@ -19,6 +19,7 @@
  * @author mkuemmel
  */
 
+#include <AlexandriaKernel/StringUtils.h>
 #include "SEFramework/Image/ProcessedImage.h"
 #include "SEImplementation/Plugin/Vignet/VignetConfig.h"
 
@@ -31,9 +32,9 @@ static const std::string VIGNET_SIZE {"vignet-size" };
 static const std::string VIGNET_DEFAULT_PIXVAL {"vignet-default-pixval" };
 
 VignetConfig::VignetConfig(long manager_id) :
-    Configuration(manager_id),
-    m_vignet_size(),
-    m_vignet_default_pixval() {
+  Configuration(manager_id),
+  m_vignet_size(),
+  m_vignet_default_pixval() {
 }
 
 std::map<std::string, Configuration::OptionDescriptionList> VignetConfig::getProgramOptions() {
@@ -46,8 +47,18 @@ std::map<std::string, Configuration::OptionDescriptionList> VignetConfig::getPro
 }
 
 void VignetConfig::initialize(const UserValues& args) {
-  if (args.find(VIGNET_SIZE) != args.end()) {
-    m_vignet_size = args.find(VIGNET_SIZE)->second.as<std::string>();
+  auto vignet_iter = args.find(VIGNET_SIZE);
+  if (vignet_iter != args.end()) {
+    auto vignet_str = vignet_iter->second.as<std::string>();
+    auto vignet_vector = Euclid::stringToVector<int>(vignet_str);
+    if (vignet_vector.size() > 2) {
+      throw Elements::Exception() << VIGNET_SIZE << " only accepts one or two numbers";
+    }
+    m_vignet_size[0] = vignet_vector.front();
+    m_vignet_size[1] = vignet_vector.back();
+    if (m_vignet_size[0] < 0 || m_vignet_size[1] < 0) {
+      throw Elements::Exception() << VIGNET_SIZE << " only accept positive numbers";
+    }
   }
   if (args.find(VIGNET_DEFAULT_PIXVAL) != args.end()) {
     m_vignet_default_pixval = args.find(VIGNET_DEFAULT_PIXVAL)->second.as<double>();

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetConfig.cpp
@@ -41,7 +41,7 @@ std::map<std::string, Configuration::OptionDescriptionList> VignetConfig::getPro
   return { {"Vignet output", {
       {VIGNET_SIZE.c_str(), po::value<std::string>()->default_value(std::string("15,15")),
           "X- and Y-size of the vignet."},
-      {VIGNET_DEFAULT_PIXVAL.c_str(), po::value<double>()->default_value(-1.0E30),
+	      {VIGNET_DEFAULT_PIXVAL.c_str(), po::value<double>()->default_value(std::nan("")), //Note: the SE2 value is "1.0E30", but nan is more consistent
           "Default pixel value for the vignet data"},
   }}};
 }

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetPlugin.cpp
@@ -1,0 +1,44 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */    
+
+/**
+ * @file VignetPlugin.cpp
+ *
+ * @date Jan 23, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#include "SEFramework/Plugin/StaticPlugin.h"
+#include "SEImplementation/Plugin/Vignet/VignetPlugin.h"
+
+namespace SourceXtractor {
+  static StaticPlugin<VignetPlugin> vignet;
+}

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetPlugin.cpp
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */    
 
 /**
  * @file VignetPlugin.cpp
@@ -40,5 +26,5 @@
 #include "SEImplementation/Plugin/Vignet/VignetPlugin.h"
 
 namespace SourceXtractor {
-  static StaticPlugin<VignetPlugin> vignet;
+static StaticPlugin<VignetPlugin> vignet;
 }

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetSourceTask.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetSourceTask.cpp
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */
 
 /**
  * @file VignetSourceTask.cpp
@@ -46,61 +32,62 @@
 
 namespace SourceXtractor {
 void VignetSourceTask::computeProperties(SourceInterface& source) const {
-	std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
+  std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
 
-    // get the detection, the variance and the threshold frames
-    const auto& sub_image = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
-    const auto& var_image = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
-    const auto& var_threshold = source.getProperty<DetectionFrame>().getFrame()->getVarianceThreshold();
-    const auto& thresh_image = source.getProperty<DetectionFrame>().getFrame()->getThresholdedImage();
+  // get the detection, the variance and the threshold frames
+  const auto& sub_image = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
+  const auto& var_image = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
+  const auto& var_threshold = source.getProperty<DetectionFrame>().getFrame()->getVarianceThreshold();
+  const auto& thresh_image = source.getProperty<DetectionFrame>().getFrame()->getThresholdedImage();
 
-	// get the object pixel data
-    const auto& pixel_coords = source.getProperty<PixelCoordinateList>().getCoordinateList();
+  // get the object pixel data
+  const auto& pixel_coords = source.getProperty<PixelCoordinateList>().getCoordinateList();
 
-    // get the central pixel coord
-    const int x_pix = (int) (source.getProperty<PixelCentroid>().getCentroidX() + 0.5);
-    const int y_pix = (int) (source.getProperty<PixelCentroid>().getCentroidY() + 0.5);
+  // get the central pixel coord
+  const int x_pix = (int) (source.getProperty<PixelCentroid>().getCentroidX() + 0.5);
+  const int y_pix = (int) (source.getProperty<PixelCentroid>().getCentroidY() + 0.5);
 
-    // get the sub-image boundaries
-    int x_start = x_pix - m_vignet_size[0] / 2;
-    int y_start = y_pix - m_vignet_size[1] / 2;
-    int x_end = x_start + m_vignet_size[0];
-    int y_end = y_start + m_vignet_size[1];
+  // get the sub-image boundaries
+  int x_start = x_pix - m_vignet_size[0] / 2;
+  int y_start = y_pix - m_vignet_size[1] / 2;
+  int x_end = x_start + m_vignet_size[0];
+  int y_end = y_start + m_vignet_size[1];
 
-    // create and fill the vignet vector
-    std::vector<SeFloat> vignet_vector(m_vignet_size[0] * m_vignet_size[1], m_vignet_default_pixval);
-    int index = 0;
-    for (int iy = y_start; iy < y_end; iy++) {
-      for (int ix = x_start; ix < x_end; ix++, index++) {
+  // create and fill the vignet vector
+  std::vector<SeFloat> vignet_vector(m_vignet_size[0] * m_vignet_size[1], m_vignet_default_pixval);
+  int index = 0;
+  for (int iy = y_start; iy < y_end; iy++) {
+    for (int ix = x_start; ix < x_end; ix++, index++) {
 
-        // skip pixels outside of the image
-        if (ix < 0 || iy < 0 || ix >= sub_image->getWidth() || iy >= sub_image->getHeight())
-          continue;
+      // skip pixels outside of the image
+      if (ix < 0 || iy < 0 || ix >= sub_image->getWidth() || iy >= sub_image->getHeight())
+        continue;
 
-        // skip masked pixels
-        if (var_image->getValue(ix, iy) < var_threshold && thresh_image->getValue(ix, iy) <= 0.0)
-          vignet_vector[index] = sub_image->getValue(ix, iy);
-      }
+      // skip masked pixels
+      if (var_image->getValue(ix, iy) < var_threshold && thresh_image->getValue(ix, iy) <= 0.0)
+        vignet_vector[index] = sub_image->getValue(ix, iy);
     }
+  }
 
-    // go over all pixel coordinates
-    for (auto one_coord: pixel_coords) {
-    	// skip coordinates outside of the vignet
-    	if (one_coord.m_y < y_start || one_coord.m_x < x_start || one_coord.m_y >= y_end || one_coord.m_x >= x_end)
-    		continue;
+  // go over all pixel coordinates
+  for (auto one_coord: pixel_coords) {
+    // skip coordinates outside of the vignet
+    if (one_coord.m_y < y_start || one_coord.m_x < x_start || one_coord.m_y >= y_end || one_coord.m_x >= x_end)
+      continue;
 
-    	// compute the vector index
-    	index = (one_coord.m_y-y_start)*m_vignet_size[0] + one_coord.m_x-x_start;
-    	if (index <0 || index >= (int)vignet_vector.size())
-    		//lets leave that sanity check in
-    		throw Elements::Exception() << "Invalid index: " << index << " for vector of size: " << vignet_vector.size();
-    	else
-    		// insert the pixel value (again)
-    		vignet_vector[(one_coord.m_y-y_start)*m_vignet_size[0]+one_coord.m_x-x_start] = sub_image->getValue(one_coord.m_x, one_coord.m_y);
-   }
+    // compute the vector index
+    index = (one_coord.m_y - y_start) * m_vignet_size[0] + one_coord.m_x - x_start;
+    if (index < 0 || index >= (int) vignet_vector.size())
+      //lets leave that sanity check in
+      throw Elements::Exception() << "Invalid index: " << index << " for vector of size: " << vignet_vector.size();
+    else
+      // insert the pixel value (again)
+      vignet_vector[(one_coord.m_y - y_start) * m_vignet_size[0] + one_coord.m_x - x_start] = sub_image->getValue(
+        one_coord.m_x, one_coord.m_y);
+  }
 
-    // set the property
-    source.setProperty<Vignet>(
-      VectorImage<DetectionImage::PixelType>::create(m_vignet_size[0], m_vignet_size[1], std::move(vignet_vector)));
-  };
+  // set the property
+  source.setProperty<Vignet>(
+    VectorImage<DetectionImage::PixelType>::create(m_vignet_size[0], m_vignet_size[1], std::move(vignet_vector)));
+}
 } // namespace SourceXtractor

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetSourceTask.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetSourceTask.cpp
@@ -1,0 +1,106 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */
+
+/**
+ * @file VignetSourceTask.cpp
+ *
+ * @date Jan. 23, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#include "SEFramework/Property/DetectionFrame.h"
+#include "SEImplementation/Plugin/PixelCentroid/PixelCentroid.h"
+#include "SEImplementation/Property/PixelCoordinateList.h"
+#include "SEImplementation/Plugin/Vignet/Vignet.h"
+#include "SEImplementation/Plugin/ShapeParameters/ShapeParameters.h"
+#include "SEImplementation/Measurement/MultithreadedMeasurement.h"
+#include "SEImplementation/Plugin/Vignet/VignetSourceTask.h"
+
+namespace SourceXtractor {
+void VignetSourceTask::computeProperties(SourceInterface& source) const {
+	std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
+
+    // get the detection, the variance and the threshold frames
+    const auto& sub_image = source.getProperty<DetectionFrame>().getFrame()->getSubtractedImage();
+    const auto& var_image = source.getProperty<DetectionFrame>().getFrame()->getUnfilteredVarianceMap();
+    const auto& var_threshold = source.getProperty<DetectionFrame>().getFrame()->getVarianceThreshold();
+    const auto& thresh_image = source.getProperty<DetectionFrame>().getFrame()->getThresholdedImage();
+
+	// get the object pixel data
+    const auto& pixel_coords = source.getProperty<PixelCoordinateList>().getCoordinateList();
+
+    // get the central pixel coord
+    const int x_pix = (int) (source.getProperty<PixelCentroid>().getCentroidX() + 0.5);
+    const int y_pix = (int) (source.getProperty<PixelCentroid>().getCentroidY() + 0.5);
+
+    // get the sub-image boundaries
+    int x_start = x_pix - m_vignet_size[0] / 2;
+    int y_start = y_pix - m_vignet_size[1] / 2;
+    int x_end = x_start + m_vignet_size[0];
+    int y_end = y_start + m_vignet_size[1];
+
+    // create and fill the vignet vector
+    std::vector<SeFloat> vignet_vector(m_vignet_size[0] * m_vignet_size[1], m_vignet_default_pixval);
+    int index = 0;
+    for (int iy = y_start; iy < y_end; iy++) {
+      for (int ix = x_start; ix < x_end; ix++, index++) {
+
+        // skip pixels outside of the image
+        if (ix < 0 || iy < 0 || ix >= sub_image->getWidth() || iy >= sub_image->getHeight())
+          continue;
+
+        // skip masked pixels
+        if (var_image->getValue(ix, iy) < var_threshold && thresh_image->getValue(ix, iy) <= 0.0)
+          vignet_vector[index] = sub_image->getValue(ix, iy);
+      }
+    }
+
+    // go over all pixel coordinates
+    for (auto one_coord: pixel_coords) {
+    	// skip coordinates outside of the vignet
+    	if (one_coord.m_y < y_start || one_coord.m_x < x_start || one_coord.m_y >= y_end || one_coord.m_x >= x_end)
+    		continue;
+
+    	// compute the vector index
+    	index = (one_coord.m_y-y_start)*m_vignet_size[0] + one_coord.m_x-x_start;
+    	if (index <0 || index >= (int)vignet_vector.size())
+    		//lets leave that sanity check in
+    		throw Elements::Exception() << "Invalid index: " << index << " for vector of size: " << vignet_vector.size();
+    	else
+    		// insert the pixel value (again)
+    		vignet_vector[(one_coord.m_y-y_start)*m_vignet_size[0]+one_coord.m_x-x_start] = sub_image->getValue(one_coord.m_x, one_coord.m_y);
+   }
+
+    // set the property
+    source.setProperty<Vignet>(
+      VectorImage<DetectionImage::PixelType>::create(m_vignet_size[0], m_vignet_size[1], std::move(vignet_vector)));
+  };
+} // namespace SourceXtractor

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetTaskFactory.cpp
@@ -1,0 +1,104 @@
+/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment    
+ *  
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
+ * any later version.  
+ *  
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
+ * details.  
+ *  
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ */    
+
+/**
+ * @file VignetPlugin.cpp
+ *
+ * @date Jan 23, 2020
+ * @author mkuemmel@usm.lmu.de
+ */
+
+#include "SEFramework/Plugin/StaticPlugin.h"
+#include "SEImplementation/Plugin/Vignet/VignetTaskFactory.h"
+
+namespace SourceXtractor {
+std::vector<int> VignetTaskFactory::stringToIntVec(const std::string inString, const std::string delimiters)
+{
+  std::vector<int> result;
+  int anInt=0;
+  std::size_t first;
+  std::size_t last;
+
+  // convert the input string to a vector of strings along the commas
+  std::vector<std::string> stringVec=stringSplit(inString, delimiters);
+
+  // go over all members
+  for (size_t index=0; index<stringVec.size(); index++)
+  {
+    // prepare trimming
+    first = stringVec[index].find_first_not_of(' ');
+    last  = stringVec[index].find_last_not_of(' ');
+
+    try
+    {
+      // try converting to int and append to result vector
+      anInt = boost::lexical_cast<size_t>(stringVec[index].substr(first, last-first+1));
+      result.push_back(anInt);
+    }
+    catch ( const boost::bad_lexical_cast &exc ) // conversion failed, exception thrown by lexical_cast and caught
+    {
+      throw Elements::Exception() << "Can not convert to 'int': '" << stringVec[index].substr(first, last-first+1) << "'";
+    }
+  }
+
+  return result;
+}
+
+std::vector<std::string> VignetTaskFactory::stringSplit(const std::string inString, const std::string delimiters)
+{
+  std::vector<std::string> result;
+  std::string trimString;
+  size_t current;
+  size_t next = -1;
+  size_t first=0;
+  size_t last=0;
+
+  // trim blanks from both sides;
+  // return the empty vector if there
+  // are only blanks
+  first = inString.find_first_not_of(' ');
+  if (first == std::string::npos)
+    return result;
+  last  = inString.find_last_not_of(' ');
+  trimString = inString.substr(first, last-first+1);
+
+  do
+  { // split along the delimiter
+    // and add to the result vector
+    current = next + 1;
+    next = trimString.find_first_of( delimiters, current );
+    result.push_back(trimString.substr( current, next - current ));
+  }
+  while (next != std::string::npos);
+
+  return result;
+}
+}

--- a/SEImplementation/src/lib/Plugin/Vignet/VignetTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/Vignet/VignetTaskFactory.cpp
@@ -14,20 +14,6 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */    
 
 /**
  * @file VignetPlugin.cpp
@@ -36,69 +22,5 @@
  * @author mkuemmel@usm.lmu.de
  */
 
-#include "SEFramework/Plugin/StaticPlugin.h"
-#include "SEImplementation/Plugin/Vignet/VignetTaskFactory.h"
-
 namespace SourceXtractor {
-std::vector<int> VignetTaskFactory::stringToIntVec(const std::string inString, const std::string delimiters)
-{
-  std::vector<int> result;
-  int anInt=0;
-  std::size_t first;
-  std::size_t last;
-
-  // convert the input string to a vector of strings along the commas
-  std::vector<std::string> stringVec=stringSplit(inString, delimiters);
-
-  // go over all members
-  for (size_t index=0; index<stringVec.size(); index++)
-  {
-    // prepare trimming
-    first = stringVec[index].find_first_not_of(' ');
-    last  = stringVec[index].find_last_not_of(' ');
-
-    try
-    {
-      // try converting to int and append to result vector
-      anInt = boost::lexical_cast<size_t>(stringVec[index].substr(first, last-first+1));
-      result.push_back(anInt);
-    }
-    catch ( const boost::bad_lexical_cast &exc ) // conversion failed, exception thrown by lexical_cast and caught
-    {
-      throw Elements::Exception() << "Can not convert to 'int': '" << stringVec[index].substr(first, last-first+1) << "'";
-    }
-  }
-
-  return result;
-}
-
-std::vector<std::string> VignetTaskFactory::stringSplit(const std::string inString, const std::string delimiters)
-{
-  std::vector<std::string> result;
-  std::string trimString;
-  size_t current;
-  size_t next = -1;
-  size_t first=0;
-  size_t last=0;
-
-  // trim blanks from both sides;
-  // return the empty vector if there
-  // are only blanks
-  first = inString.find_first_not_of(' ');
-  if (first == std::string::npos)
-    return result;
-  last  = inString.find_last_not_of(' ');
-  trimString = inString.substr(first, last-first+1);
-
-  do
-  { // split along the delimiter
-    // and add to the result vector
-    current = next + 1;
-    next = trimString.find_first_of( delimiters, current );
-    result.push_back(trimString.substr( current, next - current ));
-  }
-  while (next != std::string::npos);
-
-  return result;
-}
 }


### PR DESCRIPTION
Extracted from @mkuemmel feature/elongation branch. Required for psfex.
I have modified it to generate a 2D output columns, which seems to be the case for sextractor.

*TO BE VERIFIED*: I think SE masks out pixels that are known to belong to another source.

![vignet](https://user-images.githubusercontent.com/1410577/81704234-dab71880-946d-11ea-8d5d-1cf39721c4a2.png)
