### PR TITLE
refresh() closes the file descriptor

### DIFF
--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -164,7 +164,6 @@ FitsImageSource::FitsImageSource(const std::string& filename, int width, int hei
       long first_pixel[2] = {1, i + 1};
       fits_write_pix(fptr, getDataType(), first_pixel, width, &buffer[0], &status);
     }
-    fits_close_file(fptr, &status);
 
     if (status != 0) {
       throw Elements::Exception() << "Couldn't allocate space for new FITS file: " << filename << " status: " << status;


### PR DESCRIPTION
Otherwise, there are two closes, which is a use-after-free.

I think this is the reason for the crash that @mkuemmel is having. I managed to reproduce it, and this seems to fix it.