### PR TITLE
Fix selection of default engine for model fitting

### DIFF
--- a/ModelFitting/ModelFitting/Engine/LeastSquareEngineManager.h
+++ b/ModelFitting/ModelFitting/Engine/LeastSquareEngineManager.h
@@ -66,6 +66,11 @@ public:
   static std::vector<std::string> getImplementations();
 
   /**
+   * @return The default engine to use
+   */
+  static std::string getDefault();
+
+  /**
    * Create an instance of an engine 'name'
    * @param name
    *    The name of the engine, as passed to registerEngine. Case insensitive.

--- a/ModelFitting/src/lib/Engine/LeastSquareEngineManager.cpp
+++ b/ModelFitting/src/lib/Engine/LeastSquareEngineManager.cpp
@@ -49,6 +49,19 @@ std::vector<std::string> LeastSquareEngineManager::getImplementations() {
   return keys;
 }
 
+std::string LeastSquareEngineManager::getDefault() {
+  auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
+  std::string default_engine;
+
+  if (std::find(known_engines.begin(), known_engines.end(), "levmar") != known_engines.end()) {
+    return "levmar";
+  }
+  else if (!known_engines.empty()) {
+    return known_engines.front();
+  }
+  return "";
+}
+
 std::shared_ptr<LeastSquareEngine> LeastSquareEngineManager::create(const std::string& name, unsigned max_iterations) {
   auto factory = getEngineFactories().find(boost::algorithm::to_lower_copy(name));
   if (factory == getEngineFactories().end()) {

--- a/ModelFitting/src/lib/Engine/LeastSquareEngineManager.cpp
+++ b/ModelFitting/src/lib/Engine/LeastSquareEngineManager.cpp
@@ -53,8 +53,8 @@ std::string LeastSquareEngineManager::getDefault() {
   auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
   std::string default_engine;
 
-  if (std::find(known_engines.begin(), known_engines.end(), "levmar") != known_engines.end()) {
-    return "levmar";
+  if (std::find(known_engines.begin(), known_engines.end(), "gsl") != known_engines.end()) {
+    return "gsl";
   }
   else if (!known_engines.empty()) {
     return known_engines.front();

--- a/SEImplementation/python/sourcextractor/config/model_fitting.py
+++ b/SEImplementation/python/sourcextractor/config/model_fitting.py
@@ -486,7 +486,7 @@ point_source_model_dict = {}
 sersic_model_dict = {}
 exponential_model_dict = {}
 de_vaucouleurs_model_dict = {}
-params_dict = { "max_iterations" : 100, "modified_chi_squared_scale" : 10, "engine" : "levmar" }
+params_dict = {"max_iterations": 100, "modified_chi_squared_scale": 10, "engine": ""}
 
 
 def set_max_iterations(iterations):

--- a/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/LegacyModelFittingConfig.cpp
@@ -36,15 +36,7 @@ LegacyModelFittingConfig::LegacyModelFittingConfig(long manager_id) : Configurat
 }
 
 auto LegacyModelFittingConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
-  auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
-  std::string default_engine;
-
-  if (std::find(known_engines.begin(), known_engines.end(), "levmar") != known_engines.end()) {
-    default_engine = "levmar";
-  }
-  else if (!known_engines.empty()) {
-    default_engine = known_engines.front();
-  }
+  auto default_engine = ModelFitting::LeastSquareEngineManager::getDefault();
 
   return {{"Model Fitting",
       {

--- a/SEImplementation/src/lib/Configuration/ModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/ModelFittingConfig.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "ElementsKernel/Logging.h"
+#include "ModelFitting/Engine/LeastSquareEngineManager.h"
 #include "SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingParameter.h"
 #include "SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingConverterFactory.h"
 #include "SEImplementation/PythonConfig/ObjectInfo.h"
@@ -282,7 +283,7 @@ void ModelFittingConfig::initializeInner() {
   auto parameters = getDependency<PythonConfig>().getInterpreter().getModelFittingParams();
   m_least_squares_engine = py::extract<std::string>(parameters["engine"]);
   if (m_least_squares_engine.empty()) {
-    m_least_squares_engine = "levmar";
+    m_least_squares_engine = ModelFitting::LeastSquareEngineManager::getDefault();
   }
   m_max_iterations = py::extract<int>(parameters["max_iterations"]);
   m_modified_chi_squared_scale = py::extract<double>(parameters["modified_chi_squared_scale"]);


### PR DESCRIPTION
Defer to LeastSquareEngineManager (DRY). Pick levmar if available, the
first known one otherwise (which will be gsl).