### PR TITLE
Fix the unit information on the output

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/CoreThresholdPartition/CoreThresholdPartitionPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/CoreThresholdPartition/CoreThresholdPartitionPlugin.h
@@ -39,7 +39,7 @@ public:
             [](const NCorePixel& prop){
               return prop.getNCorePixel();
             },
-            "[]",
+            "pixel",
             "Number of core pixels used for partitioning"
     );
     plugin_api.getOutputRegistry().enableOutput<NCorePixel>("NCorePixel");

--- a/SEImplementation/SEImplementation/Plugin/NDetectedPixels/NDetectedPixelsPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/NDetectedPixels/NDetectedPixelsPlugin.h
@@ -54,7 +54,7 @@ public:
             [](const NDetectedPixels& prop){
               return prop.getNDetectedPixels();
             },
-            "[]",
+            "pixel",
             "Total number of detected pixels"
     );
     plugin_api.getOutputRegistry().enableOutput<NDetectedPixels>("NDetectedPixels");

--- a/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/SNRRatio/SNRRatioPlugin.h
@@ -41,7 +41,7 @@ public:
       [](const SNRRatio& prop) {
         return prop.getSNRRatio();
       },
-      "[]",
+      "",
       "The object signal-to-noise ratio"
     );
     plugin_api.getOutputRegistry().enableOutput<SNRRatio>("SNRRatio");

--- a/SEImplementation/SEImplementation/Plugin/SourceFlags/SourceFlagsPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/SourceFlags/SourceFlagsPlugin.h
@@ -58,7 +58,7 @@ public:
       [](const SourceFlags &prop) {
         return flags2long(prop.getSourceFlags());
       },
-      "[]",
+      "",
       "The source flags"
     );
     plugin_api.getOutputRegistry().enableOutput<SourceFlags>("SourceFlags");

--- a/SEImplementation/SEImplementation/Plugin/SourceIDs/SourceIDsPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/SourceIDs/SourceIDsPlugin.h
@@ -60,7 +60,7 @@ public:
             [](const SourceID& prop){
               return prop.getId();
             },
-            "[]",
+            "",
             "Running object number"
     );
     plugin_api.getOutputRegistry().registerColumnConverter<SourceID, int>(
@@ -68,7 +68,7 @@ public:
             [](const SourceID& prop){
               return prop.getDetectionId();
             },
-            "[]",
+            "",
             "Running detection number"
     );
     plugin_api.getOutputRegistry().enableOutput<SourceID>("SourceIDs");

--- a/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
+++ b/SEImplementation/SEImplementation/Plugin/Vignet/VignetPlugin.h
@@ -47,7 +47,7 @@ public:
       [](const VignetArray& prop) {
         return prop.getVignets();
       },
-      "[]",
+      "count",
       "The object vignet data"
     );
     plugin_api.getOutputRegistry().enableOutput<VignetArray>("Vignet");

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryPlugin.cpp
@@ -45,7 +45,7 @@ void AperturePhotometryPlugin::registerPlugin(PluginAPI &plugin_api) {
     [](const AperturePhotometryArray &prop) {
       return prop.getFluxes();
     },
-    "[count]",
+    "count",
     "Aperture flux"
   );
 
@@ -54,7 +54,7 @@ void AperturePhotometryPlugin::registerPlugin(PluginAPI &plugin_api) {
     [](const AperturePhotometryArray &prop) {
       return prop.getFluxErrors();
     },
-    "[count]",
+    "count",
     "Aperture flux error"
   );
 
@@ -63,7 +63,7 @@ void AperturePhotometryPlugin::registerPlugin(PluginAPI &plugin_api) {
     [](const AperturePhotometryArray &prop) {
       return prop.getMags();
     },
-    "[mag]",
+    "mag",
     "Aperture magnitude"
   );
 
@@ -72,7 +72,7 @@ void AperturePhotometryPlugin::registerPlugin(PluginAPI &plugin_api) {
     [](const AperturePhotometryArray &prop) {
       return prop.getMagErrors();
     },
-    "[mag]",
+    "mag",
     "Aperture magnitude error"
   );
 

