### PR TITLE
ModelFitting: Fixes related to NaN values on the weight

### DIFF
--- a/ModelFitting/ModelFitting/Engine/LeastSquareSummary.h
+++ b/ModelFitting/ModelFitting/Engine/LeastSquareSummary.h
@@ -36,15 +36,22 @@ namespace ModelFitting {
  * minimization problem
  */
 struct LeastSquareSummary {
-  
+
+  enum StatusFlag {
+    SUCCESS, MAX_ITER, ERROR
+  };
+
   /// Flag indicating if the minimization was successful
-  bool success_flag = true;
+  StatusFlag status_flag = SUCCESS;
   
   /// The number of iterations
   size_t iteration_no {0};
   
-  // 1-sigma margin of error for all the parameters
+  /// 1-sigma margin of error for all the parameters
   std::vector<double> parameter_sigmas {};
+
+  /// Engine-specific reason for stopping the fitting
+  int engine_stop_reason {0};
 
   /// Info of the minimization process, as provided by the underlying framework.
   ///

--- a/ModelFitting/ModelFitting/Engine/LevmarEngine.h
+++ b/ModelFitting/ModelFitting/Engine/LevmarEngine.h
@@ -70,7 +70,6 @@ private:
   
   size_t m_itmax;
   std::vector<double> m_opts;
-  
 };
 
 } // end of namespace ModelFitting

--- a/ModelFitting/src/lib/Engine/GSLEngine.cpp
+++ b/ModelFitting/src/lib/Engine/GSLEngine.cpp
@@ -103,6 +103,16 @@ public:
   }
 };
 
