### PR TITLE
Fix: Comment out options that receive a list of strings and have an empty default

### DIFF
--- a/SEMain/src/lib/PluginConfig.cpp
+++ b/SEMain/src/lib/PluginConfig.cpp
@@ -47,6 +47,7 @@ std::map<std::string, Configuration::OptionDescriptionList> PluginConfig::getPro
 void PluginConfig::initialize(const UserValues& args) {
   m_plugin_path = args.at(PLUGIN_DIRECTORY).as<std::string>();
   m_plugin_list = args.at(PLUGIN).as<std::vector<std::string>>();
+  m_plugin_list.erase(std::remove(m_plugin_list.begin(), m_plugin_list.end(), ""), m_plugin_list.end());
 }
 
 std::string PluginConfig::getPluginPath() const {

--- a/SEMain/src/program/SourceXtractor.cpp
+++ b/SEMain/src/program/SourceXtractor.cpp
@@ -239,7 +239,7 @@ public:
   static void writeDefaultMultiple(std::ostream& out, const po::option_description& opt, const boost::any& default_value) {
     auto values = boost::any_cast<std::vector<T>>(default_value);
     if (values.empty()) {
-      out << opt.long_name() << '=' << std::endl;
+      out << "# " << opt.long_name() << '=' << std::endl;
     }
     else {
       for (const auto& v : values)


### PR DESCRIPTION
While on it, and to avoid frictions, ignore empty occurrences of `plugin=`

Fixes #352