### PR TITLE
Protect access to image with locks

### DIFF
--- a/SEImplementation/src/lib/Partition/MultiThresholdPartitionStep.cpp
+++ b/SEImplementation/src/lib/Partition/MultiThresholdPartitionStep.cpp
@@ -21,6 +21,7 @@
  *      Author: mschefer
  */
 
+#include "SEImplementation/Measurement/MultithreadedMeasurement.h"
 #include "SEImplementation/Partition/MultiThresholdPartitionStep.h"
 
 #include "SEFramework/Image/VectorImage.h"
@@ -142,9 +143,12 @@ std::vector<std::shared_ptr<SourceInterface>> MultiThresholdPartitionStep::parti
   auto min_value = original_source->getProperty<PeakValue>().getMinValue() * .8;
   auto peak_value = original_source->getProperty<PeakValue>().getMaxValue();
 
-  for (auto pixel_coord : pixel_coords) {
-    auto value = labelling_image->getValue(pixel_coord);
-    thumbnail_image->setValue(pixel_coord - offset, value);
+  {
+    std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
+    for (auto pixel_coord : pixel_coords) {
+      auto value = labelling_image->getValue(pixel_coord);
+      thumbnail_image->setValue(pixel_coord - offset, value);
+    }
   }
 
   auto root = std::make_shared<MultiThresholdNode>(pixel_coords, 0);

--- a/SEImplementation/src/lib/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.cpp
+++ b/SEImplementation/src/lib/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.cpp
@@ -20,9 +20,9 @@
  * @author mkuemmel
  */
 
-#include "SEImplementation/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.h"
-
 #include "SEFramework/Property/DetectionFrame.h"
+#include "SEImplementation/Measurement/MultithreadedMeasurement.h"
+#include "SEImplementation/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.h"
 #include "SEImplementation/Property/PixelCoordinateList.h"
 
 namespace SourceXtractor {
@@ -33,6 +33,8 @@ CoreThresholdPartitionStep::CoreThresholdPartitionStep(double snr_level, unsigne
 
 std::vector<std::shared_ptr<SourceInterface>> CoreThresholdPartitionStep::partition(std::shared_ptr<SourceInterface> source) const {
   long int n_snr_level(0);
+  // SNR Image accesses the underlying detection image, which may be a buffered image
+  std::lock_guard<std::recursive_mutex> lock(MultithreadedMeasurement::g_global_mutex);
 
   // get the SNR image
   const auto& snr_image = source->getProperty<DetectionFrame>().getFrame()->getSnrImage();


### PR DESCRIPTION
Reported by thread sanitizer. With these locks, the segfault goes away.

May be worth thinking of an alternative way of handling this? i.e. modify the Frame class so it returns a moveable, non-copyable `SyncedImage` or something of the sort that does the lock RAII for you. 