### PR TITLE
Update Alexandria dependency to 2.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(ElementsProject)
 #---------------------------------------------------------------
 
 # Declare project name and version
-elements_project(SourceXtractorPlusPlus 0.16 USE Alexandria 2.19)
+elements_project(SourceXtractorPlusPlus 0.16 USE Alexandria 2.21.0)


### PR DESCRIPTION
[Alexandria 2.21.0 release notes](https://github.com/astrorama/Alexandria/releases/tag/2.21.0)
And [2.20](https://github.com/astrorama/Alexandria/releases/tag/2.20), which we jumped over

Notice how this releases stars using Elements 5.12.0, which should ease friction with Euclid releases.