### PR TITLE
Changed check images format from unsigned int to int

### DIFF
--- a/SEImplementation/SEImplementation/CheckImages/CheckImages.h
+++ b/SEImplementation/SEImplementation/CheckImages/CheckImages.h
@@ -51,41 +51,41 @@ public:
 
   void saveImages();
 
-  std::shared_ptr<WriteableImage<unsigned int>> getSegmentationImage() const {
+  std::shared_ptr<WriteableImage<int>> getSegmentationImage() const {
     if (m_segmentation_image != nullptr) {
-      return LockedWriteableImage<unsigned int>::create(m_segmentation_image);
+      return LockedWriteableImage<int>::create(m_segmentation_image);
     } else {
       return nullptr;
     }
   }
 
-  std::shared_ptr<WriteableImage<unsigned int>> getPartitionImage() const {
+  std::shared_ptr<WriteableImage<int>> getPartitionImage() const {
     if (m_partition_image != nullptr) {
-      return LockedWriteableImage<unsigned int>::create(m_partition_image);
+      return LockedWriteableImage<int>::create(m_partition_image);
     } else {
       return nullptr;
     }
   }
 
-  std::shared_ptr<WriteableImage<unsigned int>> getGroupImage() const {
+  std::shared_ptr<WriteableImage<int>> getGroupImage() const {
     if (m_group_image != nullptr) {
-      return LockedWriteableImage<unsigned int>::create(m_group_image);
+      return LockedWriteableImage<int>::create(m_group_image);
     } else {
       return nullptr;
     }
   }
 
-  std::shared_ptr<WriteableImage<unsigned int>> getAutoApertureImage() const {
+  std::shared_ptr<WriteableImage<int>> getAutoApertureImage() const {
     if (m_auto_aperture_image != nullptr) {
-      return LockedWriteableImage<unsigned int>::create(m_auto_aperture_image);
+      return LockedWriteableImage<int>::create(m_auto_aperture_image);
     } else {
       return nullptr;
     }
   }
 
-  std::shared_ptr<WriteableImage<unsigned int>> getApertureImage() const {
+  std::shared_ptr<WriteableImage<int>> getApertureImage() const {
     if (m_aperture_image != nullptr) {
-      return LockedWriteableImage<unsigned int>::create(m_aperture_image);
+      return LockedWriteableImage<int>::create(m_aperture_image);
     } else {
       return nullptr;
     }
@@ -99,9 +99,9 @@ public:
     }
   }
 
-  std::shared_ptr<WriteableImage<unsigned int>> getAutoApertureImage(unsigned int frame_number);
+  std::shared_ptr<WriteableImage<int>> getAutoApertureImage(unsigned int frame_number);
 
-  std::shared_ptr<WriteableImage<unsigned int>> getApertureImage(unsigned int frame_number);
+  std::shared_ptr<WriteableImage<int>> getApertureImage(unsigned int frame_number);
 
   std::shared_ptr<WriteableImage<MeasurementImage::PixelType>> getModelFittingImage(unsigned int frame_number);
 
@@ -154,11 +154,11 @@ private:
   };
 
   // check image
-  std::shared_ptr<WriteableImage<unsigned int>> m_segmentation_image;
-  std::shared_ptr<WriteableImage<unsigned int>> m_partition_image;
-  std::shared_ptr<WriteableImage<unsigned int>> m_group_image;
-  std::shared_ptr<WriteableImage<unsigned int>> m_auto_aperture_image;
-  std::shared_ptr<WriteableImage<unsigned int>> m_aperture_image;
+  std::shared_ptr<WriteableImage<int>> m_segmentation_image;
+  std::shared_ptr<WriteableImage<int>> m_partition_image;
+  std::shared_ptr<WriteableImage<int>> m_group_image;
+  std::shared_ptr<WriteableImage<int>> m_auto_aperture_image;
+  std::shared_ptr<WriteableImage<int>> m_aperture_image;
   std::shared_ptr<WriteableImage<SeFloat>> m_moffat_image;
   std::map<unsigned int, decltype(m_aperture_image)> m_measurement_aperture_images;
   std::map<unsigned int, decltype(m_auto_aperture_image)> m_measurement_auto_aperture_images;

--- a/SEImplementation/src/lib/CheckImages/CheckImages.cpp
+++ b/SEImplementation/src/lib/CheckImages/CheckImages.cpp
@@ -86,27 +86,27 @@ void CheckImages::configure(Euclid::Configuration::ConfigManager& manager) {
   m_coordinate_system = manager.getConfiguration<DetectionImageConfig>().getCoordinateSystem();
 
   if (m_segmentation_filename != "") {
-    m_segmentation_image = FitsWriter::newImage<unsigned int>(m_segmentation_filename.native(),
+    m_segmentation_image = FitsWriter::newImage<int>(m_segmentation_filename.native(),
         m_detection_image->getWidth(), m_detection_image->getHeight(), m_coordinate_system);
   }
 
   if (m_partition_filename != "") {
-    m_partition_image = FitsWriter::newImage<unsigned int>(m_partition_filename.native(),
+    m_partition_image = FitsWriter::newImage<int>(m_partition_filename.native(),
         m_detection_image->getWidth(), m_detection_image->getHeight(), m_coordinate_system);
   }
 
   if (m_group_filename != "") {
-    m_group_image = FitsWriter::newImage<unsigned int>(m_group_filename.native(),
+    m_group_image = FitsWriter::newImage<int>(m_group_filename.native(),
         m_detection_image->getWidth(), m_detection_image->getHeight(), m_coordinate_system);
   }
 
   if (m_auto_aperture_filename != "") {
-    m_auto_aperture_image = FitsWriter::newImage<unsigned int>(m_auto_aperture_filename.native(),
+    m_auto_aperture_image = FitsWriter::newImage<int>(m_auto_aperture_filename.native(),
         m_detection_image->getWidth(), m_detection_image->getHeight(), m_coordinate_system);
   }
 
   if (m_aperture_filename != "") {
-    m_aperture_image = FitsWriter::newImage<unsigned int>(m_aperture_filename.native(),
+    m_aperture_image = FitsWriter::newImage<int>(m_aperture_filename.native(),
         m_detection_image->getWidth(), m_detection_image->getHeight(), m_coordinate_system
     );
   }
@@ -134,7 +134,7 @@ void CheckImages::configure(Euclid::Configuration::ConfigManager& manager) {
   }
 }
 
-std::shared_ptr<WriteableImage<unsigned int>> CheckImages::getAutoApertureImage(unsigned int frame_number) {
+std::shared_ptr<WriteableImage<int>> CheckImages::getAutoApertureImage(unsigned int frame_number) {
   if (m_auto_aperture_filename.empty()) {
     return nullptr;
   }
@@ -151,17 +151,17 @@ std::shared_ptr<WriteableImage<unsigned int>> CheckImages::getAutoApertureImage(
     i = m_measurement_auto_aperture_images.emplace(
       std::make_pair(
         frame_number,
-        FitsWriter::newImage<unsigned int>(
+        FitsWriter::newImage<int>(
           frame_filename.native(),
           frame_info.m_width,
           frame_info.m_height,
           frame_info.m_coordinate_system
         ))).first;
   }
-  return LockedWriteableImage<unsigned int>::create(i->second);
+  return LockedWriteableImage<int>::create(i->second);
 }
 
-std::shared_ptr<WriteableImage<unsigned int>> CheckImages::getApertureImage(unsigned int frame_number) {
+std::shared_ptr<WriteableImage<int>> CheckImages::getApertureImage(unsigned int frame_number) {
   if (m_aperture_filename.empty()) {
     return nullptr;
   }
@@ -178,14 +178,14 @@ std::shared_ptr<WriteableImage<unsigned int>> CheckImages::getApertureImage(unsi
     i = m_measurement_aperture_images.emplace(
       std::make_pair(
         frame_number,
-        FitsWriter::newImage<unsigned int>(
+        FitsWriter::newImage<int>(
           frame_filename.native(),
           frame_info.m_width,
           frame_info.m_height,
           frame_info.m_coordinate_system
         ))).first;
   }
-  return LockedWriteableImage<unsigned int>::create(i->second);
+  return LockedWriteableImage<int>::create(i->second);
 }
 
 std::shared_ptr<WriteableImage<MeasurementImage::PixelType>>

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/ApertureFlagTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/ApertureFlagTask.cpp
@@ -76,7 +76,7 @@ void ApertureFlagTask::computeProperties(SourceInterface &source) const {
     unsigned int src_id = source.getProperty<SourceID>().getId();
     auto aperture = std::make_shared<CircularAperture>(m_apertures[0] / 2.);
 
-    fillAperture(aperture, centroid_x, centroid_y, aperture_check_img, src_id);
+    fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, src_id);
   }
 }
 

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryTask.cpp
@@ -110,7 +110,7 @@ void AperturePhotometryTask::computeProperties(SourceInterface &source) const {
   auto aperture_check_img = CheckImages::getInstance().getApertureImage(m_instance);
   if (aperture_check_img) {
     auto src_id = source.getProperty<SourceID>().getId();
-    fillAperture(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+    fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
   }
 }
 

--- a/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryFlagTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryFlagTask.cpp
@@ -84,8 +84,8 @@ void AutoPhotometryFlagTask::computeProperties(SourceInterface& source) const {
   // Draw the aperture
   auto aperture_check_img = CheckImages::getInstance().getAutoApertureImage();
   if (aperture_check_img) {
-    unsigned int src_id = source.getProperty<SourceID>().getId();
-    fillAperture(ell_aper, centroid_x, centroid_y, aperture_check_img, src_id);
+    auto src_id = source.getProperty<SourceID>().getId();
+    fillAperture<int>(ell_aper, centroid_x, centroid_y, aperture_check_img, src_id);
   }
 }
 

--- a/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryTask.cpp
@@ -101,7 +101,7 @@ void AutoPhotometryTask::computeProperties(SourceInterface &source) const {
   if (aperture_check_img) {
     auto src_id = source.getProperty<SourceID>().getId();
 
-    fillAperture(ell_aper, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+    fillAperture<int>(ell_aper, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
   }
 }
 


### PR DESCRIPTION
Unsigned ints are poorly supported in the FITS format. This changes the check images format to use signed integers even though we don't need negative numbers to avoid compatibility problems with other software.

Closes #304 
