### PR TITLE
FITS file creation enhancements

### DIFF
--- a/SEFramework/SEFramework/CoordinateSystem/WCS.h
+++ b/SEFramework/SEFramework/CoordinateSystem/WCS.h
@@ -37,6 +37,8 @@ namespace SourceXtractor {
 class WCS : public CoordinateSystem {
 public:
   explicit WCS(const FitsImageSource& fits_image_source);
+  explicit WCS(const WCS& original);
+
   virtual ~WCS();
 
   WorldCoordinate imageToWorld(ImageCoordinate image_coordinate) const override;
@@ -44,7 +46,11 @@ public:
 
   std::map<std::string, std::string> getFitsHeaders() const override;
 
+  void addOffset(PixelCoordinate pc);
+
 private:
+  void init(char* headers, int number_of_records);
+
   std::unique_ptr<wcsprm, std::function<void(wcsprm*)>> m_wcs;
 };
 

--- a/SEFramework/SEFramework/FITS/FitsFile.h
+++ b/SEFramework/SEFramework/FITS/FitsFile.h
@@ -60,7 +60,7 @@ public:
     return m_image_hdus;
   }
 
-  const std::map<std::string, MetadataEntry>& getHDUHeaders(int hdu) const {
+  std::map<std::string, MetadataEntry>& getHDUHeaders(int hdu) {
     return m_headers.at(hdu-1);
   }
 
@@ -69,12 +69,13 @@ public:
   void open();
   void close();
 
+
 private:
   void openFirstTime();
   void reopen();
 
+  void reloadHeaders();
   std::map<std::string, MetadataEntry> loadFitsHeader(fitsfile *fptr);
-  void loadHeaders();
   void loadHeadFile();
 
   std::string m_filename;

--- a/SEFramework/SEFramework/FITS/FitsFileManager.h
+++ b/SEFramework/SEFramework/FITS/FitsFileManager.h
@@ -53,6 +53,8 @@ public:
 
   std::shared_ptr<FitsFile> getFitsFile(const std::string& filename, bool writeable=false);
 
+  void closeAndPurgeFile(const std::string& filename);
+
   void reportClosedFile(const std::string& filename);
   void reportOpenedFile(const std::string& filename);
 

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -55,7 +55,7 @@ public:
       std::shared_ptr<FitsFileManager> manager = FitsFileManager::getInstance());
 
   FitsImageSource(const std::string &filename, int width, int height, ImageTile::ImageType image_type,
-                  const std::shared_ptr<CoordinateSystem> coord_system = nullptr,
+                  const std::shared_ptr<CoordinateSystem> coord_system = nullptr, bool append=false,
                   std::shared_ptr<FitsFileManager> manager = FitsFileManager::getInstance());
 
   virtual ~FitsImageSource() = default;
@@ -99,6 +99,8 @@ public:
     return m_fits_file->getHDUHeaders(m_hdu_number);
   }
 
+  void setMetadata(std::string key, MetadataEntry value) override;
+
 private:
   void switchHdu(fitsfile* fptr, int hdu_number) const;
 
@@ -114,13 +116,6 @@ private:
   int m_width;
   int m_height;
   ImageTile::ImageType m_image_type;
-
-//  template<typename T>
-//  std::shared_ptr<ImageTile> getImageTileImpl(int x, int y, int width, int height) const;
-//
-//  template<typename T>
-//  void saveTileImpl(ImageTile& tile);
-
 };
 
 }

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -93,6 +93,10 @@ public:
     return m_hdu_number;
   }
 