+static LeastSquareSummary::StatusFlag getStatusFlag(int ret) {
+  switch (ret) {
+    case GSL_SUCCESS:
+      return LeastSquareSummary::SUCCESS;
+    case GSL_EMAXITER:
+      return LeastSquareSummary::MAX_ITER;
+    default:
+      return LeastSquareSummary::ERROR;
+  }
+}
 
 LeastSquareSummary GSLEngine::solveProblem(ModelFitting::EngineParameterManager& parameter_manager,
                                            ModelFitting::ResidualEstimator& residual_estimator) {
@@ -192,7 +202,8 @@ LeastSquareSummary GSLEngine::solveProblem(ModelFitting::EngineParameterManager&
     parameter_manager.numberOfParameters() * parameter_manager.numberOfParameters());
 
   LeastSquareSummary summary;
-  summary.success_flag = (ret == GSL_SUCCESS);
+  summary.status_flag = getStatusFlag(ret);
+  summary.engine_stop_reason = ret;
   summary.iteration_no = gsl_multifit_nlinear_niter(workspace);
   summary.parameter_sigmas = {};
 

--- a/ModelFitting/src/lib/Engine/LevmarEngine.cpp
+++ b/ModelFitting/src/lib/Engine/LevmarEngine.cpp
@@ -29,6 +29,46 @@
 #include "ModelFitting/Engine/LeastSquareEngineManager.h"
 #include "ModelFitting/Engine/LevmarEngine.h"
 
+namespace {
+
+__attribute__((unused))
+void printLevmarInfo(std::array<double, 10> info) {
+  std::cerr << "\nMinimization info:\n";
+  std::cerr << "  ||e||_2 at initial p: " << info[0] << '\n';
+  std::cerr << "  ||e||_2: " << info[1] << '\n';
+  std::cerr << "  ||J^T e||_inf: " << info[2] << '\n';
+  std::cerr << "  ||Dp||_2: " << info[3] << '\n';
+  std::cerr << "  mu/max[J^T J]_ii: " << info[4] << '\n';
+  std::cerr << "  # iterations: " << info[5] << '\n';
+  switch ((int) info[6]) {
+    case 1:
+      std::cerr << "  stopped by small gradient J^T e\n";
+      break;
+    case 2:
+      std::cerr << "  stopped by small Dp\n";
+      break;
+    case 3:
+      std::cerr << "  stopped by itmax\n";
+      break;
+    case 4:
+      std::cerr << "  singular matrix. Restart from current p with increased mu\n";
+      break;
+    case 5:
+      std::cerr << "  no further error reduction is possible. Restart with increased mu\n";
+      break;
+    case 6:
+      std::cerr << "  stopped by small ||e||_2\n";
+      break;
+    case 7:
+      std::cerr << "  stopped by invalid (i.e. NaN or Inf) func values; a user error\n";
+      break;
+  }
+  std::cerr << "  # function evaluations: " << info[7] << '\n';
+  std::cerr << "  # Jacobian evaluations: " << info[8] << '\n';
+  std::cerr << "  # linear systems solved: " << info[9] << "\n\n";
+}
+
+}
 
 namespace ModelFitting {
 
@@ -39,6 +79,21 @@ static std::shared_ptr<LeastSquareEngine> createLevmarEngine(unsigned max_iterat
 }
 
 static LeastSquareEngineManager::StaticEngine levmar_engine{"levmar", createLevmarEngine};
+
+static LeastSquareSummary::StatusFlag getStatusFlag(const std::array<double, 10>& info, int res) {
+  if (res == -1) {
+    return LeastSquareSummary::ERROR;
+  }
+  switch (static_cast<int>(info[6])) {
+    case 7:
+    case 4:
+      return LeastSquareSummary::ERROR;
+    case 3:
+      return LeastSquareSummary::MAX_ITER;
+    default:
+      return LeastSquareSummary::SUCCESS;
+  }
+}
 
 LevmarEngine::LevmarEngine(size_t itmax, double tau, double epsilon1,
                            double epsilon2, double epsilon3, double delta)
@@ -118,7 +173,8 @@ LeastSquareSummary LevmarEngine::solveProblem(EngineParameterManager& parameter_
     summary.parameter_sigmas.push_back(sqrt(converted_covariance_matrix[i*(parameter_manager.numberOfParameters()+1)]));
   }
 
-  summary.success_flag = (res != -1);
+  summary.status_flag = getStatusFlag(info, res);
+  summary.engine_stop_reason = info[6];
   summary.iteration_no = info[5];
   summary.underlying_framework_info = info;
   return summary;

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFitting.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFitting.h
@@ -41,9 +41,12 @@ class FlexibleModelFitting : public Property {
 public:
   virtual ~FlexibleModelFitting() = default;
 
-  FlexibleModelFitting(unsigned int iterations, SeFloat chi_squared, Flags flags,
-      std::unordered_map<int, double> parameter_values, std::unordered_map<int, double> parameter_sigmas) :
+  FlexibleModelFitting(unsigned int iterations, unsigned int stop_reason,
+                       SeFloat chi_squared, Flags flags,
+                       std::unordered_map<int, double> parameter_values,
+                       std::unordered_map<int, double> parameter_sigmas) :
     m_iterations(iterations),
+    m_stop_reason(stop_reason),
     m_chi_squared(chi_squared),
     m_flags(flags),
     m_parameter_values(parameter_values),
@@ -51,6 +54,10 @@ public:
 
   unsigned int getIterations() const {
     return m_iterations;
+  }
+
+  unsigned int getStopReason() const {
+    return m_stop_reason;
   }
 
   SeFloat getReducedChiSquared() const {
@@ -70,7 +77,7 @@ public:
   }
 
 private:
-  unsigned int m_iterations;
+  unsigned int m_iterations, m_stop_reason;
   SeFloat m_chi_squared;
   Flags m_flags;
   std::unordered_map<int, double> m_parameter_values;

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingPlugin.cpp
@@ -55,6 +55,15 @@ void FlexibleModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           "Number of iterations in the model fitting"
   );
 
+  plugin_api.getOutputRegistry().registerColumnConverter<FlexibleModelFitting, int>(
+    "fmf_stop_reason",
+    [](const FlexibleModelFitting& prop) {
+      return prop.getStopReason();
+    },
+    "",
+    "Stop reason (engine dependent)"
+  );
+
   plugin_api.getOutputRegistry().registerColumnConverter<FlexibleModelFitting, int64_t>(
           "fmf_flags",
           [](const FlexibleModelFitting& prop) {

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
@@ -63,55 +63,6 @@ using namespace ModelFitting;
 
 static auto logger = Elements::Logging::getLogger("FlexibleModelFitting");
 
-namespace {
-
-__attribute__((unused))
-void printLevmarInfo(std::array<double, 10> info) {
-  std::cerr << "\nMinimization info:\n";
-  std::cerr << "  ||e||_2 at initial p: " << info[0] << '\n';
-  std::cerr << "  ||e||_2: " << info[1] << '\n';
-  std::cerr << "  ||J^T e||_inf: " << info[2] << '\n';
-  std::cerr << "  ||Dp||_2: " << info[3] << '\n';
-  std::cerr << "  mu/max[J^T J]_ii: " << info[4] << '\n';
-  std::cerr << "  # iterations: " << info[5] << '\n';
-  switch ((int) info[6]) {
-    case 1:
-      std::cerr << "  stopped by small gradient J^T e\n";
-      break;
-    case 2:
-      std::cerr << "  stopped by small Dp\n";
-      break;
-    case 3:
-      std::cerr << "  stopped by itmax\n";
-      break;
-    case 4:
-      std::cerr << "  singular matrix. Restart from current p with increased mu\n";
-      break;
-    case 5:
-      std::cerr << "  no further error reduction is possible. Restart with increased mu\n";
-      break;
-    case 6:
-      std::cerr << "  stopped by small ||e||_2\n";
-      break;
-    case 7:
-      std::cerr << "  stopped by invalid (i.e. NaN or Inf) func values; a user error\n";
-      break;
-  }
-  std::cerr << "  # function evaluations: " << info[7] << '\n';
-  std::cerr << "  # Jacobian evaluations: " << info[8] << '\n';
-  std::cerr << "  # linear systems solved: " << info[9] << "\n\n";
-}
-
-}
-
-static void updateFlags(Flags& flags, unsigned stop_reason) {
-  switch (stop_reason) {
-    case 4:
-    case 7:
-      flags |= Flags::ERROR;
-  }
-}
-
 FlexibleModelFittingTask::FlexibleModelFittingTask(const std::string &least_squares_engine,
     unsigned int max_iterations, double modified_chi_squared_scale,
     std::vector<std::shared_ptr<FlexibleModelFittingParameter>> parameters,
@@ -296,10 +247,11 @@ void FlexibleModelFittingTask::computeProperties(SourceGroupInterface& group) co
     //  LevmarEngine engine{m_max_iterations, 1E-3, 1E-6, 1E-6, 1E-6, 1E-4};
     auto engine = LeastSquareEngineManager::create(m_least_squares_engine, m_max_iterations);
     auto solution = engine->solveProblem(engine_parameter_manager, res_estimator);
-    auto engine_info = boost::any_cast<std::array<double, 10>>(solution.underlying_framework_info);
-    unsigned iterations = static_cast<unsigned>(engine_info[5]);
-    unsigned stop_reason = static_cast<unsigned>(engine_info[6]);
-    updateFlags(group_flags, stop_reason);
+    auto iterations = solution.iteration_no;
+    auto stop_reason = solution.engine_stop_reason;
+    if (solution.status_flag == LeastSquareSummary::ERROR) {
+      group_flags |= Flags::ERROR;
+    }
 
     int total_data_points = 0;
     SeFloat avg_reduced_chi_squared = computeChiSquared(group, pixel_scale, parameter_manager, total_data_points);

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
@@ -151,20 +151,19 @@ std::shared_ptr<VectorImage<SeFloat>> FlexibleModelFittingTask::createWeightImag
 
   auto rect = group.getProperty<MeasurementFrameGroupRectangle>(frame_index);
   auto weight = VectorImage<SeFloat>::create(rect.getWidth(), rect.getHeight());
-  std::fill(weight->getData().begin(), weight->getData().end(), 1);
 
   for (int y = 0; y < rect.getHeight(); y++) {
     for (int x = 0; x < rect.getWidth(); x++) {
       auto back_var = variance_map->getValue(rect.getTopLeft().m_x + x, rect.getTopLeft().m_y + y);
-      if (saturation > 0 && frame_image->getValue(rect.getTopLeft().m_x + x, rect.getTopLeft().m_y + y) > saturation) {
+      auto pixel_val = frame_image->getValue(rect.getTopLeft().m_x + x, rect.getTopLeft().m_y + y);
+      if (saturation > 0 && pixel_val > saturation) {
         weight->at(x, y) = 0;
-      } else if (weight->at(x, y) > 0) {
-        if (gain > 0.0) {
-          weight->at(x, y) = sqrt(
-            1.0 / (back_var + frame_image->getValue(rect.getTopLeft().m_x + x, rect.getTopLeft().m_y + y) / gain));
-        } else {
-          weight->at(x, y) = sqrt(1.0 / back_var); // infinite gain
-        }
+      }
+      else if (gain > 0.0 && pixel_val > 0.0) {
+        weight->at(x, y) = sqrt(1.0 / (back_var + pixel_val / gain));
+      }
+      else {
+        weight->at(x, y) = sqrt(1.0 / back_var); // infinite gain
       }
     }
   }


### PR DESCRIPTION
Fixes #326.

Two changes here, really

1. Write into the catalog the stop reason, and flag as ERROR if the stop reason is not due to convergence (i.e. 7 = NaN or Inf)
2. Clip negative flux values to 0, avoiding NaN on the weight map