--- a/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryPlugin.cpp
@@ -42,7 +42,7 @@ void AutoPhotometryPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const AutoPhotometryArray& prop){
             return prop.getFluxes();
           },
-          "[count]",
+          "count",
           "Flux within a Kron-like elliptical aperture"
           );
 
@@ -51,7 +51,7 @@ void AutoPhotometryPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const AutoPhotometryArray& prop){
             return prop.getFluxErrors();
           },
-          "[count]",
+          "count",
           "Flux error within a Kron-like elliptical aperture"
           );
 
@@ -60,7 +60,7 @@ void AutoPhotometryPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const AutoPhotometryArray& prop){
             return prop.getMags();
           },
-          "[count]",
+          "mag",
           "Magnitude within a Kron-like elliptical aperture"
           );
 
@@ -69,7 +69,7 @@ void AutoPhotometryPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const AutoPhotometryArray& prop){
             return prop.getMagErrors();
           },
-          "[count]",
+          "mag",
           "Magnitude error within a Kron-like elliptical aperture"
           );
 

--- a/SEImplementation/src/lib/Plugin/DetectionFrameGroupStamp/DetectionFrameGroupStampPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/DetectionFrameGroupStamp/DetectionFrameGroupStampPlugin.cpp
@@ -40,7 +40,7 @@ void DetectionFrameGroupStampPlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const DetectionFrameGroupStamp &d) {
       return d.getTopLeft().m_y;
     },
-    "[pixel]",
+    "pixel",
     "Maximum y-coordinate of the detection group"
   );
   plugin_api.getOutputRegistry().registerColumnConverter<DetectionFrameGroupStamp, int>(
@@ -48,7 +48,7 @@ void DetectionFrameGroupStampPlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const DetectionFrameGroupStamp &d) {
       return d.getTopLeft().m_x;
     },
-    "[pixel]",
+    "pixel",
     "Minimum x-coordinate of the detection group"
   );
   plugin_api.getOutputRegistry().registerColumnConverter<DetectionFrameGroupStamp, int>(
@@ -56,7 +56,7 @@ void DetectionFrameGroupStampPlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const DetectionFrameGroupStamp &d) {
       return d.getStamp().getWidth();
     },
-    "[pixel]",
+    "pixel",
     "Width of the detection group"
   );
   plugin_api.getOutputRegistry().registerColumnConverter<DetectionFrameGroupStamp, int>(
@@ -64,7 +64,7 @@ void DetectionFrameGroupStampPlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const DetectionFrameGroupStamp &d) {
       return d.getStamp().getHeight();
     },
-    "[pixel]",
+    "pixel",
     "Height of the detection group"
   );
   plugin_api.getOutputRegistry().enableOutput<DetectionFrameGroupStamp>("GroupStamp");

--- a/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagPlugin.cpp
@@ -40,7 +40,7 @@ void ExternalFlagPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ExternalFlag& prop){
             return prop.getFlag();
           },
-          "[]",
+          "",
           "Flags for the isophotal magnitude"
   );
 
@@ -49,7 +49,7 @@ void ExternalFlagPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ExternalFlag& prop){
             return prop.getCount();
           },
-          "[]",
+          "",
           "Flags provided from input images"
   );
 

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingPlugin.cpp
@@ -42,7 +42,7 @@ void FlexibleModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const FlexibleModelFitting& prop) {
             return prop.getReducedChiSquared();
           },
-          "[]",
+          "",
           "Reduced chi-square of the model fitting"
   );
 
@@ -51,7 +51,7 @@ void FlexibleModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const FlexibleModelFitting& prop) {
             return prop.getIterations();
           },
-          "[]",
+          "",
           "Number of iterations in the model fitting"
   );
 
@@ -60,7 +60,7 @@ void FlexibleModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const FlexibleModelFitting& prop) {
             return flags2long(prop.getFlags());
           },
-          "[]",
+          "",
           "Model fitting flags"
   );
 

--- a/SEImplementation/src/lib/Plugin/FluxRadius/FluxRadiusPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/FluxRadius/FluxRadiusPlugin.cpp
@@ -38,7 +38,7 @@ void FluxRadiusPlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const FluxRadius& prop){
       return prop.getFluxRadius();
     },
