### PR TITLE
Disable CompactSersic

### DIFF
--- a/ModelFitting/src/lib/Engine/LeastSquareEngineManager.cpp
+++ b/ModelFitting/src/lib/Engine/LeastSquareEngineManager.cpp
@@ -53,8 +53,8 @@ std::string LeastSquareEngineManager::getDefault() {
   auto known_engines = ModelFitting::LeastSquareEngineManager::getImplementations();
   std::string default_engine;
 
-  if (std::find(known_engines.begin(), known_engines.end(), "gsl") != known_engines.end()) {
-    return "gsl";
+  if (std::find(known_engines.begin(), known_engines.end(), "levmar") != known_engines.end()) {
+    return "levmar";
   }
   else if (!known_engines.empty()) {
     return known_engines.front();

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingModel.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingModel.cpp
@@ -222,9 +222,18 @@ void FlexibleModelFittingSersicModel::addForSource(FlexibleModelFittingParameter
   auto& boundaries = source.getProperty<PixelBoundaries>();
   int size = std::max(MODEL_MIN_SIZE, MODEL_SIZE_FACTOR * std::max(boundaries.getWidth(), boundaries.getHeight()));
 
+  std::vector<std::unique_ptr<ModelComponent>> sersic_component;
+  sersic_component.emplace_back(new SersicModelComponent(make_unique<OldSharp>(), i0,
+                                                         manager.getParameter(source, m_sersic_index), k));
+
+  extended_models.emplace_back(std::make_shared<TransformedModel<ImageInterfaceTypePtr>>(
+    std::move(sersic_component), x_scale, manager.getParameter(source, m_aspect_ratio),
+    manager.getParameter(source, m_angle), size, size, pixel_x, pixel_y, jacobian));
+/*
   extended_models.emplace_back(std::make_shared<CompactSersicModel<ImageInterfaceTypePtr>>(
       3.0, i0, k, manager.getParameter(source, m_sersic_index), x_scale, manager.getParameter(source, m_aspect_ratio),
       manager.getParameter(source, m_angle), size, size, pixel_x, pixel_y, jacobian));
+*/
 }
 
 void FlexibleModelFittingConstantModel::addForSource(FlexibleModelFittingParameterManager& manager,


### PR DESCRIPTION
So as Marc suggested in #271, I have disabled the `CompactSersicModel` and gone back to the previous implementation, which is slower, but seems to work better with Levmar.
Here are some numbers from `sim11_i_01` and `sim12_i_01`:

<table>
<thead>
  <tr>
    <th rowspan="2">sim12</th>
    <th></th>
    <th colspan="2">All</th>
    <th colspan="2">&lt; 16.7</th>
    <th colspan="2">16.7 - 20.6</th>
    <th colspan="2">&gt; 20.6</th>
  </tr>
  <tr>
    <td>Engine</td>
    <td>Mean</td>
    <td>Var</td>
    <td>Mean</td>
    <td>Var</td>
    <td>Mean</td>
    <td>Var</td>
    <td>Mean</td>
    <td>Var</td>
  </tr>
</thead>
<tbody>
  <tr>
    <td rowspan="2">CompactSersic</td>
    <td>Levmar</td>
    <td>0.194</td>
    <td>0.540</td>
    <td>-1.083</td>
    <td>0.562</td>
    <td>0.159</td>
    <td>0.142</td>
    <td>0.252</td>
    <td>0.600</td>
  </tr>
  <tr>
    <td>GSL</td>
    <td>0.086</td>
    <td>0.300</td>
    <td>-0.463</td>
    <td>0.369</td>
    <td>-0.039</td>
    <td>0.069</td>
    <td>0.178</td>
    <td>0.356</td>
  </tr>
  <tr>
    <td rowspan="2">Previous<br></td>
    <td>Levmar</td>
    <td>0.109</td>
    <td>0.351</td>
    <td>-1.056</td>
    <td>0.799</td>
    <td>-0.017</td>
    <td>0.071</td>
    <td>0.191</td>
    <td>0.360</td>
  </tr>
  <tr>
    <td>GSL</td>
    <td>0.054</td>
    <td>0.282</td>
    <td>-1.479</td>
    <td>1.595</td>
    <td>-0.029</td>
    <td>0.070</td>
    <td>0.137</td>
    <td>0.203</td>
  </tr>
</tbody>
</table>
<table>
<thead>
  <tr>
    <th rowspan="2">sim11</th>
    <th></th>
    <th colspan="2">All</th>
    <th colspan="2">&lt; 16.2</th>
    <th colspan="2">16.2 - 20.2</th>
    <th colspan="2">&gt; 20.2</th>
  </tr>
  <tr>
    <td>Engine</td>
    <td>Mean</td>
    <td>Var</td>
    <td>Mean</td>
    <td>Var</td>
    <td>Mean</td>
    <td>Var</td>
    <td>Mean</td>
    <td>Var</td>
  </tr>
</thead>
<tbody>
  <tr>
    <td rowspan="2">CompactSersic</td>
    <td>Levmar</td>
    <td>0.189</td>
    <td>0.557</td>
    <td>-2.384</td>
    <td>0.000*</td>
    <td>0.025</td>
    <td>0.019</td>
    <td>0.239</td>
    <td>0.645</td>
  </tr>
  <tr>
    <td>GSL</td>
    <td>0.112</td>
    <td>0.353</td>
    <td>-0.055</td>
    <td>0.041</td>
    <td>0.001</td>
    <td>0.026</td>
    <td>0.204</td>
    <td>0.582</td>
  </tr>
  <tr>
    <td rowspan="2">Previous<br></td>
    <td>Levmar</td>
    <td>0.168</td>
    <td>0.466</td>
    <td>-2.379</td>
    <td>0.000*</td>
    <td>0.038</td>
    <td>0.020</td>
    <td>0.209</td>
    <td>0.534</td>
  </tr>
  <tr>
    <td>GSL</td>
    <td>0.121</td>
    <td>0.289</td>
    <td>-0.025</td>
    <td>0.044</td>
    <td>0.013</td>
    <td>0.012</td>
    <td>0.209</td>
    <td>0.478</td>
  </tr>
</tbody>
</table>

(*) Only one source in that bin

* From what I can see, levmar does better with the previous implementation, while GSL is not that sensitive. It tends maybe slightly to be better, but not by much.
* I can hardly tell which one is doing better now. I would tend to prefer to leave GSL as default for the moment being.
* The differences are not that big for sim11. Could this be triggered by the assymetric PSF?

@ebertin , could you give this rollback a try, and let me know what do you think?