### PR TITLE
Bugfix/aper checkimages

### DIFF
--- a/SEFramework/SEFramework/Aperture/Aperture.h
+++ b/SEFramework/SEFramework/Aperture/Aperture.h
@@ -35,6 +35,8 @@ public:
 
   virtual SeFloat getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const = 0;
 
+  virtual SeFloat drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const = 0;
+
   virtual PixelCoordinate getMinPixel(SeFloat centroid_x, SeFloat centroid_y) const = 0;
 
   virtual PixelCoordinate getMaxPixel(SeFloat centroid_x, SeFloat centroid_y) const = 0;

--- a/SEFramework/SEFramework/Aperture/CircularAperture.h
+++ b/SEFramework/SEFramework/Aperture/CircularAperture.h
@@ -36,6 +36,8 @@ public:
 
   SeFloat getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const override;
 
+  SeFloat drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const override;
+
   PixelCoordinate getMinPixel(SeFloat centroid_x, SeFloat centroid_y) const override;
 
   PixelCoordinate getMaxPixel(SeFloat centroid_x, SeFloat centroid_y) const override;

--- a/SEFramework/SEFramework/Aperture/EllipticalAperture.h
+++ b/SEFramework/SEFramework/Aperture/EllipticalAperture.h
@@ -36,6 +36,8 @@ public:
 
   SeFloat getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const override;
 
+  SeFloat drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const override;
+
   PixelCoordinate getMinPixel(SeFloat centroid_x, SeFloat centroid_y) const override;
 
   PixelCoordinate getMaxPixel(SeFloat centroid_x, SeFloat centroid_y) const override;

--- a/SEFramework/SEFramework/Aperture/FluxMeasurement.h
+++ b/SEFramework/SEFramework/Aperture/FluxMeasurement.h
@@ -94,6 +94,37 @@ void fillAperture(const std::shared_ptr<Aperture> &aperture, SeFloat centroid_x,
   }
 }
 
+/**
+ * Draws the pixels that fall within the aperture with the given value. Useful for debugging.
+ * @tparam T
+ * @param aperture
+ *  Aperture to use
+ * @param centroid_x
+ *  Center of the aperture on the X axis
+ * @param centroid_y
+ *  Center of the aperture on the Y axis
+ * @param img
+ *  Image to modify
+ * @param value
+ *  Value to use for the fill
+ */
+template <typename T>
+void drawAperture(const std::shared_ptr<Aperture> &aperture, SeFloat centroid_x, SeFloat centroid_y,
+                  const std::shared_ptr<WriteableImage<T>> &img, T value) {
+  auto min_pixel = aperture->getMinPixel(centroid_x, centroid_y);
+  auto max_pixel = aperture->getMaxPixel(centroid_x, centroid_y);
+
+  for (int y = min_pixel.m_y; y <= max_pixel.m_y; ++y) {
+    for (int x = min_pixel.m_x; x <= max_pixel.m_x; ++x) {
+      if (aperture->drawArea(centroid_x, centroid_y, x, y) > 0) {
+        if (x >= 0 && y >= 0 && x < img->getWidth() && y < img->getHeight()) {
+          img->setValue(x, y, value);
+        }
+      }
+    }
+  }
+}
+
 } // end SourceXtractor
 
 #endif // _SEFRAMEWORK_SEFRAMEWORK_APERTURE_MEASUREFLUX_H

--- a/SEFramework/SEFramework/Aperture/TransformedAperture.h
+++ b/SEFramework/SEFramework/Aperture/TransformedAperture.h
@@ -36,6 +36,8 @@ public:
 
   SeFloat getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const override;
 
+  SeFloat drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const override;
+
   PixelCoordinate getMinPixel(SeFloat centroid_x, SeFloat centroid_y) const override;
 
   PixelCoordinate getMaxPixel(SeFloat centroid_x, SeFloat centroid_y) const override;

--- a/SEFramework/src/lib/Aperture/CircularAperture.cpp
+++ b/SEFramework/src/lib/Aperture/CircularAperture.cpp
@@ -55,19 +55,18 @@ SeFloat CircularAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pi
 }
 
 SeFloat CircularAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
-	SeFloat rim = 0;
-	SeFloat thickness = 1.0;
+	SeFloat thickness = 0.5;
 
-	SeFloat min_supersampled_radius_squared = m_radius > thickness ? (m_radius - thickness) * (m_radius - thickness) : 0;
-	SeFloat max_supersampled_radius_squared = (m_radius + .75) * (m_radius + .75);
+	// define an inner and an outer radius
+	SeFloat min_radius_squared = m_radius > thickness ? (m_radius - thickness) * (m_radius - thickness) : 0;
+	SeFloat max_radius_squared = (m_radius + thickness) * (m_radius + thickness);
 
