### PR TITLE
Use inf for variance if weight is 0

### DIFF
--- a/SEFramework/SEFramework/Image/MaskedImage.h
+++ b/SEFramework/SEFramework/Image/MaskedImage.h
@@ -67,7 +67,7 @@ public:
    * @param replacement
    *    Replace masked pixels with this value
    * @param mask_flag
-   *    If Operator(mask pixel, mask_flag) is true, this given pixel is replaces
+   *    If Operator(mask pixel, mask_flag) is true, this given pixel is replaced
    * @return
    *    A new masked image
    */

--- a/SEImplementation/src/lib/Configuration/WeightImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/WeightImageConfig.cpp
@@ -183,7 +183,7 @@ protected:
           tile.getImage()->setValue(ix, iy, 1.0 / value);
         }
         else {
-          tile.getImage()->setValue(ix, iy, std::numeric_limits<WeightImage::PixelType>::max());
+          tile.getImage()->setValue(ix, iy, std::numeric_limits<WeightImage::PixelType>::infinity());
         }
       }
     }

--- a/SEImplementation/src/lib/Segmentation/BgDFTConvolutionImageSource.cpp
+++ b/SEImplementation/src/lib/Segmentation/BgDFTConvolutionImageSource.cpp
@@ -23,8 +23,8 @@
  */
 
 #include "SEImplementation/Segmentation/BgDFTConvolutionImageSource.h"
-#include "SEFramework/Image/ProcessedImage.h"
 #include "SEFramework/Image/FunctionalImage.h"
+#include "SEFramework/Image/MaskedImage.h"
 
 namespace SourceXtractor {
 
@@ -76,7 +76,8 @@ void BgDFTConvolutionImageSource::generateTile(const std::shared_ptr<Image<Detec
   );
 
   // Get the image masking out values where the variance is greater than the threshold
-  auto masked_img = MultiplyImage<DetectionImage::PixelType>::create(clipped_img, mask);
+  auto masked_img = MaskedImage<DetectionImage::PixelType, DetectionImage::PixelType, std::equal_to>::create(
+    clipped_img, mask, 0., 0.);
 
   // Convolve the masked image, padding with 0
   auto conv_masked = VectorImage<DetectionImage::PixelType>::create(masked_img);


### PR DESCRIPTION
Fixes #289.
The source of the issue is that the variance map may be scaled after being created (if marked as absolute, by the flux scale, if not, by the background scaling factor). If the scale is less than 1, then all pixels will be below the default threshold, which is the max.value a float can store.

After this I had to change the convolution code too, since `inf * 0 = nan`