### PR TITLE
fix maximum number of simultaneous files regression

### DIFF
--- a/SEFramework/SEFramework/FITS/FitsFileManager.h
+++ b/SEFramework/SEFramework/FITS/FitsFileManager.h
@@ -53,6 +53,9 @@ public:
 
   std::shared_ptr<FitsFile> getFitsFile(const std::string& filename, bool writeable=false);
 
+  void reportClosedFile(const std::string& filename);
+  void reportOpenedFile(const std::string& filename);
+
 private:
   std::unordered_map<std::string, std::shared_ptr<FitsFile>> m_fits_files;
 

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -100,8 +100,6 @@ public:
   }
 
 private:
-
-
   void switchHdu(fitsfile* fptr, int hdu_number) const;
 
   int getDataType() const;

--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -24,6 +24,7 @@
 
 #include <assert.h>
 
+#include <iostream>
 #include <iomanip>
 #include <fstream>
 #include <string>
@@ -162,6 +163,7 @@ void FitsFile::reopen() {
 
 void FitsFile::open() {
   if (!m_is_file_opened) {
+    m_manager->reportOpenedFile(m_filename);
     if (m_was_opened_before) {
       reopen();
     } else {
@@ -173,6 +175,7 @@ void FitsFile::open() {
 
 void FitsFile::close() {
   if (m_is_file_opened) {
+    m_manager->reportClosedFile(m_filename);
     int status = 0;
     fits_close_file(m_file_pointer, &status);
     m_file_pointer = nullptr;

--- a/SEFramework/src/lib/FITS/FitsFileManager.cpp
+++ b/SEFramework/src/lib/FITS/FitsFileManager.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <iostream>
+#include <algorithm>
+
 #include <assert.h>
 
 #include "ElementsKernel/Exception.h"

--- a/SEFramework/src/lib/FITS/FitsFileManager.cpp
+++ b/SEFramework/src/lib/FITS/FitsFileManager.cpp
@@ -67,8 +67,20 @@ void FitsFileManager::closeExtraFiles() {
   while (m_open_files.size() > m_max_open_files) {
     auto& file_to_close = m_fits_files[m_open_files.back()];
     file_to_close->close();
-    m_open_files.pop_back();
   }
 }
+
+void FitsFileManager::reportClosedFile(const std::string& filename) {
+  m_open_files.remove(filename);
+}
+
+void FitsFileManager::reportOpenedFile(const std::string& filename) {
+  auto iter = std::find(m_open_files.begin(), m_open_files.end(), filename);
+  if (iter == m_open_files.end()) {
+    m_open_files.push_front(filename);
+  }
+  closeExtraFiles();
+}
+
 
 }


### PR DESCRIPTION
Somehow the code for maximum number of simultaneous FITS files open at the same time was broken and not fixed at some point. There was no longer a limit being enforced and it was hard to notice until i ran into the problem again.