+  ImageTile::ImageType getType() const override {
+    return m_image_type;
+  }
+
   std::unique_ptr<std::vector<char>> getFitsHeaders(int& number_of_records) const;
 
   const std::map<std::string, MetadataEntry> getMetadata() const override {

--- a/SEFramework/SEFramework/FITS/FitsWriter.h
+++ b/SEFramework/SEFramework/FITS/FitsWriter.h
@@ -51,8 +51,8 @@ public:
 
   template <typename T>
   static void writeFile(const Image<T> &image, const std::string &filename,
-                        const std::shared_ptr<CoordinateSystem> coord_system = nullptr) {
-    auto target_image = newImage<T>(filename, image.getWidth(), image.getHeight(), coord_system);
+                        const std::shared_ptr<CoordinateSystem> coord_system = nullptr, bool append=false) {
+    auto target_image = newImage<T>(filename, image.getWidth(), image.getHeight(), coord_system, append);
 
     // FIXME optimize the copy by using tile boundaries, image chunks, etc
     for (int y = 0; y < image.getHeight(); y++) {
@@ -64,10 +64,10 @@ public:
 
   template <typename T>
   static std::shared_ptr<WriteableImage<T>> newImage(const std::string &filename, int width, int height,
-                                                     const std::shared_ptr<CoordinateSystem> coord_system = nullptr) {
+                                                     const std::shared_ptr<CoordinateSystem> coord_system = nullptr, bool append=false) {
     fitsWriterLogger.debug() << "Creating file " << filename;
 
-    auto image_source = std::make_shared<FitsImageSource>(filename, width, height, ImageTile::getTypeValue(T()), coord_system);
+    auto image_source = std::make_shared<FitsImageSource>(filename, width, height, ImageTile::getTypeValue(T()), coord_system, append);
     return WriteableBufferedImage<T>::create(image_source);
   }
 

--- a/SEFramework/SEFramework/FITS/TemporaryFitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/TemporaryFitsImageSource.h
@@ -70,6 +70,10 @@ public:
     return m_image_source->getHeight();
   }
 
+  ImageTile::ImageType getType() const override {
+    return m_image_source->getType();
+  }
+
 private:
   Elements::TempFile m_temp_file;
   std::shared_ptr<FitsImageSource> m_image_source;

--- a/SEFramework/SEFramework/Image/ImageSource.h
+++ b/SEFramework/SEFramework/Image/ImageSource.h
@@ -74,6 +74,8 @@ public:
    */
   virtual const std::map<std::string, MetadataEntry> getMetadata() const { return {}; };
 
+  virtual void setMetadata(std::string key, MetadataEntry value) {}
+
 private:
 
 };

--- a/SEFramework/SEFramework/Image/ImageSource.h
+++ b/SEFramework/SEFramework/Image/ImageSource.h
@@ -69,6 +69,8 @@ public:
   /// Returns the height of the image in pixels
   virtual int getHeight() const = 0;
 
+  virtual ImageTile::ImageType getType() const = 0;
+
   /**
    * @return A copy of the metadata set
    */

--- a/SEFramework/SEFramework/Image/ImageTile.h
+++ b/SEFramework/SEFramework/Image/ImageTile.h
@@ -143,6 +143,10 @@ public:
     }
   }
 
+  ImageType getType() const {
+    return m_image_type;
+  }
+
 protected:
   virtual void getValue(int x, int y, float& value) const = 0;
   virtual void getValue(int x, int y, double& value) const = 0;

--- a/SEFramework/SEFramework/Image/InterpolatedImageSource.h
+++ b/SEFramework/SEFramework/Image/InterpolatedImageSource.h
@@ -45,6 +45,10 @@ public:
     return "InterpolatedImageSource(" + getImageRepr() + "," + m_variance_map->getRepr() + ")";
   }
 
+  ImageTile::ImageType getType() const override {
+    return ImageTile::getTypeValue(T());
+  }
+
 protected:
   using ProcessingImageSource<T>::getImageRepr;
 

--- a/SEFramework/SEFramework/Image/ProcessingImageSource.h
+++ b/SEFramework/SEFramework/Image/ProcessingImageSource.h
@@ -59,6 +59,10 @@ public:
     return m_image->getHeight();
   }
 
