### PR TITLE
Use Alexandria 2.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(ElementsProject)
 #---------------------------------------------------------------
 
 # Declare project name and version
-elements_project(SourceXtractorPlusPlus 0.15 USE Alexandria 2.18)
+elements_project(SourceXtractorPlusPlus 0.15 USE Alexandria 2.19)


### PR DESCRIPTION
Which has been [just released](https://github.com/astrorama/Alexandria/releases/tag/2.19)

This is required for #327, and for a fix I have for what I think is the root cause of #334 (in any case, it is required to fix a bug when an unhandled exception is raised on the multithreaded measurement)