### PR TITLE
Use a pool of file descriptors in FitsFileManager

### DIFF
--- a/.github/workflows/dependencies.txt
+++ b/.github/workflows/dependencies.txt
@@ -14,3 +14,4 @@ gtest-devel
 levmar-devel
 log4cpp-devel
 wcslib-devel
+lsof

--- a/SEFramework/CMakeLists.txt
+++ b/SEFramework/CMakeLists.txt
@@ -164,6 +164,9 @@ elements_add_unit_test(TransformedAperture_test tests/src/Aperture/TransformedAp
 elements_add_unit_test(NeighbourInfo_test tests/src/Aperture/NeighbourInfo_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)
+elements_add_unit_test(FitsFileManager_test tests/src/FITS/FitsFileManager_test.cpp
+                     LINK_LIBRARIES SEFramework
+                     TYPE Boost)
 elements_add_unit_test(FitsImageSource_test tests/src/FITS/FitsImageSource_test.cpp
                      LINK_LIBRARIES SEFramework
                      TYPE Boost)

--- a/SEFramework/SEFramework/FITS/FitsFile.h
+++ b/SEFramework/SEFramework/FITS/FitsFile.h
@@ -39,22 +39,36 @@ namespace SourceXtractor {
 /**
  * @class FitsFile
  * @brief represents access to a whole FITS file and handles loading and caching FITS headers
- *
+ * @details
+ *  The implementation probably needs some explanation:
+ *  In principle, the FitsFileManager may decide to close a file descriptor anytime
+ *  it sees fit. It could be while someone is using the pointer this class holds (that's why
+ *  getFitsFilePtr returns a std::shared_ptr, so it is kept alive while needed). It could be
+ *  just between opening a file and returning it. The former has a non negligible chance,
+ *  the later would be extremely unlikely (and unlucky), but is a race condition nevertheless.
+ *  That's why doOpen returns a shared_ptr apart of setting the m_file_pointer member. This should
+ *  (I think) solve the issue, as there will be a shared_ptr keeping the file descriptor alive
+ *  all the way to the caller of getFitsFilePtr(), even if close() is called in the middle.
+ * @warning
+ *  The FitsFileManager must outlive any instance of FitsFile it created.
+ *  We do not store a shared pointer because otherwise there is a reference cycle between the
+ *  FitsManager and the FitsFile
  */
 class FitsFile {
 protected:
-  FitsFile(const std::string& filename, bool writeable);
+  FitsFile(const std::string& filename, bool writeable, FitsFileManager *manager);
 
 public:
 
   virtual ~FitsFile();
 
-  fitsfile* getFitsFilePtr() {
-    if (!m_is_file_opened) {
-      open();
-    }
-    return m_file_pointer;
-  }
+  /**
+   * @return A shared pointer to a low-level fitsfile handler
+   * This point should *not* be stored anywhere. It is return as a std::shared_ptr
+   * so it is guaranteed to stay alive as long as it is needed, even if the FitsFileManager
+   * decides to close it on a separate thread
+   */
+  std::shared_ptr<fitsfile> getFitsFilePtr();
 
   const std::vector<int>& getImageHdus() const {
     return m_image_hdus;
@@ -68,34 +82,33 @@ public:
     return m_filename;
   }
 
-  bool isOpen() const {
-    return m_is_file_opened;
-  }
+  bool isOpen() const;
 
   void setWriteMode();
 
   void open();
+
   void close();
 
 private:
-  void openFirstTime();
-  void reopen();
-
-  void reloadHeaders();
-  std::map<std::string, MetadataEntry> loadFitsHeader(fitsfile *fptr);
-  void loadHeadFile();
+  friend class FitsFileManager;
 
   std::string m_filename;
-  fitsfile* m_file_pointer;
-  bool m_is_file_opened;
+  std::shared_ptr<fitsfile> m_file_pointer;
   bool m_is_writeable;
   bool m_was_opened_before;
 
   std::vector<int> m_image_hdus;
-
   std::vector<std::map<std::string, MetadataEntry>> m_headers;
+  FitsFileManager* m_manager;
 
-  friend class FitsFileManager;
+  std::shared_ptr<fitsfile> doOpen();
+  fitsfile* openFirstTime();
+  fitsfile* reopen();
+
+  void reloadHeaders(fitsfile* fptr);
+  std::map<std::string, MetadataEntry> loadFitsHeader(fitsfile *fptr);
+  void loadHeadFile();
 };
 
 }

--- a/SEFramework/SEFramework/FITS/FitsFile.h
+++ b/SEFramework/SEFramework/FITS/FitsFile.h
@@ -43,7 +43,7 @@ namespace SourceXtractor {
  */
 class FitsFile {
 protected:
-  FitsFile(const std::string& filename, bool writeable, std::shared_ptr<FitsFileManager> manager);
+  FitsFile(const std::string& filename, bool writeable);
 
 public:
 
@@ -64,11 +64,18 @@ public:
     return m_headers.at(hdu-1);
   }
 
+  const std::string& getFilename() const {
+    return m_filename;
+  }
+
+  bool isOpen() const {
+    return m_is_file_opened;
+  }
+
   void setWriteMode();
 
   void open();
   void close();
-
 
 private:
   void openFirstTime();
@@ -87,8 +94,6 @@ private:
   std::vector<int> m_image_hdus;
 
   std::vector<std::map<std::string, MetadataEntry>> m_headers;
-
-  std::shared_ptr<FitsFileManager> m_manager;
 
   friend class FitsFileManager;
 };

--- a/SEFramework/SEFramework/FITS/FitsFileManager.h
+++ b/SEFramework/SEFramework/FITS/FitsFileManager.h
@@ -28,7 +28,9 @@
 #include <string>
 #include <list>
 #include <vector>
+#include <deque>
 #include <unordered_map>
+#include <mutex>
 
 #include <fitsio.h>
 
@@ -55,14 +57,13 @@ public:
 
   void closeAndPurgeFile(const std::string& filename);
 
-  void reportClosedFile(const std::string& filename);
-  void reportOpenedFile(const std::string& filename);
+  unsigned count() const;
 
 private:
-  std::unordered_map<std::string, std::shared_ptr<FitsFile>> m_fits_files;
+  mutable std::mutex m_mutex;
+  std::unordered_map<std::string, std::deque<std::unique_ptr<FitsFile>>> m_fits_files;
 
   unsigned int m_max_open_files;
-  std::list<std::string> m_open_files;
 
   static std::shared_ptr<FitsFileManager> s_instance;
 

--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -87,29 +87,41 @@ static typename MetadataEntry::value_t valueAutoCast(const std::string& value) {
   return unquoted;
 }
 
-FitsFile::FitsFile(const std::string& filename, bool writeable) :
+FitsFile::FitsFile(const std::string& filename, bool writeable, FitsFileManager* manager) :
   m_filename(filename),
-  m_file_pointer(nullptr),
-  m_is_file_opened(false),
   m_is_writeable(writeable),
-  m_was_opened_before(false) {
+  m_was_opened_before(false),
+  m_manager(manager) {
 }
 
 FitsFile::~FitsFile() {
-  close();
 }
 
-void FitsFile::openFirstTime() {
+std::shared_ptr<fitsfile> FitsFile::getFitsFilePtr() {
+  if (!m_file_pointer) {
+    return doOpen();
+  }
+  return m_file_pointer;
+}
+
+void FitsFile::open() {
+  doOpen();
+}
+
+fitsfile* FitsFile::openFirstTime() {
+  assert(!m_file_pointer && !m_was_opened_before);
+
   int status = 0;
 
-  fits_open_image(&m_file_pointer, m_filename.c_str(), m_is_writeable ? READWRITE : READONLY, &status);
+  fitsfile* fptr;
+  fits_open_image(&fptr, m_filename.c_str(), m_is_writeable ? READWRITE : READONLY, &status);
   if (status != 0) {
     throw Elements::Exception() << "Can't open FITS file: " << m_filename;
   }
 
   m_image_hdus.clear() ;
   int number_of_hdus = 0;
-  if (fits_get_num_hdus(m_file_pointer, &number_of_hdus, &status) < 0) {
+  if (fits_get_num_hdus(fptr, &number_of_hdus, &status) < 0) {
     throw Elements::Exception() << "Can't get the number of HDUs in FITS file: " << m_filename;
   }
 
@@ -117,12 +129,12 @@ void FitsFile::openFirstTime() {
 
   // save current HDU (if the file is opened with advanced cfitsio syntax it might be set already
   int original_hdu = 0;
-  fits_get_hdu_num(m_file_pointer, &original_hdu);
+  fits_get_hdu_num(fptr, &original_hdu);
 
   // loop over HDUs to determine which ones are images
   int hdu_type = 0;
   for (int hdu_number=1; hdu_number <= number_of_hdus; hdu_number++) {
-    fits_movabs_hdu(m_file_pointer, hdu_number, &hdu_type, &status);
+    fits_movabs_hdu(fptr, hdu_number, &hdu_type, &status);
     if (status != 0) {
       throw Elements::Exception() << "Can't switch HDUs while opening: " << m_filename;
     }
@@ -131,7 +143,7 @@ void FitsFile::openFirstTime() {
       int bitpix, naxis;
       long naxes[2] = {1,1};
 
-      fits_get_img_param(m_file_pointer, 2, &bitpix, &naxis, naxes, &status);
+      fits_get_img_param(fptr, 2, &bitpix, &naxis, naxes, &status);
       if (status == 0 && naxis == 2) {
         m_image_hdus.emplace_back(hdu_number);
       }
@@ -139,45 +151,61 @@ void FitsFile::openFirstTime() {
   }
 
   // go back to saved HDU
-  fits_movabs_hdu(m_file_pointer, original_hdu, &hdu_type, &status);
+  fits_movabs_hdu(fptr, original_hdu, &hdu_type, &status);
 
   // load all FITS headers
-  reloadHeaders();
+  reloadHeaders(fptr);
 
   // load optional .head file to override headers
   loadHeadFile();
 
-  m_is_file_opened = true;
   m_was_opened_before = true;
+  return fptr;
 }
 
-void FitsFile::reopen() {
+fitsfile* FitsFile::reopen() {
+  assert(!m_file_pointer && m_was_opened_before);
+
   int status = 0;
-  fits_open_image(&m_file_pointer, m_filename.c_str(), m_is_writeable ? READWRITE : READONLY, &status);
+  fitsfile *fptr;
+  fits_open_image(&fptr, m_filename.c_str(), m_is_writeable ? READWRITE : READONLY, &status);
   if (status != 0) {
     throw Elements::Exception() << "Can't open FITS file: " << m_filename;
   }
-  m_is_file_opened = true;
+  return fptr;
 }
 
-void FitsFile::open() {
-  if (!m_is_file_opened) {
-    if (m_was_opened_before) {
-      reopen();
-    } else {
-      openFirstTime();
-    }
+std::shared_ptr<fitsfile> FitsFile::doOpen() {
+  assert (!m_file_pointer);
+
+  fitsfile *fptr;
+  if (m_was_opened_before) {
+    fptr = reopen();
   }
-  assert(m_file_pointer != nullptr);
+  else {
+    fptr = openFirstTime();
+  }
+  assert(fptr != nullptr);
+
+  auto shared_ptr = std::shared_ptr<fitsfile>(fptr, [](fitsfile *file_ptr) {
+    int status = 0;
+    fits_close_file(file_ptr, &status);
+  });
+  m_file_pointer = shared_ptr;
+  m_manager->reportOpenedFile(this);
+
+  return shared_ptr;
 }
 
 void FitsFile::close() {
-  if (m_is_file_opened) {
-    int status = 0;
-    fits_close_file(m_file_pointer, &status);
+  if (m_file_pointer) {
+    m_manager->reportClosedFile(this);
     m_file_pointer = nullptr;
-    m_is_file_opened = false;
   }
+}
+
+bool FitsFile::isOpen() const {
+  return m_file_pointer != nullptr;
 }
 
 void FitsFile::setWriteMode() {
@@ -188,22 +216,22 @@ void FitsFile::setWriteMode() {
   }
 }
 
-void FitsFile::reloadHeaders() {
+void FitsFile::reloadHeaders(fitsfile* fptr) {
   int status = 0;
 
   // save current HDU (if the file is opened with advanced cfitsio syntax it might be set already)
   int original_hdu = 0;
-  fits_get_hdu_num(m_file_pointer, &original_hdu);
+  fits_get_hdu_num(fptr, &original_hdu);
 
   int hdu_type = 0;
   for (unsigned int i = 0; i < m_headers.size(); i++) {
-    fits_movabs_hdu(m_file_pointer, i+1, &hdu_type, &status); // +1 hdus start at 1
+    fits_movabs_hdu(fptr, i + 1, &hdu_type, &status); // +1 hdus start at 1
 
-    m_headers[i] = loadFitsHeader(m_file_pointer);
+    m_headers[i] = loadFitsHeader(fptr);
   }
 
   // go back to saved HDU
-  fits_movabs_hdu(m_file_pointer, original_hdu, &hdu_type, &status);
+  fits_movabs_hdu(fptr, original_hdu, &hdu_type, &status);
 }
 
 std::map<std::string, MetadataEntry> FitsFile::loadFitsHeader(fitsfile *fptr) {

--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -87,13 +87,12 @@ static typename MetadataEntry::value_t valueAutoCast(const std::string& value) {
   return unquoted;
 }
 
-FitsFile::FitsFile(const std::string& filename, bool writeable, std::shared_ptr<FitsFileManager> manager) :
-      m_filename(filename),
-      m_file_pointer(nullptr),
-      m_is_file_opened(false),
-      m_is_writeable(writeable),
-      m_was_opened_before(false),
-      m_manager(manager) {
+FitsFile::FitsFile(const std::string& filename, bool writeable) :
+  m_filename(filename),
+  m_file_pointer(nullptr),
+  m_is_file_opened(false),
+  m_is_writeable(writeable),
+  m_was_opened_before(false) {
 }
 
 FitsFile::~FitsFile() {
@@ -163,7 +162,6 @@ void FitsFile::reopen() {
 
 void FitsFile::open() {
   if (!m_is_file_opened) {
-    m_manager->reportOpenedFile(m_filename);
     if (m_was_opened_before) {
       reopen();
     } else {
@@ -175,7 +173,6 @@ void FitsFile::open() {
 
 void FitsFile::close() {
   if (m_is_file_opened) {
-    m_manager->reportClosedFile(m_filename);
     int status = 0;
     fits_close_file(m_file_pointer, &status);
     m_file_pointer = nullptr;

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -54,15 +54,15 @@ FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number, Im
   auto fptr = m_fits_file->getFitsFilePtr();
 
   if (m_hdu_number <= 0) {
-    if (fits_get_hdu_num(fptr, &m_hdu_number) < 0) {
+    if (fits_get_hdu_num(fptr.get(), &m_hdu_number) < 0) {
       throw Elements::Exception() << "Can't get the active HDU from the FITS file: " << filename;
     }
   }
   else {
-    switchHdu(fptr, m_hdu_number);
+    switchHdu(fptr.get(), m_hdu_number);
   }
 
-  fits_get_img_param(fptr, 2, &bitpix, &naxis, naxes, &status);
+  fits_get_img_param(fptr.get(), 2, &bitpix, &naxis, naxes, &status);
   if (status != 0 || naxis != 2) {
     throw Elements::Exception() << "Can't find 2D image in FITS file: " << filename << "[" << m_hdu_number << "]";
   }
@@ -168,12 +168,12 @@ FitsImageSource::FitsImageSource(const std::string& filename, int width, int hei
   // Reopens the newly created file through theFitsFileManager
   m_fits_file = m_manager->getFitsFile(filename, true);
   auto fptr = m_fits_file->getFitsFilePtr();
-  switchHdu(fptr, m_hdu_number);
+  switchHdu(fptr.get(), m_hdu_number);
 }
 
 std::shared_ptr<ImageTile> FitsImageSource::getImageTile(int x, int y, int width, int height) const {
   auto fptr = m_fits_file->getFitsFilePtr();
-  switchHdu(fptr, m_hdu_number);
+  switchHdu(fptr.get(), m_hdu_number);
 
   auto tile = ImageTile::create(m_image_type, x, y, width, height,
       std::const_pointer_cast<ImageSource>(shared_from_this()));
@@ -183,7 +183,7 @@ std::shared_ptr<ImageTile> FitsImageSource::getImageTile(int x, int y, int width
   long increment[2] = {1, 1};
   int status = 0;
 
-  fits_read_subset(fptr, getDataType(), first_pixel, last_pixel, increment,
+  fits_read_subset(fptr.get(), getDataType(), first_pixel, last_pixel, increment,
                    nullptr, tile->getDataPtr(), nullptr, &status);
   if (status != 0) {
     throw Elements::Exception() << "Error reading image tile from FITS file.";
@@ -194,7 +194,7 @@ std::shared_ptr<ImageTile> FitsImageSource::getImageTile(int x, int y, int width
 
 void FitsImageSource::saveTile(ImageTile& tile) {
     auto fptr = m_fits_file->getFitsFilePtr();
-    switchHdu(fptr, m_hdu_number);
+    switchHdu(fptr.get(), m_hdu_number);
 
     int x = tile.getPosX();
     int y = tile.getPosY();
@@ -205,7 +205,7 @@ void FitsImageSource::saveTile(ImageTile& tile) {
     long last_pixel[2] = {x + width, y + height};
     int status = 0;
 
-    fits_write_subset(fptr, getDataType(), first_pixel, last_pixel, tile.getDataPtr(), &status);
+    fits_write_subset(fptr.get(), getDataType(), first_pixel, last_pixel, tile.getDataPtr(), &status);
     if (status != 0) {
       throw Elements::Exception() << "Error saving image tile to FITS file.";
     }
@@ -273,7 +273,7 @@ std::unique_ptr<std::vector<char>> FitsImageSource::getFitsHeaders(int& number_o
 
 void FitsImageSource::setMetadata(std::string key, MetadataEntry value) {
   auto fptr = m_fits_file->getFitsFilePtr();
-  switchHdu(fptr, m_hdu_number);
+  switchHdu(fptr.get(), m_hdu_number);
 
   std::ostringstream padded_key, serializer;
   padded_key << std::setw(8) << std::left << key;
@@ -282,7 +282,7 @@ void FitsImageSource::setMetadata(std::string key, MetadataEntry value) {
   auto str = serializer.str();
 
   int status = 0;
-  fits_update_card(fptr, padded_key.str().c_str(), str.c_str(), &status);
+  fits_update_card(fptr.get(), padded_key.str().c_str(), str.c_str(), &status);
 
   if (status != 0) {
     char err_txt[31];

--- a/SEFramework/tests/src/FITS/FitsFileManager_test.cpp
+++ b/SEFramework/tests/src/FITS/FitsFileManager_test.cpp
@@ -1,0 +1,110 @@
+/** Copyright © 2021 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <ElementsKernel/Auxiliary.h>
+#include "SEFramework/FITS/FitsFile.h"
+#include "SEFramework/FITS/FitsFileManager.h"
+
+using namespace SourceXtractor;
+
+struct FitsImageSourceFixture {
+  std::string mhdu_path;
+
+  FitsImageSourceFixture() {
+    mhdu_path = Elements::getAuxiliaryPath("multiple_hdu.fits").native();
+  }
+};
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(FitsFileManager_test)
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(OpenOnce_test, FitsImageSourceFixture) {
+  auto manager = std::make_shared<FitsFileManager>();
+  auto fits = manager->getFitsFile(mhdu_path);
+  fits->open();
+  BOOST_CHECK_EQUAL(fits->getImageHdus().size(), 2);
+  auto metadata = fits->getHDUHeaders(2);
+  BOOST_CHECK_EQUAL(boost::get<std::string>(metadata["EXTNAME"].m_value), "COMPRESSED_IMAGE");
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(OpenReturn_test, FitsImageSourceFixture) {
+  auto manager = std::make_shared<FitsFileManager>();
+  fitsfile *ptr;
+  {
+    auto fits = manager->getFitsFile(mhdu_path);
+    ptr = fits->getFitsFilePtr();
+  }
+  auto fits2 = manager->getFitsFile(mhdu_path);
+  // Since it was returned, it should be the same
+  BOOST_CHECK_EQUAL(fits2->getFitsFilePtr(), ptr);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(OpenTwice_test, FitsImageSourceFixture) {
+  auto manager = std::make_shared<FitsFileManager>();
+  auto fits = manager->getFitsFile(mhdu_path);
+  auto fits2 = manager->getFitsFile(mhdu_path);
+  // Since it is still open, they should be two different file descriptors
+  BOOST_CHECK_NE(fits2->getFitsFilePtr(), fits->getFitsFilePtr());
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(OpenAndClosed_test, FitsImageSourceFixture) {
+  auto manager = std::make_shared<FitsFileManager>();
+  fitsfile *ptr;
+  {
+    auto fits = manager->getFitsFile(mhdu_path);
+    ptr = fits->getFitsFilePtr();
+    fits->close();
+  }
+  auto fits2 = manager->getFitsFile(mhdu_path);
+  // Since it was closed before being returned to the pool, it should *not* be the same
+  BOOST_CHECK_NE(fits2->getFitsFilePtr(), ptr);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(FileLimit_test, FitsImageSourceFixture) {
+  auto manager = std::make_shared<FitsFileManager>(5);
+  std::vector<std::shared_ptr<FitsFile>> hold;
+  for (int i = 0; i < 10; ++i) {
+    hold.emplace_back(manager->getFitsFile(mhdu_path));
+    hold.back()->open();
+  }
+  BOOST_CHECK_EQUAL(hold.size(), 10);
+  // All are outside
+  BOOST_CHECK_EQUAL(manager->count(), 0);
+
+  // Release all
+  hold.resize(0);
+
+  BOOST_CHECK_EQUAL(manager->count(), 5);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//-----------------------------------------------------------------------------

--- a/SEFramework/tests/src/FITS/FitsFileManager_test.cpp
+++ b/SEFramework/tests/src/FITS/FitsFileManager_test.cpp
@@ -54,6 +54,7 @@ BOOST_FIXTURE_TEST_CASE(OpenReturn_test, FitsImageSourceFixture) {
     auto fits = manager->getFitsFile(mhdu_path);
     ptr = fits->getFitsFilePtr();
   }
+  BOOST_CHECK_EQUAL(manager->count(), 1);
   auto fits2 = manager->getFitsFile(mhdu_path);
   // Since it was returned, it should be the same
   BOOST_CHECK_EQUAL(fits2->getFitsFilePtr(), ptr);
@@ -73,15 +74,12 @@ BOOST_FIXTURE_TEST_CASE(OpenTwice_test, FitsImageSourceFixture) {
 
 BOOST_FIXTURE_TEST_CASE(OpenAndClosed_test, FitsImageSourceFixture) {
   auto manager = std::make_shared<FitsFileManager>();
-  fitsfile *ptr;
   {
     auto fits = manager->getFitsFile(mhdu_path);
-    ptr = fits->getFitsFilePtr();
     fits->close();
   }
-  auto fits2 = manager->getFitsFile(mhdu_path);
-  // Since it was closed before being returned to the pool, it should *not* be the same
-  BOOST_CHECK_NE(fits2->getFitsFilePtr(), ptr);
+
+  BOOST_CHECK_EQUAL(manager->count(), 0);
 }
 
 //-----------------------------------------------------------------------------

--- a/SEFramework/tests/src/FITS/FitsFileManager_test.cpp
+++ b/SEFramework/tests/src/FITS/FitsFileManager_test.cpp
@@ -29,7 +29,7 @@ namespace bp = boost::process;
 ///     This seems to be unreliable when running through valgrind
 static int countOpenFiles() {
   bp::ipstream is;
-  bp::child lsof(bp::search_path("lsof"), "-p", std::to_string(getpid()), bp::std_out > is);
+  bp::child lsof(bp::search_path("lsof"), "-a", "-p", std::to_string(getpid()), "-d", "0-999", bp::std_out > is);
   int count = 0;
   std::string line;
   while (lsof.running() && std::getline(is, line) && !line.empty()) {

--- a/SEFramework/tests/src/FITS/FitsImageSource_test.cpp
+++ b/SEFramework/tests/src/FITS/FitsImageSource_test.cpp
@@ -29,10 +29,10 @@
 using namespace SourceXtractor;
 
 struct FitsImageSourceFixture {
-  std::string mhdu_path, primary_path;
+  std::string fits_path, primary_path;
 
   FitsImageSourceFixture() {
-    mhdu_path = Elements::getAuxiliaryPath("multiple_hdu.fits").native();
+    fits_path = Elements::getAuxiliaryPath("multiple_hdu.fits").native();
     primary_path = Elements::getAuxiliaryPath("with_primary.fits").native();
   }
 };
@@ -67,7 +67,7 @@ BOOST_FIXTURE_TEST_CASE(explicit_primary_test, FitsImageSourceFixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(compressed_image_test, FitsImageSourceFixture) {
-  auto img_src = std::make_shared<FitsImageSource>(mhdu_path, 0, ImageTile::FloatImage);
+  auto img_src = std::make_shared<FitsImageSource>(fits_path, 0, ImageTile::FloatImage);
   BOOST_CHECK_EQUAL(img_src->getHeight(), 1);
   BOOST_CHECK_EQUAL(img_src->getWidth(), 1);
   BOOST_CHECK_CLOSE(img_src->getImageTile(0, 0, 1, 1)->getValue<SeFloat>(0, 0), 256.2f, 1e-8);
@@ -76,7 +76,7 @@ BOOST_FIXTURE_TEST_CASE(compressed_image_test, FitsImageSourceFixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(explicit_compressed_image_test, FitsImageSourceFixture) {
-  auto img_src = std::make_shared<FitsImageSource>(mhdu_path + "[1]", 0, ImageTile::FloatImage);
+  auto img_src = std::make_shared<FitsImageSource>(fits_path + "[1]", 0, ImageTile::FloatImage);
   BOOST_CHECK_EQUAL(img_src->getHeight(), 1);
   BOOST_CHECK_EQUAL(img_src->getWidth(), 1);
   BOOST_CHECK_CLOSE(img_src->getImageTile(0, 0, 1, 1)->getValue<SeFloat>(0, 0), 256.2f, 1e-8);
@@ -85,7 +85,7 @@ BOOST_FIXTURE_TEST_CASE(explicit_compressed_image_test, FitsImageSourceFixture) 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(second_image_test, FitsImageSourceFixture) {
-  auto img_src = std::make_shared<FitsImageSource>(mhdu_path + "[3]", 0, ImageTile::FloatImage);
+  auto img_src = std::make_shared<FitsImageSource>(fits_path + "[3]", 0, ImageTile::FloatImage);
   BOOST_CHECK_EQUAL(img_src->getHeight(), 1);
   BOOST_CHECK_EQUAL(img_src->getWidth(), 1);
   BOOST_CHECK_CLOSE(img_src->getImageTile(0, 0, 1, 1)->getValue<SeFloat>(0, 0), 1024.44f, 1e-8);
@@ -94,7 +94,7 @@ BOOST_FIXTURE_TEST_CASE(second_image_test, FitsImageSourceFixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(second_image_by_name_test, FitsImageSourceFixture) {
-  auto img_src = std::make_shared<FitsImageSource>(mhdu_path + "[IMAGE2]", 0, ImageTile::FloatImage);
+  auto img_src = std::make_shared<FitsImageSource>(fits_path + "[IMAGE2]", 0, ImageTile::FloatImage);
   BOOST_CHECK_EQUAL(img_src->getHeight(), 1);
   BOOST_CHECK_EQUAL(img_src->getWidth(), 1);
   BOOST_CHECK_CLOSE(img_src->getImageTile(0, 0, 1, 1)->getValue<SeFloat>(0, 0), 1024.44f, 1e-8);
@@ -103,21 +103,21 @@ BOOST_FIXTURE_TEST_CASE(second_image_by_name_test, FitsImageSourceFixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(hdu_is_table_test, FitsImageSourceFixture) {
-  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[2]"), Elements::Exception);
-  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[TABLE]"), Elements::Exception);
+  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(fits_path + "[2]"), Elements::Exception);
+  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(fits_path + "[TABLE]"), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(bad_hdu_test, FitsImageSourceFixture) {
-  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[5]"), Elements::Exception);
+  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(fits_path + "[5]"), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(empty_primary_hdu_test, FitsImageSourceFixture) {
-  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[0]"), Elements::Exception);
-  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[PRIMARY]"), Elements::Exception);
+  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(fits_path + "[0]"), Elements::Exception);
+  BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(fits_path + "[PRIMARY]"), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the crashes mentioned in #294, but I have split it into its own pull request for clarity.

This fix fully gives the `FitsFile` pointer to the caller, so any additional call for the same file will get a different pointer.
In this way, threads that access the same file at the same time will get different file descriptors.

When the returned `shared_ptr` is fully destroyed, it returns the `FitsFile` to the `FitsFileManager` so it can be reused.

With this mechanism, `FitsFile` does not need to ping back the manager anymore when it is closed/reopen a different file. The manager will simply not re-insert back into the pool closed descriptors.