### PR TITLE
Fixes for (cross) compiling on arm64-apple-darwin

### DIFF
--- a/SEFramework/CMakeLists.txt
+++ b/SEFramework/CMakeLists.txt
@@ -30,7 +30,7 @@ elements_depends_on_subdirs(ModelFitting)
 find_package(GMock)
 find_package(CCfits)
 find_package(BoostDLL)
-find_package(FFTW COMPONENTS single double long)
+find_package(FFTW COMPONENTS single double)
 find_package(WCSLIB REQUIRED)
 
 
@@ -44,9 +44,9 @@ find_package(WCSLIB REQUIRED)
 #===============================================================================
 elements_add_library(SEFramework
                      src/lib/Aperture/*.cpp
-                     src/lib/Pipeline/*.cpp 
+                     src/lib/Pipeline/*.cpp
                      src/lib/Property/*.cpp
-                     src/lib/Source/*.cpp 
+                     src/lib/Source/*.cpp
                      src/lib/Task/*.cpp
                      src/lib/Output/*.cpp
                      src/lib/Plugin/*.cpp
@@ -60,7 +60,7 @@ elements_add_library(SEFramework
                                     ${CCFITS_LIBRARIES} ${FFTW_LIBRARIES}
                      INCLUDE_DIRS SEUtils ${CCFITS_INCLUDE_DIRS} ${BoostDLL_INCLUDE_DIRS} ${FFTW_INCLUDE_DIRS}
                      PUBLIC_HEADERS SEFramework)
-                     
+
 #===============================================================================
 # Declare the executables here
 # Example:
@@ -78,42 +78,42 @@ elements_add_library(SEFramework
 #                       LINK_LIBRARIES ElementsExamples TYPE Boost)
 #===============================================================================
 if(GMOCK_FOUND)
-elements_add_unit_test(PropertyHolder_test tests/src/Property/PropertyHolder_test.cpp 
+elements_add_unit_test(PropertyHolder_test tests/src/Property/PropertyHolder_test.cpp
                      LINK_LIBRARIES SEFramework GMock
                      INCLUDE_DIRS GMock
                      TYPE Boost)
-elements_add_unit_test(SourceWithOnDemandProperties_test tests/src/Source/SourceWithOnDemandProperties_test.cpp 
+elements_add_unit_test(SourceWithOnDemandProperties_test tests/src/Source/SourceWithOnDemandProperties_test.cpp
                      LINK_LIBRARIES SEFramework GMock
                      INCLUDE_DIRS GMock
                      TYPE Boost)
-elements_add_unit_test(SourceInterface_test tests/src/Source/SourceInterface_test.cpp 
+elements_add_unit_test(SourceInterface_test tests/src/Source/SourceInterface_test.cpp
                      LINK_LIBRARIES SEFramework GMock
                      INCLUDE_DIRS GMock
                      TYPE Boost)
-elements_add_unit_test(Partition_test tests/src/Pipeline/Partition_test.cpp 
+elements_add_unit_test(Partition_test tests/src/Pipeline/Partition_test.cpp
                      LINK_LIBRARIES SEFramework GMock
                      INCLUDE_DIRS GMock
                      TYPE Boost)
-elements_add_unit_test(SourceGroupWithOnDemandProperties_test tests/src/Source/SourceGroupWithOnDemandProperties_test.cpp 
+elements_add_unit_test(SourceGroupWithOnDemandProperties_test tests/src/Source/SourceGroupWithOnDemandProperties_test.cpp
                      LINK_LIBRARIES SEFramework GMock
                      TYPE Boost)
 endif(GMOCK_FOUND)
-elements_add_unit_test(TaskProvider_test tests/src/Task/TaskProvider_test.cpp 
+elements_add_unit_test(TaskProvider_test tests/src/Task/TaskProvider_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
-elements_add_unit_test(PropertyId_test tests/src/Property/PropertyId_test.cpp 
+elements_add_unit_test(PropertyId_test tests/src/Property/PropertyId_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
-elements_add_unit_test(SourceGrouping_test tests/src/Pipeline/SourceGrouping_test.cpp 
+elements_add_unit_test(SourceGrouping_test tests/src/Pipeline/SourceGrouping_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
-elements_add_unit_test(Deblending_test tests/src/Pipeline/Deblending_test.cpp 
+elements_add_unit_test(Deblending_test tests/src/Pipeline/Deblending_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
-elements_add_unit_test(VectorImage_test tests/src/Image/VectorImage_test.cpp 
+elements_add_unit_test(VectorImage_test tests/src/Image/VectorImage_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
-elements_add_unit_test(ImageChunk_test tests/src/Image/ImageChunk_test.cpp 
+elements_add_unit_test(ImageChunk_test tests/src/Image/ImageChunk_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
 elements_add_unit_test(SimpleSource_test tests/src/Source/SimpleSource_test.cpp
@@ -167,7 +167,7 @@ elements_add_unit_test(NeighbourInfo_test tests/src/Aperture/NeighbourInfo_test.
 elements_add_unit_test(FitsImageSource_test tests/src/FITS/FitsImageSource_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
-elements_add_unit_test(ImageFitsReader_test tests/src/FITS/FitsReader_test.cpp 
+elements_add_unit_test(ImageFitsReader_test tests/src/FITS/FitsReader_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
 elements_add_unit_test(TemporaryFitsSource_test tests/src/FITS/TemporaryFitsSource_test.cpp

--- a/SEFramework/SEFramework/Image/ImageTile.h
+++ b/SEFramework/SEFramework/Image/ImageTile.h
@@ -82,7 +82,7 @@ public:
   virtual void setValue(int x, int y, double value) = 0;
   virtual void setValue(int x, int y, int value) = 0;
   virtual void setValue(int x, int y, unsigned int value) = 0;
-  virtual void setValue(int x, int y, long int value) = 0;
+  virtual void setValue(int x, int y, std::int64_t value) = 0;
 
   template<typename T>
   std::shared_ptr<VectorImage<T>> getImage() const {
@@ -122,13 +122,9 @@ public:
     return UIntImage;
   }
 
-  static ImageType getTypeValue(long int) {
+  static ImageType getTypeValue(std::int64_t) {
     return LongLongImage;
   }
-
-//  static ImageType getTypeValue(std::int64_t) {
-//    return LongLongImage;
-//  }
 
   static size_t getTypeSize(ImageType image_type) {
     switch (image_type) {
@@ -148,7 +144,7 @@ protected:
   virtual void getValue(int x, int y, double& value) const = 0;
   virtual void getValue(int x, int y, int& value) const = 0;
   virtual void getValue(int x, int y, unsigned int& value) const = 0;
-  virtual void getValue(int x, int y, long int& value) const = 0;
+  virtual void getValue(int x, int y, std::int64_t& value) const = 0;
 
 
   ImageTile(ImageType image_type, int x, int y, int width, int height, std::shared_ptr<ImageSource> source=nullptr)
@@ -173,7 +169,7 @@ protected:
       m_tile_image = VectorImage<unsigned int>::create(width, height);
       break;
     case LongLongImage:
-      m_tile_image = VectorImage<long int>::create(width, height);
+      m_tile_image = VectorImage<std::int64_t>::create(width, height);
       break;
     }
   }

--- a/SEFramework/src/lib/Image/ImageTile.cpp
+++ b/SEFramework/src/lib/Image/ImageTile.cpp
@@ -68,7 +68,7 @@ public:
     getValueImpl(x, y, value);
   }
 
-  virtual void getValue(int x, int y, long int& value) const {
+  virtual void getValue(int x, int y, std::int64_t& value) const {
     getValueImpl(x, y, value);
   }
 
@@ -88,7 +88,7 @@ public:
     setValueImpl(x, y, value);
   }
 
-  virtual void setValue(int x, int y, long int value) {
+  virtual void setValue(int x, int y, std::int64_t value) {
     setValueImpl(x, y, value);
   }
 };
@@ -105,7 +105,7 @@ std::shared_ptr<ImageTile> ImageTile::create(ImageType image_type, int x, int y,
   case UIntImage:
     return std::make_shared<ImageTileImpl<unsigned int>>(image_type, x, y, width, height, source);
   case LongLongImage:
-    return std::make_shared<ImageTileImpl<long long>>(image_type, x, y, width, height, source);
+    return std::make_shared<ImageTileImpl<std::int64_t>>(image_type, x, y, width, height, source);
   }
 }
 

--- a/cmake/ElementsBuildFlags.cmake
+++ b/cmake/ElementsBuildFlags.cmake
@@ -233,7 +233,7 @@ option(SQUEEZED_INSTALL
 option(SANITIZE_OPTIONS
        "Activate the Sanitizing options"
        OFF)
-       
+
 if(NOT SANITIZE_STYLE)
   set(SANITIZE_STYLE "undefined" CACHE STRING "Style used for the -fsanitize= option" FORCE)
 endif()
@@ -270,7 +270,7 @@ if(NOT ELEMENTS_DEFAULT_LOGLEVEL)
   if(USE_LOCAL_INSTALLAREA)
     set(ELEMENTS_DEFAULT_LOGLEVEL "INFO" CACHE STRING "Set the default loglevel for the framework messages" FORCE)
   else()
-    set(ELEMENTS_DEFAULT_LOGLEVEL "DEBUG" CACHE STRING "Set the default loglevel for the framework messages" FORCE)  
+    set(ELEMENTS_DEFAULT_LOGLEVEL "DEBUG" CACHE STRING "Set the default loglevel for the framework messages" FORCE)
   endif()
 endif()
 
@@ -303,7 +303,7 @@ if(NOT ELEMENTS_FLAGS_SET)
   else()
     set(CMAKE_C_FLAGS)
   endif()
-      
+
   set(CMAKE_C_FLAGS
       "${CMAKE_C_FLAGS} -fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Wno-long-long -Wno-unknown-pragmas -Wno-unused-parameter -fPIC"
       CACHE STRING "Flags used by the compiler during all build types."
@@ -471,7 +471,7 @@ if(NOT ELEMENTS_FLAGS_SET)
     else()
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--enable-new-dtags -Wl,--as-needed -pie"
           CACHE STRING "Flags used by the linker during the creation of exe's."
-          FORCE)    
+          FORCE)
     endif()
   endif()
 
@@ -607,8 +607,6 @@ if (SGS_HOST_ARCH AND SGS_ARCH)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
     set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -m32")
     set(GCCXML_CXX_FLAGS "${GCCXML_CXX_FLAGS} -m32")
-  elseif(NOT SGS_HOST_ARCH STREQUAL SGS_ARCH)
-    message(FATAL_ERROR "Cannot build for ${SGS_ARCH} on ${SGS_HOST_ARCH}.")
   endif()
 endif()
 


### PR DESCRIPTION
* We have a requirement on "fftw long double", which is not available on arm64 darwin (in conda, at least), but we don't need it anyway
* `ElementsBuildFlags.cmake` refuses to cross-compile except for i686 on x86_64, but, in fact, it can be done as long as the compilers are [properly set](https://github.com/astrorama/elements-feedstock/blob/master/recipe/build.sh#L8)
* `long` is 32 bits on arm64, but 64 on x86_64, so the compilation fails on arm64. I have replaced them with `int64_t`