### PR TITLE
fixed regression when opening FITS files for append

### DIFF
--- a/SEFramework/SEFramework/FITS/FitsFile.h
+++ b/SEFramework/SEFramework/FITS/FitsFile.h
@@ -54,14 +54,17 @@ public:
 
   std::map<std::string, MetadataEntry>& getHDUHeaders(int hdu);
 
+  void refresh();
+
 private:
-  boost::filesystem::path                           m_path;
-  bool                                              m_is_writeable;
-  std::unique_ptr<fitsfile, void (*)(fitsfile*)>    m_fits_ptr;
-  std::vector<int>                                  m_image_hdus;
+  boost::filesystem::path m_path;
+  bool m_is_writeable;
+  std::unique_ptr<fitsfile, void (*)(fitsfile*)> m_fits_ptr;
+  std::vector<int> m_image_hdus;
   std::vector<std::map<std::string, MetadataEntry>> m_headers;
 
   void open();
+  void loadInfo();
   void loadFitsHeader();
   void loadHeadFile();
 };

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -117,7 +117,6 @@ FitsImageSource::FitsImageSource(const std::string& filename, int width, int hei
     // delete file if it exists already
     boost::filesystem::remove(m_filename);
   }
-
   auto acc  = m_handler->getAccessor<FitsFile>(FileHandler::kWrite);
   fptr = acc->m_fd.getFitsFilePtr();
 
@@ -170,6 +169,13 @@ FitsImageSource::FitsImageSource(const std::string& filename, int width, int hei
   }
 
   acc->m_fd.refresh(); // make sure changes to the file structure are taken into account
