### PR TITLE
Workaround for bug in boost::python::exec_file

### DIFF
--- a/SEImplementation/src/lib/PythonConfig/PythonInterpreter.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PythonInterpreter.cpp
@@ -20,6 +20,8 @@
  */
 
 #include <signal.h>
+#include <fstream>
+#include <system_error>
 #include <utility>
 #include <boost/python/dict.hpp>
 #include <boost/python/exec.hpp>


### PR DESCRIPTION
It is running now without crashing, so this workaround fixes the heap smashing detected by `asan` (likely the one reported by `chap` offline)

No idea if this has something to do with other crashes (#384, #385 or #329). If they were installed from conda, and sourcextractor++ was built against boost >= 1.55, it may.

Fixes #387 