+	// compare the actual radius against the inner and outer radius
 	auto distance_squared = getRadiusSquared(center_x, center_y, pixel_x, pixel_y);
-
-	//if (distance_squared >= min_supersampled_radius_squared && distance_squared <= max_supersampled_radius_squared) {
-	if (min_supersampled_radius_squared < distance_squared && distance_squared <= max_supersampled_radius_squared) {
-		rim = 1.0;
+	if (min_radius_squared < distance_squared && distance_squared <= max_radius_squared) {
+		return 1.0;
 	}
-	return rim;
+	return 0.0;
 }
 
 SeFloat CircularAperture::getRadiusSquared(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {

--- a/SEFramework/src/lib/Aperture/CircularAperture.cpp
+++ b/SEFramework/src/lib/Aperture/CircularAperture.cpp
@@ -31,15 +31,18 @@ const int SUPERSAMPLE_NB = 10;
 SeFloat CircularAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
   auto dx = pixel_x - center_x;
   auto dy = pixel_y - center_y;
-  SeFloat min_supersampled_radius_squared = m_radius > .75 ? (m_radius - .75) * (m_radius - .75) : 0;
+  //SeFloat min_supersampled_radius_squared = m_radius > .75 ? (m_radius - .75) * (m_radius - .75) : 0;
+  //SeFloat max_supersampled_radius_squared = (m_radius + .75) * (m_radius + .75);
+  SeFloat min_supersampled_radius_squared = m_radius > .1 ? (m_radius - 1) * (m_radius - 1) : 0;
   SeFloat max_supersampled_radius_squared = (m_radius + .75) * (m_radius + .75);
 
   auto distance_squared = dx * dx + dy * dy;
   SeFloat area = 0.0;
-  if (distance_squared < min_supersampled_radius_squared) {
-    area = 1.0;
-  }
-  else if (distance_squared <= max_supersampled_radius_squared) {
+  //if (distance_squared < min_supersampled_radius_squared) {
+  //  area = 1.0;
+  //}
+  //else if (distance_squared <= max_supersampled_radius_squared) {
+  if (distance_squared >= min_supersampled_radius_squared && distance_squared <= max_supersampled_radius_squared) {
     for (int sub_y = 0; sub_y < SUPERSAMPLE_NB; sub_y++) {
       for (int sub_x = 0; sub_x < SUPERSAMPLE_NB; sub_x++) {
         auto dx2 = dx + SeFloat(sub_x - SUPERSAMPLE_NB / 2) / SUPERSAMPLE_NB;

--- a/SEFramework/src/lib/Aperture/CircularAperture.cpp
+++ b/SEFramework/src/lib/Aperture/CircularAperture.cpp
@@ -20,7 +20,7 @@
  *  Created on: Oct 08, 2018
  *      Author: Alejandro Alvarez
  */
-
+#include <iostream>
 #include "SEFramework/Aperture/CircularAperture.h"
 
 namespace SourceXtractor {
@@ -31,18 +31,15 @@ const int SUPERSAMPLE_NB = 10;
 SeFloat CircularAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
   auto dx = pixel_x - center_x;
   auto dy = pixel_y - center_y;
-  //SeFloat min_supersampled_radius_squared = m_radius > .75 ? (m_radius - .75) * (m_radius - .75) : 0;
-  //SeFloat max_supersampled_radius_squared = (m_radius + .75) * (m_radius + .75);
-  SeFloat min_supersampled_radius_squared = m_radius > .1 ? (m_radius - 1) * (m_radius - 1) : 0;
+  SeFloat min_supersampled_radius_squared = m_radius > .75 ? (m_radius - .75) * (m_radius - .75) : 0;
   SeFloat max_supersampled_radius_squared = (m_radius + .75) * (m_radius + .75);
 
   auto distance_squared = dx * dx + dy * dy;
   SeFloat area = 0.0;
-  //if (distance_squared < min_supersampled_radius_squared) {
-  //  area = 1.0;
-  //}
-  //else if (distance_squared <= max_supersampled_radius_squared) {
-  if (distance_squared >= min_supersampled_radius_squared && distance_squared <= max_supersampled_radius_squared) {
+  if (distance_squared < min_supersampled_radius_squared) {
+    area = 1.0;
+  }
+  else if (distance_squared <= max_supersampled_radius_squared) {
     for (int sub_y = 0; sub_y < SUPERSAMPLE_NB; sub_y++) {
       for (int sub_x = 0; sub_x < SUPERSAMPLE_NB; sub_x++) {
         auto dx2 = dx + SeFloat(sub_x - SUPERSAMPLE_NB / 2) / SUPERSAMPLE_NB;
@@ -55,6 +52,21 @@ SeFloat CircularAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pi
     }
   }
   return area;
+}
+
+SeFloat CircularAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
+	SeFloat rim = 0;
+	SeFloat thickness = 1.0;
+
+	SeFloat min_supersampled_radius_squared = m_radius > thickness ? (m_radius - thickness) * (m_radius - thickness) : 0;
+	SeFloat max_supersampled_radius_squared = (m_radius + .75) * (m_radius + .75);
+
+	auto distance_squared = getRadiusSquared(center_x, center_y, pixel_x, pixel_y);
+
+	if (distance_squared >= min_supersampled_radius_squared && distance_squared <= max_supersampled_radius_squared) {
+		rim = 1;
+	}
+	return rim;
 }
 
 SeFloat CircularAperture::getRadiusSquared(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {

--- a/SEFramework/src/lib/Aperture/CircularAperture.cpp
+++ b/SEFramework/src/lib/Aperture/CircularAperture.cpp
@@ -63,8 +63,9 @@ SeFloat CircularAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat p
 
 	auto distance_squared = getRadiusSquared(center_x, center_y, pixel_x, pixel_y);
 
-	if (distance_squared >= min_supersampled_radius_squared && distance_squared <= max_supersampled_radius_squared) {
-		rim = 1;
+	//if (distance_squared >= min_supersampled_radius_squared && distance_squared <= max_supersampled_radius_squared) {
+	if (min_supersampled_radius_squared < distance_squared && distance_squared <= max_supersampled_radius_squared) {
+		rim = 1.0;
 	}
 	return rim;
 }

--- a/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
+++ b/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "SEFramework/Aperture/EllipticalAperture.h"
-
+#include <iostream>
 namespace SourceXtractor {
 
 
@@ -32,10 +32,15 @@ EllipticalAperture::EllipticalAperture(SeFloat cxx, SeFloat cyy, SeFloat cxy,
 }
 
 SeFloat EllipticalAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
-  if (getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
-    return 1.0;
-  }
-  return 0.;
+	//std::cout << min_radius << " " << m_rad_max * m_rad_max << std::endl;
+	//if ((m_rad_max * m_rad_max)-2.0 < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+	//auto min_radius = (m_rad_max-1.0) * (m_rad_max-1.0);
+	//if (min_radius < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+	if (getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+
+		return 1.0;
+	}
+	return 0.;
 }
 
 SeFloat EllipticalAperture::getRadiusSquared(SeFloat center_x, SeFloat center_y, SeFloat pixel_x,

--- a/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
+++ b/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
@@ -40,15 +40,18 @@ EllipticalAperture::EllipticalAperture(SeFloat cxx, SeFloat cyy, SeFloat cxy,
   }
 
   SeFloat EllipticalAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
-  	//std::cout << min_radius << " " << m_rad_max * m_rad_max << std::endl;
-  	//if ((m_rad_max * m_rad_max)-2.0 < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
-  	//auto min_radius = (m_rad_max-1.0) * (m_rad_max-1.0);
-  	//if (min_radius < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
-  	if (getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+	  SeFloat thickness = 1.0;
+	  SeFloat rad_min_squared = m_rad_max > thickness ? (m_rad_max - thickness) * (m_rad_max - thickness) : 0;
 
-  		return 1.0;
-  	}
-  	return 0.;
+	  auto distance_squared = getRadiusSquared(center_x, center_y, pixel_x, pixel_y);
+
+	  //if (min_supersampled_radius_squared < distance_squared && distance_squared <= max_supersampled_radius_squared) {
+	  //if ((m_rad_max-1.)*(m_rad_max-1.)< distance_squared && distance_squared < m_rad_max * m_rad_max) {
+	  //if ((m_rad_max*m_rad_max-thickness)< distance_squared && distance_squared < (m_rad_max * m_rad_max)) {
+	  if (rad_min_squared < distance_squared && distance_squared < (m_rad_max * m_rad_max)) {
+		  return 1.0;
+	  }
+	  return 0.;
   }
 
 SeFloat EllipticalAperture::getRadiusSquared(SeFloat center_x, SeFloat center_y, SeFloat pixel_x,

--- a/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
+++ b/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
@@ -31,17 +31,25 @@ EllipticalAperture::EllipticalAperture(SeFloat cxx, SeFloat cyy, SeFloat cxy,
   : m_cxx{cxx}, m_cyy{cyy}, m_cxy{cxy}, m_rad_max{rad_max} {
 }
 
-SeFloat EllipticalAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
-	//std::cout << min_radius << " " << m_rad_max * m_rad_max << std::endl;
-	//if ((m_rad_max * m_rad_max)-2.0 < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
-	//auto min_radius = (m_rad_max-1.0) * (m_rad_max-1.0);
-	//if (min_radius < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
-	if (getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+  SeFloat EllipticalAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
+  	if (getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
 
-		return 1.0;
-	}
-	return 0.;
-}
+  		return 1.0;
+  	}
+  	return 0.;
+  }
+
+  SeFloat EllipticalAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
+  	//std::cout << min_radius << " " << m_rad_max * m_rad_max << std::endl;
+  	//if ((m_rad_max * m_rad_max)-2.0 < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+  	//auto min_radius = (m_rad_max-1.0) * (m_rad_max-1.0);
+  	//if (min_radius < getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+  	if (getRadiusSquared(center_x, center_y, pixel_x, pixel_y) < m_rad_max * m_rad_max) {
+
+  		return 1.0;
+  	}
+  	return 0.;
+  }
 
 SeFloat EllipticalAperture::getRadiusSquared(SeFloat center_x, SeFloat center_y, SeFloat pixel_x,
                                              SeFloat pixel_y) const {

--- a/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
+++ b/SEFramework/src/lib/Aperture/EllipticalAperture.cpp
@@ -41,14 +41,22 @@ EllipticalAperture::EllipticalAperture(SeFloat cxx, SeFloat cyy, SeFloat cxy,
 
   SeFloat EllipticalAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
 	  SeFloat thickness = 1.0;
-	  SeFloat rad_min_squared = m_rad_max > thickness ? (m_rad_max - thickness) * (m_rad_max - thickness) : 0;
+	  SeFloat min_rad_squared = m_rad_max > thickness ? (m_rad_max - thickness) * (m_rad_max - thickness) : 0;
 
-	  auto distance_squared = getRadiusSquared(center_x, center_y, pixel_x, pixel_y);
+	  //SeFloat min_rad_squared = .877777*(m_rad_max*m_rad_max);
+	  //SeFloat min_rad_squared = .877777*(m_rad_max*m_rad_max);
+	  //SeFloat min_rad_squared = .133333*(m_rad_max*m_rad_max) > 6.0 ? .877777*(m_rad_max*m_rad_max) : (m_rad_max*m_rad_max)-6.0;
+
+	  //SeFloat max_rad_squared = (m_rad_max + thickness) * (m_rad_max + thickness);
 
 	  //if (min_supersampled_radius_squared < distance_squared && distance_squared <= max_supersampled_radius_squared) {
 	  //if ((m_rad_max-1.)*(m_rad_max-1.)< distance_squared && distance_squared < m_rad_max * m_rad_max) {
 	  //if ((m_rad_max*m_rad_max-thickness)< distance_squared && distance_squared < (m_rad_max * m_rad_max)) {
-	  if (rad_min_squared < distance_squared && distance_squared < (m_rad_max * m_rad_max)) {
+	  //if (fabs(distance_squared - (m_rad_max * m_rad_max)) < thickness) {
+
+	  auto distance_squared = getRadiusSquared(center_x, center_y, pixel_x, pixel_y);
+	  if (min_rad_squared < distance_squared && distance_squared < (m_rad_max * m_rad_max)) {
+	  //if (min_rad_squared < distance_squared && distance_squared < max_rad_squared) {
 		  return 1.0;
 	  }
 	  return 0.;

--- a/SEFramework/src/lib/Aperture/TransformedAperture.cpp
+++ b/SEFramework/src/lib/Aperture/TransformedAperture.cpp
@@ -90,6 +90,16 @@ SeFloat TransformedAperture::getArea(SeFloat center_x, SeFloat center_y, SeFloat
   return m_decorated->getArea(0, 0, new_diff_x, new_diff_y);
 }
 
+SeFloat TransformedAperture::drawArea(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
+  auto diff_x = pixel_x - center_x;
+  auto diff_y = pixel_y - center_y;
+
+  SeFloat new_diff_x = diff_x * m_inv_transform[0] + diff_y * m_inv_transform[2];
+  SeFloat new_diff_y = diff_x * m_inv_transform[1] + diff_y * m_inv_transform[3];
+
+  return m_decorated->drawArea(0, 0, new_diff_x, new_diff_y);
+}
+
 SeFloat TransformedAperture::getRadiusSquared(SeFloat center_x, SeFloat center_y, SeFloat pixel_x, SeFloat pixel_y) const {
   auto diff_x = pixel_x - center_x;
   auto diff_y = pixel_y - center_y;

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/ApertureFlagTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/ApertureFlagTask.cpp
@@ -70,13 +70,14 @@ void ApertureFlagTask::computeProperties(SourceInterface &source) const {
   // set the source properties
   source.setProperty<ApertureFlag>(all_flags);
 
-  // draw check image
+  // draw check image for all apertures
   auto aperture_check_img = CheckImages::getInstance().getApertureImage();
   if (aperture_check_img) {
-    unsigned int src_id = source.getProperty<SourceID>().getId();
-    auto aperture = std::make_shared<CircularAperture>(m_apertures[0] / 2.);
-
-    fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, src_id);
+	  for (auto aperture_diameter : m_apertures) {
+		  unsigned int src_id = source.getProperty<SourceID>().getId();
+		  auto aperture = std::make_shared<CircularAperture>(aperture_diameter / 2.);
+		  fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+	  }
   }
 }
 

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/ApertureFlagTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/ApertureFlagTask.cpp
@@ -76,7 +76,7 @@ void ApertureFlagTask::computeProperties(SourceInterface &source) const {
 	  for (auto aperture_diameter : m_apertures) {
 		  unsigned int src_id = source.getProperty<SourceID>().getId();
 		  auto aperture = std::make_shared<CircularAperture>(aperture_diameter / 2.);
-		  fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+		  drawAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
 	  }
   }
 }

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryTask.cpp
@@ -113,7 +113,7 @@ void AperturePhotometryTask::computeProperties(SourceInterface &source) const {
     for (auto aperture_diameter : m_apertures) {
     	auto aperture = std::make_shared<TransformedAperture>(std::make_shared<CircularAperture>(aperture_diameter / 2.),
     			jacobian.asTuple());
-    		fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+    		drawAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
     }
 
   }

--- a/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AperturePhotometry/AperturePhotometryTask.cpp
@@ -106,14 +106,16 @@ void AperturePhotometryTask::computeProperties(SourceInterface &source) const {
   // set the source properties
   source.setIndexedProperty<AperturePhotometry>(m_instance, fluxes, fluxes_error, mags, mags_error, flags);
 
-  // Draw the last aperture
-  auto aperture = std::make_shared<TransformedAperture>(std::make_shared<CircularAperture>(m_apertures[0] / 2.),
-                                                        jacobian.asTuple());
-
+  // draw the apertures onto the checkimage
   auto aperture_check_img = CheckImages::getInstance().getApertureImage(m_instance);
   if (aperture_check_img) {
     auto src_id = source.getProperty<SourceID>().getId();
-    fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+    for (auto aperture_diameter : m_apertures) {
+    	auto aperture = std::make_shared<TransformedAperture>(std::make_shared<CircularAperture>(aperture_diameter / 2.),
+    			jacobian.asTuple());
+    		fillAperture<int>(aperture, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+    }
+
   }
 }
 

--- a/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryFlagTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryFlagTask.cpp
@@ -85,7 +85,7 @@ void AutoPhotometryFlagTask::computeProperties(SourceInterface& source) const {
   auto aperture_check_img = CheckImages::getInstance().getAutoApertureImage();
   if (aperture_check_img) {
     auto src_id = source.getProperty<SourceID>().getId();
-    fillAperture<int>(ell_aper, centroid_x, centroid_y, aperture_check_img, src_id);
+    drawAperture<int>(ell_aper, centroid_x, centroid_y, aperture_check_img, src_id);
   }
 }
 

--- a/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryTask.cpp
+++ b/SEImplementation/src/lib/Plugin/AutoPhotometry/AutoPhotometryTask.cpp
@@ -101,7 +101,7 @@ void AutoPhotometryTask::computeProperties(SourceInterface &source) const {
   if (aperture_check_img) {
     auto src_id = source.getProperty<SourceID>().getId();
 
-    fillAperture<int>(ell_aper, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
+    drawAperture<int>(ell_aper, centroid_x, centroid_y, aperture_check_img, static_cast<unsigned>(src_id));
   }
 }
 


### PR DESCRIPTION
Minimal but consistent solution for #371. All circular aperture are shown now, and also the elliptical aperture is shown as the boundary only.