### PR TITLE
Pass ImageTileWithType to copyOverlappingPixels

### DIFF
--- a/SEFramework/SEFramework/Image/BufferedImage.h
+++ b/SEFramework/SEFramework/Image/BufferedImage.h
@@ -65,7 +65,7 @@ protected:
   std::shared_ptr<TileManager> m_tile_manager;
   mutable std::shared_ptr<ImageTile> m_current_tile;
 
-  void copyOverlappingPixels(const ImageTile &tile, std::vector<T> &output,
+  void copyOverlappingPixels(const ImageTileWithType<T> &tile, std::vector<T> &output,
                              int x, int y, int w, int h,
                              int tile_w, int tile_h) const;
 };

--- a/SEFramework/src/lib/Image/BufferedImage.cpp
+++ b/SEFramework/src/lib/Image/BufferedImage.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<ImageChunk<T>> BufferedImage<T>::getChunk(int x, int y, int widt
 
     for (int iy = tile_start_y; iy <= tile_end_y; iy += tile_h) {
       for (int ix = tile_start_x; ix <= tile_end_x; ix += tile_w) {
-        auto tile = m_tile_manager->getTileForPixel(ix, iy, m_source);
+        auto tile =std::dynamic_pointer_cast<ImageTileWithType<T>>(m_tile_manager->getTileForPixel(ix, iy, m_source));
         copyOverlappingPixels(*tile, data, x, y, width, height, tile_w, tile_h);
       }
     }
@@ -113,7 +113,7 @@ std::shared_ptr<ImageChunk<T>> BufferedImage<T>::getChunk(int x, int y, int widt
 
 
 template<typename T>
-void BufferedImage<T>::copyOverlappingPixels(const ImageTile& tile, std::vector<T>& output,
+void BufferedImage<T>::copyOverlappingPixels(const ImageTileWithType<T> &tile, std::vector<T>& output,
                                              int x, int y, int w, int h,
                                              int tile_w, int tile_h) const {
   int start_x = std::max(tile.getPosX(), x);
@@ -125,7 +125,7 @@ void BufferedImage<T>::copyOverlappingPixels(const ImageTile& tile, std::vector<
 
   for (int data_y = off_y, img_y = start_y; img_y < end_y; ++data_y, ++img_y) {
     for (int data_x = off_x, img_x = start_x; img_x < end_x; ++data_x, ++img_x) {
-      output[data_x + data_y * w] = tile.getValue<T>(img_x, img_y);
+      tile.getValue(img_x, img_y, output[data_x + data_y * w]);
     }
   }
 }


### PR DESCRIPTION
Sorry I didn't think about this before, but it occurred to me while having the coffee. If we use `final` on  `ImageTileWithType` the compiler can optimize the calls to `getValue` and directly ignore the vtable.

I have also changed `copyOverlappingPixels` so it works over the typed tile.

The improvement is not massive (~12%), but with this the performance is as good as 0.12 (+/-, the test I run is limited).