### PR TITLE
Fix a file descriptor leak

### DIFF
--- a/SEFramework/src/lib/FITS/FitsFile.cpp
+++ b/SEFramework/src/lib/FITS/FitsFile.cpp
@@ -117,18 +117,19 @@ void FitsFile::open() {
 
   // Open
   fits_open_image(&ptr, m_path.native().c_str(), m_is_writeable ? READWRITE : READONLY, &status);
+  m_fits_ptr.reset(ptr);
   if (status != 0) {
     if (m_is_writeable) {
       // Create file if it does not exists
       status = 0;
       fits_create_file(&ptr, m_path.native().c_str(), &status);
+      m_fits_ptr.reset(ptr);
     }
     if (status != 0) {
       throw Elements::Exception() << "Can't open FITS file: " << m_path << " status: " << status;
     }
   }
   assert(ptr->Fptr->open_count == 1);
-  m_fits_ptr.reset(ptr);
 }
 
 void FitsFile::refresh() {


### PR DESCRIPTION
It is really small, and I do not think it will matter much. The leak only happens when there is an error opening a file, so in any case sourcextractor will exit. Still, I am cleaning reports from AddressSanitizer and LeakSanitizer (see also astrorama/Alexandria#67)