-    "[pixel]",
+    "pixel",
     "Radius containing a fraction of the flux"
   );
 

--- a/SEImplementation/src/lib/Plugin/GrowthCurve/GrowthCurvePlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/GrowthCurve/GrowthCurvePlugin.cpp
@@ -42,7 +42,7 @@ void SourceXtractor::GrowthCurvePlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const GrowthCurveResampled& prop){
       return prop.getStepSize();
     },
-    "[pixel]",
+    "pixel",
     "Growth curve step size"
   );
   plugin_api.getOutputRegistry().registerColumnConverter<GrowthCurveResampled, NdArray<DetectionImage::PixelType>>(
@@ -50,7 +50,7 @@ void SourceXtractor::GrowthCurvePlugin::registerPlugin(PluginAPI& plugin_api) {
     [](const GrowthCurveResampled& prop) {
       return prop.getSamples();
     },
-    "[count]",
+    "count",
     "Growth curve samples"
   );
 

--- a/SEImplementation/src/lib/Plugin/IsophotalFlux/IsophotalFluxPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/IsophotalFlux/IsophotalFluxPlugin.cpp
@@ -40,7 +40,7 @@ void IsophotalFluxPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const IsophotalFlux& prop){
             return prop.getFlux();
           },
-          "[count]",
+          "count",
           "Isophotal flux"
   );
 
@@ -49,7 +49,7 @@ void IsophotalFluxPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const IsophotalFlux& prop){
             return prop.getFluxError();
           },
-          "[count]",
+          "count",
           "Isophotal flux error"
   );
 
@@ -58,7 +58,7 @@ void IsophotalFluxPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const IsophotalFlux& prop){
             return prop.getMag();
           },
-          "[mag]",
+          "mag",
           "Isophotal magnitude"
   );
 
@@ -67,7 +67,7 @@ void IsophotalFluxPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const IsophotalFlux& prop){
             return prop.getMagError();
           },
-          "[mag]",
+          "mag",
           "Isophotal magnitude error"
   );
 

--- a/SEImplementation/src/lib/Plugin/KronRadius/KronRadiusPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/KronRadius/KronRadiusPlugin.cpp
@@ -39,7 +39,7 @@ void KronRadiusPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const KronRadius& prop){
             return prop.getKronRadius();
           },
-          "[pixel]",
+          "pixel",
           "Kron radius"
   );
 
@@ -48,7 +48,7 @@ void KronRadiusPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const KronRadius& prop){
             return prop.getFlag();
           },
-          "[]",
+          "",
           "Flags for the Kron radius"
   );
 

--- a/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingPlugin.cpp
@@ -41,7 +41,7 @@ void MoffatModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const MoffatModelFitting& prop) {
             return prop.getX() + 1.0;
           },
-          "[pixel]",
+          "pixel",
           "X-position of the Moffat fit"
   );
 
@@ -50,7 +50,7 @@ void MoffatModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const MoffatModelFitting& prop) {
             return prop.getY() + 1.0;
           },
-          "[pixel]",
+          "pixel",
           "Y-position of the Moffat fit"
   );
 

--- a/SEImplementation/src/lib/Plugin/PeakValue/PeakValuePlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/PeakValue/PeakValuePlugin.cpp
@@ -40,7 +40,7 @@ void PeakValuePlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PeakValue& prop){
             return prop.getMaxValue();
           },
-          "[count]",
+          "count",
           "Highest pixel value in the detection image"
   );
 

--- a/SEImplementation/src/lib/Plugin/PixelBoundaries/PixelBoundariesPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/PixelBoundaries/PixelBoundariesPlugin.cpp
@@ -42,7 +42,7 @@ void PixelBoundariesPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PixelBoundaries& prop){
             return prop.getMin().m_x;
           },
-          "[pixel]",
+          "pixel",
           "Minimum x-coordinate of the detection area"
   );
 
@@ -51,7 +51,7 @@ void PixelBoundariesPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PixelBoundaries& prop){
             return prop.getMin().m_y;
           },
-          "[pixel]",
+          "pixel",
           "Minimum y-coordinate of the detection area"
   );
 
