### PR TITLE
Fixes for bugs found when building in Fedora 33

### DIFF
--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -35,7 +35,6 @@
 #include <boost/algorithm/string/trim.hpp>
 
 #include "ElementsKernel/Exception.h"
-
 #include "SEFramework/FITS/FitsFile.h"
 
 namespace SourceXtractor {
@@ -67,9 +66,23 @@ static typename MetadataEntry::value_t valueAutoCast(const std::string& value) {
   } catch (...) {
   }
 
-  std::stringstream quoted(value);
+  // Single quotes are used as escape code of another single quote, and
+  // the string starts and ends with single quotes.
+  // We used to use boost::io::quoted here, but it seems that starting with 1.73 it
+  // does not work well when the escape code and the delimiter are the same
   std::string unquoted;
-  quoted >> boost::io::quoted(unquoted, '\'', '\'');
+  bool escape = false;
+  unquoted.reserve(value.size());
+  for (auto i = value.begin(); i != value.end(); ++i) {
+    if (*i == '\'' && !escape) {
+      escape = true;
+      // skip this char
+    }
+    else {
+      escape = false;
+      unquoted.push_back(*i);
+    }
+  }
   return unquoted;
 }
 

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -31,7 +31,6 @@
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/io/detail/quoted_manip.hpp>
 
 #include <ElementsKernel/Exception.h>
 

--- a/SEImplementation/src/lib/Output/LdacWriter.cpp
+++ b/SEImplementation/src/lib/Output/LdacWriter.cpp
@@ -16,12 +16,17 @@
  */
 
 #include <sstream>
-#include <boost/io/detail/quoted_manip.hpp>
 #include <AlexandriaKernel/memory_tools.h>
 #include "SEFramework/Property/DetectionFrame.h"
 #include "SEImplementation/Output/LdacWriter.h"
 #include "SEImplementation/Configuration/DetectionImageConfig.h"
 #include "SOURCEXTRACTORPLUSPLUS_VERSION.h"
+
+#if BOOST_VERSION < 107300
+#include <boost/io/detail/quoted_manip.hpp>
+#else
+#include <boost/io/quoted.hpp>
+#endif
 
 namespace SourceXtractor {
 

--- a/SEImplementation/src/lib/Plugin/FluxRadius/FluxRadiusTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FluxRadius/FluxRadiusTask.cpp
@@ -51,6 +51,9 @@ void FluxRadiusTask::computeProperties(SourceInterface& source) const {
       // >= the target flux, and interpolate with the previous one
       auto next = std::find_if(std::begin(growth_curve), std::end(growth_curve),
                                std::bind2nd(std::greater_equal<double>(), target_flux));
+      if (next == std::end(growth_curve)) {
+        --next;
+      }
       size_t next_i = std::distance(std::begin(growth_curve), next);
 
       SeFloat y0, y1;


### PR DESCRIPTION
* One is really introduced by the newer boost version, where `boost::io::quoted` change behavior.
* The other is an out-of-bounds that did not trigger any error when building with older gcc versions, although valgrind finds it.