### PR TITLE
Fix: stall/crash on exception

### DIFF
--- a/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
@@ -44,6 +44,8 @@ public:
         m_group_counter(0),
         m_input_done(false), m_abort_raised(false) {}
 
+  virtual ~MultithreadedMeasurement();
+
   void handleMessage(const std::shared_ptr<SourceGroupInterface>& source_group) override;
 
   void startThreads() override;

--- a/SEImplementation/src/lib/Configuration/ModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/ModelFittingConfig.cpp
@@ -186,8 +186,8 @@ void ModelFittingConfig::initializeInner() {
     }
 
     auto dependent_func = [py_func](const std::shared_ptr<CoordinateSystem> &cs, const std::vector<double> &params) -> double {
+      GILStateEnsure ensure;
       try {
-        GILStateEnsure ensure;
         PythonInterpreter::getSingleton().setCoordinateSystem(cs);
         return py::extract<double>((*py_func)(*py::tuple(params)));
       }

--- a/SEImplementation/src/lib/Configuration/MultiThreadingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MultiThreadingConfig.cpp
@@ -49,7 +49,9 @@ void MultiThreadingConfig::initialize(const UserValues& args) {
   else if (m_threads_nb < -1) {
     throw Elements::Exception("Invalid number of threads.");
   }
-  m_thread_pool = std::make_shared<Euclid::ThreadPool>(m_threads_nb);
+  if (m_threads_nb > 0) {
+    m_thread_pool = std::make_shared<Euclid::ThreadPool>(m_threads_nb);
+  }
 }
 
 } // SourceXtractor namespace

--- a/SEImplementation/src/lib/Measurement/MultithreadedMeasurement.cpp
+++ b/SEImplementation/src/lib/Measurement/MultithreadedMeasurement.cpp
@@ -34,6 +34,12 @@ static Elements::Logging logger = Elements::Logging::getLogger("Multithreading")
 
 std::recursive_mutex MultithreadedMeasurement::g_global_mutex;
 
+MultithreadedMeasurement::~MultithreadedMeasurement() {
+  if (m_output_thread->joinable()) {
+    m_output_thread->join();
+  }
+}
+
 void MultithreadedMeasurement::startThreads() {
   m_output_thread = Euclid::make_unique<std::thread>(outputThreadStatic, this);
 }
@@ -86,7 +92,7 @@ void MultithreadedMeasurement::outputThreadStatic(MultithreadedMeasurement *meas
 }
 
 void MultithreadedMeasurement::outputThreadLoop() {
-  while (true) {
+  while (m_thread_pool->activeThreads() > 0) {
     std::unique_lock<std::mutex> output_lock(m_output_queue_mutex);
 
     // Wait for something in the output queue

--- a/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
+++ b/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
@@ -79,7 +79,7 @@ void Prefetcher::requestProperty(const PropertyId& property_id) {
 void Prefetcher::outputLoop() {
   logger.debug() << "Starting prefetcher output loop";
 
-  while (true) {
+  while (m_thread_pool->activeThreads() > 0) {
     std::unique_lock<std::mutex> output_lock(m_queue_mutex);
 
     // Wait for something new


### PR DESCRIPTION
I think these are two closely related bugs, crashing or stalling depending on your chances/configuration.

First, the expression inside a `DependentParameter` raises an exception.
The GIL is acquired only while inside the `try`. This introduces a race condition, since by the time `pyToElementsException` tries to translate the exception to C++, the error may have been cleared by the interpreter on a different thread. This is fixed by  784220a.

Second, `pyToElementsException` throws another exception, as the error type is `null`. This exception is of type `boost::python::already_set`, which is unknown outside of the Python side (and does not inherit from `std::exception`)

Third, a worker thread dies due to this exception. It stores a pointer into it, though.

Now, depending on your luck

* Either the process stalls, because the source that triggered the exception will never be done, and everything else will be waiting for it (and/or you run out of worker threads and nothing moves anymore)

* The destructor of `MultithreadedMeasurement` is called, which tries to destroy a running attached thread. This triggers a call to `std::terminate`, aborting the process (I think this is the root cause of #334). No chance to let you know what failed.  fdb87b8  should fix this.

Additionally,  df7c3bd makes single-threaded really single-threaded.