@@ -60,7 +60,7 @@ void PixelBoundariesPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PixelBoundaries& prop){
             return prop.getMax().m_x;
           },
-          "[pixel]",
+          "pixel",
           "Maximum x-coordinate of the detection area"
   );
 
@@ -69,7 +69,7 @@ void PixelBoundariesPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PixelBoundaries& prop){
             return prop.getMax().m_y;
           },
-          "[pixel]",
+          "pixel",
           "Maximum y-coordinate of the detection area"
   );
 

--- a/SEImplementation/src/lib/Plugin/PixelCentroid/PixelCentroidPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/PixelCentroid/PixelCentroidPlugin.cpp
@@ -40,7 +40,7 @@ void PixelCentroidPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PixelCentroid& prop){
             return prop.getCentroidX() + 1.0; // add one to use FITS standard coordinates
           },
-          "[pixel]",
+          "pixel",
           "X-position of the object in the detection image"
   );
 
@@ -49,7 +49,7 @@ void PixelCentroidPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const PixelCentroid& prop){
             return prop.getCentroidY() + 1.0; // add one to use FITS standard coordinates
           },
-          "[pixel]",
+          "pixel",
           "Y-position of the object in the detection image"
   );
 

--- a/SEImplementation/src/lib/Plugin/ShapeParameters/ShapeParametersPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/ShapeParameters/ShapeParametersPlugin.cpp
@@ -40,7 +40,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getEllipseA();
           },
-          "[pixel]",
+          "pixel",
           "Profile RMS along major axis"
   );
 
@@ -49,7 +49,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getEllipseB();
           },
-          "[pixel]",
+          "pixel",
           "Profile RMS along minor axis"
   );
 
@@ -58,7 +58,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getEllipseTheta() * 180.0 / M_PI;
           },
-          "[deg]",
+          "deg",
           "Position angle (CCW/x)"
   );
 
@@ -67,7 +67,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getEllipseCxx();
           },
-          "[pixel^{-2}]",
+          "pixel^{-2}",
           "Cxx object ellipse parameter"
   );
 
@@ -76,7 +76,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getEllipseCyy();
           },
-          "[pixel^{-2}]",
+          "pixel^{-2}",
           "Cyy object ellipse parameter"
   );
 
@@ -85,7 +85,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getEllipseCxy();
           },
-          "[pixel^{-2}]",
+          "pixel^{-2}",
           "Cxy object ellipse parameter"
   );
 
@@ -94,7 +94,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop){
             return prop.getArea();
           },
-          "[]",
+          "pixel",
           "Total number of detected pixels"
   );
 
@@ -103,7 +103,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop) {
             return prop.getElongation();
           },
-          "[]",
+          "",
           "The object elongation (a_image / b_image)"
   );
 
@@ -112,7 +112,7 @@ void ShapeParametersPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const ShapeParameters& prop) {
             return prop.getEllipticity();
           },
-          "[]",
+          "",
           "The object ellipticity"
   );
 

--- a/SEImplementation/src/lib/Plugin/WorldCentroid/WorldCentroidPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/WorldCentroid/WorldCentroidPlugin.cpp
@@ -41,7 +41,7 @@ void WorldCentroidPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const WorldCentroid& prop){
             return prop.getCentroidAlpha();
           },
-          "[deg]",
+          "deg",
           "RA object position"
   );
 
@@ -50,7 +50,7 @@ void WorldCentroidPlugin::registerPlugin(PluginAPI& plugin_api) {
           [](const WorldCentroid& prop){
             return prop.getCentroidDelta();
           },
-          "[deg]",
+          "deg",
           "Dec object position"
   );
 


### PR DESCRIPTION
The `[]` are not needed when going through CCfits (maybe it is for cfitsio?).
They end as-is on the output catalog, which confuses other FITS implementations like Astropy, which fails to identify the unit.
i.e

```Python
In [5]: t['world_centroid_alpha'].unit                                                                                                                                                        
Out[5]: UnrecognizedUnit([deg])
```

After this fix

```Python
In [12]: t['world_centroid_alpha'].unit                                                                                                                                                       
Out[12]: Unit("deg")
```