### PR TITLE
Call saveIfModified from ~ImageTileWithType

### DIFF
--- a/SEFramework/SEFramework/Image/ImageTile.h
+++ b/SEFramework/SEFramework/Image/ImageTile.h
@@ -45,9 +45,7 @@ public:
 
   static std::shared_ptr<ImageTile> create(ImageType image_type, int x, int y, int width, int height, std::shared_ptr<ImageSource> source=nullptr);
 
-  virtual ~ImageTile() {
-    saveIfModified();
-  }
+  virtual ~ImageTile() = default;
 
   bool isPixelInTile(int x, int y) const {
     return x >= m_x && y >= m_y && x < m_max_x && y < m_max_y;
@@ -94,7 +92,7 @@ public:
     return m_modified;
   }
 
-  virtual void saveIfModified();
+  void saveIfModified();
 
   static ImageType getTypeValue(float) {
     return FloatImage;
@@ -163,6 +161,10 @@ public:
   ImageTileWithType(int x, int y, int width, int height, std::shared_ptr<ImageSource> source)
       : ImageTile(getTypeValue(T()), x, y, width, height, source) {
     m_tile_image = VectorImage<T>::create(width, height);
+  }
+
+  virtual ~ImageTileWithType() {
+    saveIfModified();
   }
 
   int getTileMemorySize() const override {


### PR DESCRIPTION
Fixes #380 , may fix #369 

`saveIfModified` depends on `ImageTileWithType` being still valid, which is not the case if called from the destructor of the base 
class. By that time, the derived `ImageTileWithType` has been destroyed, and the pure virtual methods would be undefined.

Calling `saveIfModified` from the destructor of the derived class is enough to guarantee the state is still valid.