+
+  // work around for canonical name bug:
+  // our file's canonical name might be wrong if it didn't exist, so we need to make sure we get the correct handler
+  // after we created the file
+
+  m_handler = nullptr;
+  m_handler = manager->getFileHandler(filename);
 }
 
 std::shared_ptr<ImageTile> FitsImageSource::getImageTile(int x, int y, int width, int height) const {

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -117,58 +117,62 @@ FitsImageSource::FitsImageSource(const std::string& filename, int width, int hei
     // delete file if it exists already
     boost::filesystem::remove(m_filename);
   }
-  auto acc  = m_handler->getAccessor<FitsFile>(FileHandler::kWrite);
-  fptr = acc->m_fd.getFitsFilePtr();
 
-  assert(fptr != nullptr);
+  {
+    auto acc  = m_handler->getAccessor<FitsFile>(FileHandler::kWrite);
+    fptr = acc->m_fd.getFitsFilePtr();
 
-  if (empty_primary &&  acc->m_fd.getImageHdus().size() == 0) {
-    fits_create_img(fptr, FLOAT_IMG, 0, nullptr, &status);
-    if (status != 0) {
-      throw Elements::Exception() << "Can't create empty hdu: " << filename << " status: " << status;
-    }
-  }
+    assert(fptr != nullptr);
 
-  long naxes[2] = {width, height};
-  fits_create_img(fptr, getImageType(), 2, naxes, &status);
-
-  if (fits_get_hdu_num(fptr, &m_hdu_number) < 0) {
-    throw Elements::Exception() << "Can't get the active HDU from the FITS file: " << filename << " status: " << status;
-  }
-
-  int hdutype = 0;
-  fits_movabs_hdu(fptr, m_hdu_number, &hdutype, &status);
-
-  if (coord_system) {
-    auto headers = coord_system->getFitsHeaders();
-    for (auto& h : headers) {
-      std::ostringstream padded_key, serializer;
-      padded_key << std::setw(8) << std::left << h.first;
-
-      serializer << padded_key.str() << "= " << std::left << std::setw(70) << h.second;
-      auto str = serializer.str();
-
-      fits_update_card(fptr, padded_key.str().c_str(), str.c_str(), &status);
+    if (empty_primary &&  acc->m_fd.getImageHdus().size() == 0) {
+      fits_create_img(fptr, FLOAT_IMG, 0, nullptr, &status);
       if (status != 0) {
-        char err_txt[31];
-        fits_get_errstatus(status, err_txt);
-        throw Elements::Exception() << "Couldn't write the WCS headers (" << err_txt << "): " << str << " status: " << status;
+        throw Elements::Exception() << "Can't create empty hdu: " << filename << " status: " << status;
       }
     }
-  }
 
-  std::vector<char> buffer(width * ImageTile::getTypeSize(image_type));
-  for (int i = 0; i < height; i++) {
-    long first_pixel[2] = {1, i + 1};
-    fits_write_pix(fptr, getDataType(), first_pixel, width, &buffer[0], &status);
-  }
-  fits_close_file(fptr, &status);
+    long naxes[2] = {width, height};
+    fits_create_img(fptr, getImageType(), 2, naxes, &status);
 
-  if (status != 0) {
-    throw Elements::Exception() << "Couldn't allocate space for new FITS file: " << filename << " status: " << status;
-  }
+    if (fits_get_hdu_num(fptr, &m_hdu_number) < 0) {
+      throw Elements::Exception() << "Can't get the active HDU from the FITS file: " << filename << " status: " << status;
+    }
 
-  acc->m_fd.refresh(); // make sure changes to the file structure are taken into account
+    int hdutype = 0;
+    fits_movabs_hdu(fptr, m_hdu_number, &hdutype, &status);
+
+    if (coord_system) {
+      auto headers = coord_system->getFitsHeaders();
+      for (auto& h : headers) {
+        std::ostringstream padded_key, serializer;
+        padded_key << std::setw(8) << std::left << h.first;
+
+        serializer << padded_key.str() << "= " << std::left << std::setw(70) << h.second;
+        auto str = serializer.str();
+
+        fits_update_card(fptr, padded_key.str().c_str(), str.c_str(), &status);
+        if (status != 0) {
+          char err_txt[31];
+          fits_get_errstatus(status, err_txt);
+          throw Elements::Exception() << "Couldn't write the WCS headers (" << err_txt << "): " << str << " status: " << status;
+        }
+      }
+    }
+
+    std::vector<char> buffer(width * ImageTile::getTypeSize(image_type));
+    for (int i = 0; i < height; i++) {
+      long first_pixel[2] = {1, i + 1};
+      fits_write_pix(fptr, getDataType(), first_pixel, width, &buffer[0], &status);
+    }
+    fits_close_file(fptr, &status);
+
+    if (status != 0) {
+      throw Elements::Exception() << "Couldn't allocate space for new FITS file: " << filename << " status: " << status;
+    }
+
+    acc->m_fd.refresh(); // make sure changes to the file structure are taken into account
+
+  }
 
   // work around for canonical name bug:
   // our file's canonical name might be wrong if it didn't exist, so we need to make sure we get the correct handler

--- a/SEFramework/tests/src/FITS/FitsImageSource_test.cpp
+++ b/SEFramework/tests/src/FITS/FitsImageSource_test.cpp
@@ -22,16 +22,20 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "ElementsKernel/Temporary.h"
 #include <ElementsKernel/Auxiliary.h>
 #include <ElementsKernel/Real.h>
+
+#include "SEFramework/Image/WriteableBufferedImage.h"
 #include "SEFramework/FITS/FitsImageSource.h"
 
 using namespace SourceXtractor;
 
 struct FitsImageSourceFixture {
   std::string mhdu_path, primary_path;
+  Elements::TempFile temp_path;
 
-  FitsImageSourceFixture() {
+  FitsImageSourceFixture() : temp_path("FitsImageSource_test_%%%%%%.fits") {
     mhdu_path = Elements::getAuxiliaryPath("multiple_hdu.fits").native();
     primary_path = Elements::getAuxiliaryPath("with_primary.fits").native();
   }
@@ -118,6 +122,38 @@ BOOST_FIXTURE_TEST_CASE(bad_hdu_test, FitsImageSourceFixture) {
 BOOST_FIXTURE_TEST_CASE(empty_primary_hdu_test, FitsImageSourceFixture) {
   BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[0]"), Elements::Exception);
   BOOST_CHECK_THROW(std::make_shared<FitsImageSource>(mhdu_path + "[PRIMARY]"), Elements::Exception);
+}
+
+BOOST_FIXTURE_TEST_CASE(open_write_close_append, FitsImageSourceFixture) {
+  // Test creating a FITS file then reopening it to append to it
+  {
+    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(),
+        100, 100, ImageTile::FloatImage, nullptr, false);
+    auto image = WriteableBufferedImage<float>::create(image_source);
+    image->setValue(10, 10, 123.f);
+  }
+  {
+    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(),
+        100, 100, ImageTile::FloatImage, nullptr, true);
+    auto image = WriteableBufferedImage<float>::create(image_source);
+    BOOST_CHECK_EQUAL(image->getValue(10, 10), 0);
+    image->setValue(10, 10, 42.f);
+  }
+
+  // We need to flush as we don't recognize reopening the same file as being the same ImageSource
+  // (we also need a flush at some point to prevent error due to elements deleting the tmp file before destructor)
+  TileManager::getInstance()->flush();
+
+  {
+    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(), 1);
+    auto image = BufferedImage<float>::create(image_source);
+    BOOST_CHECK_EQUAL(image->getValue(10, 10), 123.f);
+  }
+  {
+    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(), 2);
+    auto image = BufferedImage<float>::create(image_source);
+    BOOST_CHECK_EQUAL(image->getValue(10, 10), 42.f);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/SEFramework/tests/src/FITS/FitsImageSource_test.cpp
+++ b/SEFramework/tests/src/FITS/FitsImageSource_test.cpp
@@ -128,7 +128,7 @@ BOOST_FIXTURE_TEST_CASE(open_write_close_append, FitsImageSourceFixture) {
   // Test creating a FITS file then reopening it to append to it
   {
     auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(),
-        100, 100, ImageTile::FloatImage, nullptr, false);
+        100, 100, ImageTile::FloatImage, nullptr, false, true);
     auto image = WriteableBufferedImage<float>::create(image_source);
     image->setValue(10, 10, 123.f);
   }
@@ -145,12 +145,12 @@ BOOST_FIXTURE_TEST_CASE(open_write_close_append, FitsImageSourceFixture) {
   TileManager::getInstance()->flush();
 
   {
-    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(), 1);
+    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(), 2);
     auto image = BufferedImage<float>::create(image_source);
     BOOST_CHECK_EQUAL(image->getValue(10, 10), 123.f);
   }
   {
-    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(), 2);
+    auto image_source = std::make_shared<FitsImageSource>(temp_path.path().native(), 3);
     auto image = BufferedImage<float>::create(image_source);
     BOOST_CHECK_EQUAL(image->getValue(10, 10), 42.f);
   }


### PR DESCRIPTION
The switch to the new multi-threaded file manager introduced some problems with the way FITS file were created in FitsImageSource, in particular the append mode which is not used in SourceXtractor++ but in the CutOut tool wasn't working anymore.

A potential problem still remains with the tile cache as several ImageSources can point to the same file. In that case, changes need to be manually flushed before they will be available when reopening the file. I don't think this is a big deal but it something that could potentially cause problems in the future if we are not careful.
