### PR TITLE
Disable MKL multithreading (if needed)

### DIFF
--- a/SEMain/src/program/SourceXtractor.cpp
+++ b/SEMain/src/program/SourceXtractor.cpp
@@ -20,10 +20,11 @@
  * @author mschefer
  */
 
-#include <typeinfo>
+#include <dlfcn.h>
+#include <iomanip>
 #include <map>
 #include <string>
-#include <iomanip>
+#include <typeinfo>
 
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/predicate.hpp>

--- a/SEMain/src/program/SourceXtractor.cpp
+++ b/SEMain/src/program/SourceXtractor.cpp
@@ -124,6 +124,29 @@ static void setupEnvironment(void) {
   }
 }
 
+/**
+ * MKL blas implementation use multithreading by default, which
+ * tends to play badly with sourcextractor++ own multithreading.
+ * We disable multithreading here *unless* explicitly enabled by the user via
+ * environment variables
+ */
+static void disableBlasMultithreading() {
+  bool omp_env_present = getenv("OMP_NUM_THREADS") || getenv("OMP_DYNAMIC");
+  bool mkl_env_present = getenv("MKL_NUM_THREADS") || getenv("MKL_DYNAMIC");
+  if (!omp_env_present && !mkl_env_present) {
+    // Despite the documentation, the methods following C ABI are capitalized
+    void (*set_num_threads)(int) = reinterpret_cast<void (*)(int)>(dlsym(RTLD_DEFAULT, "MKL_Set_Num_Threads"));
+    void (*set_dynamic)(int)     = reinterpret_cast<void (*)(int)>(dlsym(RTLD_DEFAULT, "MKL_Set_Dynamic"));
+    if (set_num_threads) {
+      logger.debug() << "Disabling multithreading";
+      set_num_threads(1);
+    }
+    if (set_dynamic) {
+      logger.debug() << "Disabling dynamic multithreading";
+      set_dynamic(0);
+    }
+  }
+}
 
 class SEMain : public Elements::Program {
 
@@ -280,6 +303,9 @@ public:
       printDefaults();
       return Elements::ExitCode::OK;
     }
+
+    // Make sure the BLAS multithreading does not interfere
+    disableBlasMultithreading();
 
     // Elements does not verify that the config-file exists. It will just not read it.
     // We verify that it does exist here.


### PR DESCRIPTION
Fixes #333

If any of the environment variables `OMP_NUM_THREADS`, `OMP_DYNAMIC`, `MKL_NUM_THREADS` or `MKL_DYNAMIC` is present, then it is not disabled.

If they are not, it uses `dlsym` to find the symbols required to disable multithreading. This works without adding an extra dependency to the build, and is portable even if another BLAS implementation has been used when building fftw and levmar.

I have checked on my laptop that the conda build tried to use the 8 cores on develop (on top of the existing sourcextractor threads), but it stays at 4 cores usages with this patch.