### PR TITLE
Fix error with some numbers in FITS headers

### DIFF
--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -48,7 +48,7 @@ namespace SourceXtractor {
  * - anything else will be casted to std::string, removing simple quotes if necessary
  */
 static typename MetadataEntry::value_t valueAutoCast(const std::string& value) {
-  boost::regex float_regex("^[-+]?\\d*\\.?\\d+([eE][-+]?\\d+)?$");
+  boost::regex float_regex("^[-+]?(\\d*\\.?\\d+|\\d+\\.?\\d*)([eE][-+]?\\d+)?$");
   boost::regex int_regex("^[-+]?\\d+$");
 
   try {


### PR DESCRIPTION
Closes #324

The problem was numbers like "123." that end with a decimal point and have nothing after. They didn't match our regex to detect floating point numbers. We now accept either "123." or ".123" as being floating point numbers.