### PR TITLE
Add a hard limit to group size

### DIFF
--- a/SEFramework/SEFramework/Pipeline/SourceGrouping.h
+++ b/SEFramework/SEFramework/Pipeline/SourceGrouping.h
@@ -112,7 +112,8 @@ public:
   virtual ~SourceGrouping() = default;
 
   SourceGrouping(std::shared_ptr<GroupingCriteria> grouping_criteria,
-                 std::shared_ptr<SourceGroupFactory> group_factory);
+                 std::shared_ptr<SourceGroupFactory> group_factory,
+                 unsigned int hard_limit);
 
   /// Handles a new Source
   virtual void handleMessage(const std::shared_ptr<SourceInterface>& source) override;
@@ -128,6 +129,7 @@ private:
   std::shared_ptr<GroupingCriteria> m_grouping_criteria;
   std::shared_ptr<SourceGroupFactory> m_group_factory;
   std::list<std::shared_ptr<SourceGroupInterface>> m_source_groups;
+  unsigned int m_hard_limit;
 
 }; /* End of SourceGrouping class */
 

--- a/SEImplementation/SEImplementation/Configuration/GroupingConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/GroupingConfig.h
@@ -66,10 +66,15 @@ public:
     return m_moffat_max_distance;
   }
 
+  unsigned int getHardLimit() const {
+    return m_hard_limit;
+  }
+
 private:
   Algorithm m_selected_algorithm;
   double m_moffat_threshold;
   double m_moffat_max_distance;
+  unsigned int m_hard_limit;
 
 }; /* End of GroupingConfig class */
 

--- a/SEImplementation/SEImplementation/Grouping/GroupingFactory.h
+++ b/SEImplementation/SEImplementation/Grouping/GroupingFactory.h
@@ -43,7 +43,7 @@ class GroupingFactory : public Configurable {
 public:
 
   GroupingFactory(std::shared_ptr<SourceGroupFactory> source_group_factory)
-    : m_source_group_factory(source_group_factory) {}
+    : m_source_group_factory(source_group_factory), m_hard_limit(0) {}
 
   virtual ~GroupingFactory() = default;
 
@@ -67,18 +67,20 @@ public:
       m_grouping_criteria = std::make_shared<MoffatCriteria>(grouping_config.getMoffatThreshold(), grouping_config.getMoffatMaxDistance());
       break;
     }
+    m_hard_limit = grouping_config.getHardLimit();
   }
 
   std::shared_ptr<SourceGrouping> createGrouping() const {
     assert(m_grouping_criteria != nullptr);
     assert(m_source_group_factory != nullptr);
 
-    return std::make_shared<SourceGrouping>(m_grouping_criteria, m_source_group_factory);
+    return std::make_shared<SourceGrouping>(m_grouping_criteria, m_source_group_factory, m_hard_limit);
   }
 
 private:
   std::shared_ptr<GroupingCriteria> m_grouping_criteria;
   std::shared_ptr<SourceGroupFactory> m_source_group_factory;
+  unsigned int m_hard_limit;
 };
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/src/lib/Configuration/GroupingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/GroupingConfig.cpp
@@ -34,6 +34,7 @@ namespace po = boost::program_options;
 namespace SourceXtractor {
 
 static const std::string GROUPING_ALGORITHM {"grouping-algorithm" };
+static const std::string GROUPING_HARD_LIMIT {"grouping-hard-limit" };
 static const std::string GROUPING_MOFFAT_THRESHOLD {"grouping-moffat-threshold" };
 static const std::string GROUPING_MOFFAT_MAX_DISTANCE {"grouping-moffat-max-distance" };
 
@@ -43,13 +44,16 @@ static const std::string GROUPING_ALGORITHM_SPLIT {"SPLIT" };
 static const std::string GROUPING_ALGORITHM_MOFFAT {"MOFFAT" };
 
 GroupingConfig::GroupingConfig(long manager_id)
-    : Configuration(manager_id), m_selected_algorithm(Algorithm::SPLIT_SOURCES), m_moffat_threshold(0.02), m_moffat_max_distance(300) {
+    : Configuration(manager_id),
+      m_selected_algorithm(Algorithm::SPLIT_SOURCES), m_moffat_threshold(0.02), m_moffat_max_distance(300), m_hard_limit(0) {
 }
 
 std::map<std::string, Configuration::OptionDescriptionList> GroupingConfig::getProgramOptions() {
   return { {"Grouping", {
       {GROUPING_ALGORITHM.c_str(), po::value<std::string>()->default_value(GROUPING_ALGORITHM_NONE),
           "Grouping algorithm to be used [none|overlap|split|moffat]."},
+      {GROUPING_HARD_LIMIT.c_str(), po::value<unsigned int>()->default_value(0),
+          "Maximum number of sources in a single group (0 = unlimited)"},
       {GROUPING_MOFFAT_THRESHOLD.c_str(), po::value<double>()->default_value(0.02),
           "Threshold used for Moffat grouping."},
       {GROUPING_MOFFAT_MAX_DISTANCE.c_str(), po::value<double>()->default_value(300),
@@ -76,6 +80,9 @@ void GroupingConfig::initialize(const UserValues& args) {
   }
   if (args.find(GROUPING_MOFFAT_MAX_DISTANCE) != args.end()) {
     m_moffat_max_distance = args.find(GROUPING_MOFFAT_MAX_DISTANCE)->second.as<double>();
+  }
+  if (args.find(GROUPING_HARD_LIMIT) != args.end()) {
+    m_hard_limit = args.find(GROUPING_HARD_LIMIT)->second.as<unsigned int>();
   }
 }
 


### PR DESCRIPTION
Adds a hard limit to groups to diagnose and work around performance issues related to large groups.

Currently this is done by preventing groups over `--grouping-hard-limit` from being created. This can result in some groups not being merged at all so the result could be several groups well under the limit.

There are no flags as this method can't guarantee correct flagging.

If this proves useful then a more advanced method could still allow the groups to be created and then try to split them "intelligently" though the exact method for that is not clear.

So for now this really should be used as a last resort to avoid problems and not as a correct way to handle large groups.