+  ImageTile::ImageType getType() const override {
+    return ImageTile::getTypeValue(T());
+  }
+
 protected:
   virtual void generateTile(const std::shared_ptr<Image<T>>& image, ImageTile& tile, int x, int y, int width, int height) const = 0;
 

--- a/SEFramework/SEFramework/Image/ScaledImageSource.h
+++ b/SEFramework/SEFramework/Image/ScaledImageSource.h
@@ -150,6 +150,10 @@ public:
     return m_height;
   }
 
+  ImageTile::ImageType getType() const override {
+    return ImageTile::getTypeValue(T());
+  }
+
 private:
   std::shared_ptr<Image<T>> m_image;
   int m_width, m_height;

--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -143,7 +143,7 @@ void FitsFile::openFirstTime() {
   fits_movabs_hdu(m_file_pointer, original_hdu, &hdu_type, &status);
 
   // load all FITS headers
-  loadHeaders();
+  reloadHeaders();
 
   // load optional .head file to override headers
   loadHeadFile();
@@ -191,7 +191,7 @@ void FitsFile::setWriteMode() {
   }
 }
 
-void FitsFile::loadHeaders() {
+void FitsFile::reloadHeaders() {
   int status = 0;
 
   // save current HDU (if the file is opened with advanced cfitsio syntax it might be set already)

--- a/SEFramework/src/lib/FITS/FitsFileManager.cpp
+++ b/SEFramework/src/lib/FITS/FitsFileManager.cpp
@@ -76,6 +76,15 @@ void FitsFileManager::reportClosedFile(const std::string& filename) {
   m_open_files.remove(filename);
 }
 
+void FitsFileManager::closeAndPurgeFile(const std::string& filename) {
+  auto it = m_fits_files.find(filename);
+  if (it != m_fits_files.end()) {
+   it->second->close();
+   m_fits_files.erase(filename);
+  }
+}
+
+
 void FitsFileManager::reportOpenedFile(const std::string& filename) {
   auto iter = std::find(m_open_files.begin(), m_open_files.end(), filename);
   if (iter == m_open_files.end()) {

--- a/SEFramework/src/lib/Image/BufferedImage.cpp
+++ b/SEFramework/src/lib/Image/BufferedImage.cpp
@@ -134,5 +134,8 @@ void BufferedImage<T>::copyOverlappingPixels(const ImageTile& tile, std::vector<
 template class BufferedImage<MeasurementImage::PixelType>;
 template class BufferedImage<FlagImage::PixelType>;
 template class BufferedImage<unsigned int>;
+template class BufferedImage<int>;
+template class BufferedImage<double>;
+
 
 } // end namespace SourceXtractor

--- a/SEFramework/tests/src/Image/BufferedImage_test.cpp
+++ b/SEFramework/tests/src/Image/BufferedImage_test.cpp
@@ -63,6 +63,10 @@ public:
     }
     return tile;
   }
+
+  ImageTile::ImageType getType() const override {
+    return ImageTile::getTypeValue(T());
+  }
 };
 
 struct BufferedImageFixture {

--- a/SEImplementation/SEImplementation/Background/SE2/TypedSplineModelWrapper.h
+++ b/SEImplementation/SEImplementation/Background/SE2/TypedSplineModelWrapper.h
@@ -98,6 +98,10 @@ public:
     assert(false);
   }
 
+  ImageTile::ImageType getType() const override {
+    return ImageTile::getTypeValue(T());
+  }
+
 private:
   TypedSplineModelWrapper(const size_t* naxes, const size_t* gridCellSize, const size_t* nGrid, PIXTYPE* gridData){
     m_spline_model = new SplineModel(naxes, gridCellSize, nGrid, gridData);


### PR DESCRIPTION
Allows appending HDUs, writing new FITS headers and offsetting WCS coordinates
(features needed for use of the SourceXtractor++ framework for the strong lensing pipeline cutout service)
