### PR TITLE
Couple of fixes for sigma computation in model fitting

### DIFF
--- a/ModelFitting/src/lib/Engine/GSLEngine.cpp
+++ b/ModelFitting/src/lib/Engine/GSLEngine.cpp
@@ -141,12 +141,12 @@ LeastSquareSummary GSLEngine::solveProblem(ModelFitting::EngineParameterManager&
   }
 
   // Allocate space for the parameters and initialize with the guesses
-  std::vector<double> param_values (parameter_manager.numberOfParameters());
+  std::vector<double> param_values(parameter_manager.numberOfParameters());
   parameter_manager.getEngineValues(param_values.begin());
   gsl_vector_view gsl_param_view = gsl_vector_view_array(param_values.data(), param_values.size());
 
   // Function to be minimized
-  auto function = [](const gsl_vector* x, void *extra, gsl_vector *f) -> int {
+  auto function = [](const gsl_vector *x, void *extra, gsl_vector *f) -> int {
     auto *extra_ptr = (decltype(adata) *) extra;
     EngineParameterManager& pm = std::get<0>(*extra_ptr);
     pm.updateEngineValues(GslVectorConstIterator{x});
@@ -188,7 +188,8 @@ LeastSquareSummary GSLEngine::solveProblem(ModelFitting::EngineParameterManager&
   gsl_blas_ddot(residual, residual, &chisq);
 
   // Build run summary
-  std::vector<double> covariance_matrix (parameter_manager.numberOfParameters() * parameter_manager.numberOfParameters());
+  std::vector<double> covariance_matrix(
+    parameter_manager.numberOfParameters() * parameter_manager.numberOfParameters());
 
   LeastSquareSummary summary;
   summary.success_flag = (ret == GSL_SUCCESS);
@@ -200,6 +201,20 @@ LeastSquareSummary GSLEngine::solveProblem(ModelFitting::EngineParameterManager&
   gsl_matrix_view covar = gsl_matrix_view_array(covariance_matrix.data(), parameter_manager.numberOfParameters(),
                                                 parameter_manager.numberOfParameters());
   gsl_multifit_nlinear_covar(J, 0.0, &covar.matrix);
+
+  // We have done an unweighted minimization, so, from the documentation, we need
+  // to multiply the covariance matrix by the variance of the residuals
+  // See: https://www.gnu.org/software/gsl/doc/html/nls.html#covariance-matrix-of-best-fit-parameters
+  double sigma2 = 0;
+  for (size_t i = 0; i < residual->size; ++i) {
+    auto v = gsl_vector_get(residual, i);
+    sigma2 += v * v;
+  }
+  sigma2 /= (fdf.n - fdf.p);
+
+  for (auto ci = covariance_matrix.begin(); ci != covariance_matrix.end(); ++ci) {
+    *ci *= sigma2;
+  }
 
   auto converted_covariance_matrix = parameter_manager.convertCovarianceMatrixToWorldSpace(covariance_matrix);
   for (unsigned int i=0; i<parameter_manager.numberOfParameters(); i++) {

--- a/ModelFitting/src/lib/Parameters/ExpSigmoidConverter.cpp
+++ b/ModelFitting/src/lib/Parameters/ExpSigmoidConverter.cpp
@@ -45,7 +45,7 @@ double ExpSigmoidConverter::engineToWorld(const double engine_value) const {
 }
 
 double ExpSigmoidConverter::getEngineToWorldDerivative(const double value) const {
-  return value * log(value - m_min_value) * log(m_max_value - value) / log(m_max_value - m_min_value);
+  return value * log(value / m_min_value) * log(m_max_value / value) / log(m_max_value / m_min_value);
 }
 
 


### PR DESCRIPTION
* I realized re-reading [the GSL documentation](https://www.gnu.org/software/gsl/doc/html/nls.html#covariance-matrix-of-best-fit-parameters) that, since we are doing non weighted least squares, the covariance matrix has to be scaled by the sigma^2 of the residuals to get the error from the parameters.

* I *think* `ExpSigmoidConverter::getEngineToWorldDerivative` was wrong. Looking at [sextractor](https://github.com/astromatic/sextractor/blob/cd4590c0b8ed43ea74bda107f8a218827c63d7b1/src/profit.c#L3665) it seems we should be dividing instead of subtracting.

Here is flux vs flux err:

![flux_err](https://user-images.githubusercontent.com/1410577/84894657-6ccfc380-b0a1-11ea-8ae3-97d8eb76afbe.png)

It is specially visible in mag vs mag err: the extremely high errors for bright sources disappear.

![mag_err](https://user-images.githubusercontent.com/1410577/84894662-6e998700-b0a1-11ea-81f5-9125ed12dce4.png)

There are still some weirdos, bright objects with an error of mag 40, but it is better than an error of 14000 mag. Besides, they look to be false detections. I haven't cross-validated with the true simulation.

![Figure 19](https://user-images.githubusercontent.com/1410577/84896362-1f088a80-b0a4-11ea-83ea-6e131b135e4b.png)
