### PR TITLE
Lazy stamps

### DIFF
--- a/SEFramework/SEFramework/Image/ImageAccessor.h
+++ b/SEFramework/SEFramework/Image/ImageAccessor.h
@@ -37,18 +37,17 @@ namespace SourceXtractor {
  * @tparam T
  *      Pixel type
  */
-template<typename T>
-class ImageAccessor: public Image<T> {
+template <typename T>
+class ImageAccessor : public Image<T> {
 public:
-
   /** Hints about the access pattern
    * @details
    *    Even if you don't honor the hint, it will still work!
    */
   enum AccessHint {
-    TOP_LEFT,     //< The first coordinate is likely the top left corner of what is going to be needed
-    CENTERED,     //< The first coordinate is likely the center of a region
-    BOTTOM_RIGHT, //< The first coordinate is likely the bottom right corner
+    TOP_LEFT,      //< The first coordinate is likely the top left corner of what is going to be needed
+    CENTERED,      //< The first coordinate is likely the center of a region
+    BOTTOM_RIGHT,  //< The first coordinate is likely the bottom right corner
   };
 
   /** Destructor */
@@ -69,12 +68,11 @@ public:
    *    Of course, if you know beforehand the exact chunk that will be needed, better use
    *    getChunk directly!
    */
-  ImageAccessor(std::shared_ptr<const Image<T>> img, AccessHint hint = TOP_LEFT, int w = 64, int h = 1)
-    : m_image(img.get()), m_keep_alive(std::move(img)), m_hint(hint), m_read_width(w),
-      m_read_height(h) {};
+  explicit ImageAccessor(std::shared_ptr<const Image<T>> img, AccessHint hint = TOP_LEFT, int w = 64, int h = 1)
+      : m_image(img.get()), m_keep_alive(std::move(img)), m_hint(hint), m_read_width(w), m_read_height(h){};
 
-  ImageAccessor(const Image<T>& img, AccessHint hint = TOP_LEFT, int w = 64, int h = 64)
-    : m_image(&img), m_hint(hint), m_read_width(w), m_read_height(h) {};
+  explicit ImageAccessor(const Image<T>& img, AccessHint hint = TOP_LEFT, int w = 64, int h = 64)
+      : m_image(&img), m_hint(hint), m_read_width(w), m_read_height(h){};
 
   /**
    * Can not be copied!
@@ -130,12 +128,12 @@ public:
   };
 
 private:
-  const Image<T>* m_image;
-  std::shared_ptr<const Image<T>> m_keep_alive;
+  const Image<T>*                      m_image;
+  std::shared_ptr<const Image<T>>      m_keep_alive;
   std::shared_ptr<const ImageChunk<T>> m_chunk;
-  PixelCoordinate m_chunk_min, m_chunk_max;
-  AccessHint m_hint;
-  int m_read_width, m_read_height;
+  PixelCoordinate                      m_chunk_min, m_chunk_max;
+  AccessHint                           m_hint;
+  int                                  m_read_width, m_read_height;
 
   /**
    * Verify if the requested coordinates can be satisfied, and asks
@@ -155,18 +153,17 @@ private:
   void nextCoordinates(const PixelCoordinate& coord) {
     if (!m_chunk) {
       m_chunk_min = firstCoordinates(coord);
-    }
-    else {
+    } else {
       switch (m_hint) {
-        case TOP_LEFT:
-        case CENTERED:
-          m_chunk_min.m_x = coord.m_x;
-          m_chunk_min.m_y = coord.m_y;
-          break;
-        case BOTTOM_RIGHT:
-          m_chunk_min.m_x = coord.m_x - m_read_width + 1;
-          m_chunk_min.m_y = coord.m_y - m_read_height + 1;
-          break;
+      case TOP_LEFT:
+      case CENTERED:
+        m_chunk_min.m_x = coord.m_x;
+        m_chunk_min.m_y = coord.m_y;
+        break;
+      case BOTTOM_RIGHT:
+        m_chunk_min.m_x = coord.m_x - m_read_width + 1;
+        m_chunk_min.m_y = coord.m_y - m_read_height + 1;
+        break;
       }
     }
     // Make sure we don't leave the image
@@ -179,17 +176,17 @@ private:
 
   PixelCoordinate firstCoordinates(const PixelCoordinate& coord) {
     switch (m_hint) {
-      case CENTERED:
-        return PixelCoordinate(coord.m_x - m_read_width / 2, coord.m_y - m_read_height / 2);
-      case TOP_LEFT:
-        return coord;
-      case BOTTOM_RIGHT:
-        return PixelCoordinate(coord.m_x - m_read_width, coord.m_y - m_read_height);
+    case CENTERED:
+      return PixelCoordinate(coord.m_x - m_read_width / 2, coord.m_y - m_read_height / 2);
+    case TOP_LEFT:
+      return coord;
+    case BOTTOM_RIGHT:
+      return PixelCoordinate(coord.m_x - m_read_width, coord.m_y - m_read_height);
     }
     return coord;
   }
 };
 
-} // end of namespace SourceXtractor
+}  // end of namespace SourceXtractor
 
-#endif // _SEFRAMEWORK_IMAGE_IMAGEACCESSOR_H
+#endif  // _SEFRAMEWORK_IMAGE_IMAGEACCESSOR_H

--- a/SEImplementation/SEImplementation/Plugin/DetectionFrameGroupStamp/DetectionFrameGroupStamp.h
+++ b/SEImplementation/SEImplementation/Plugin/DetectionFrameGroupStamp/DetectionFrameGroupStamp.h
@@ -24,36 +24,33 @@
 #ifndef _SEIMPLEMENTATION_PLUGIN_DETECTIONFRAMEGROUPSTAMP_DETECTIONFRAMEGROUPSTAMP_H_
 #define _SEIMPLEMENTATION_PLUGIN_DETECTIONFRAMEGROUPSTAMP_DETECTIONFRAMEGROUPSTAMP_H_
 
-
-#include "SEFramework/Property/Property.h"
 #include "SEFramework/Image/Image.h"
+#include "SEFramework/Image/ImageAccessor.h"
+#include "SEFramework/Property/Property.h"
 
 namespace SourceXtractor {
 
 class DetectionFrameGroupStamp : public Property {
 
 public:
-
   virtual ~DetectionFrameGroupStamp() = default;
 
-  DetectionFrameGroupStamp(std::shared_ptr<DetectionImage> stamp,
-      std::shared_ptr<DetectionImage> thresholded_stamp, PixelCoordinate top_left,
-      std::shared_ptr<WeightImage> variance_stamp) :
-        m_stamp(stamp), m_thresholded_stamp(thresholded_stamp),
-        m_variance_stamp(variance_stamp), m_top_left(top_left) {}
+  DetectionFrameGroupStamp(std::shared_ptr<DetectionImage> stamp, std::shared_ptr<DetectionImage> thresholded_stamp,
+                           PixelCoordinate top_left, std::shared_ptr<WeightImage> variance_stamp)
+      : m_stamp(stamp), m_thresholded_stamp(thresholded_stamp), m_variance_stamp(variance_stamp), m_top_left(top_left) {}
 
   // Returns the stamp image
-  const DetectionImage& getStamp() const {
-    return *m_stamp;
+  ImageAccessor<DetectionImage::PixelType> getStamp() const {
+    return ImageAccessor<DetectionImage::PixelType>(*m_stamp);
   }
 
-  const DetectionImage& getThresholdedStamp() const {
-    return *m_thresholded_stamp;
+  ImageAccessor<DetectionImage::PixelType> getThresholdedStamp() const {
+    return ImageAccessor<DetectionImage::PixelType>(*m_thresholded_stamp);
   }
 
   // Returns the stamp's associated weight image
-  const DetectionImage& getVarianceStamp() const {
-    return *m_variance_stamp;
+  ImageAccessor<WeightImage::PixelType> getVarianceStamp() const {
+    return ImageAccessor<WeightImage::PixelType>(*m_variance_stamp);
   }
 
   PixelCoordinate getTopLeft() const {
@@ -62,15 +59,10 @@ public:
 
 private:
   std::shared_ptr<DetectionImage> m_stamp, m_thresholded_stamp;
-  std::shared_ptr<WeightImage> m_variance_stamp;
-  PixelCoordinate m_top_left;
-
+  std::shared_ptr<WeightImage>    m_variance_stamp;
+  PixelCoordinate                 m_top_left;
 };
 
-
 } /* namespace SourceXtractor */
-
-
-
 
 #endif /* _SEIMPLEMENTATION_PLUGIN_DETECTIONFRAMEGROUPSTAMP_DETECTIONFRAMEGROUPSTAMP_H_ */

--- a/SEImplementation/SEImplementation/Plugin/DetectionFrameGroupStamp/DetectionFrameGroupStamp.h
+++ b/SEImplementation/SEImplementation/Plugin/DetectionFrameGroupStamp/DetectionFrameGroupStamp.h
@@ -41,16 +41,19 @@ public:
 
   // Returns the stamp image
   ImageAccessor<DetectionImage::PixelType> getStamp() const {
-    return ImageAccessor<DetectionImage::PixelType>(*m_stamp);
+    return ImageAccessor<DetectionImage::PixelType>(*m_stamp, ImageAccessor<float>::TOP_LEFT, m_stamp->getWidth(),
+                                                    m_stamp->getHeight());
   }
 
   ImageAccessor<DetectionImage::PixelType> getThresholdedStamp() const {
-    return ImageAccessor<DetectionImage::PixelType>(*m_thresholded_stamp);
+    return ImageAccessor<DetectionImage::PixelType>(*m_thresholded_stamp, ImageAccessor<float>::TOP_LEFT,
+                                                    m_thresholded_stamp->getWidth(), m_thresholded_stamp->getHeight());
   }
 
   // Returns the stamp's associated weight image
   ImageAccessor<WeightImage::PixelType> getVarianceStamp() const {
-    return ImageAccessor<WeightImage::PixelType>(*m_variance_stamp);
+    return ImageAccessor<WeightImage::PixelType>(*m_variance_stamp, ImageAccessor<float>::TOP_LEFT, m_variance_stamp->getWidth(),
+                                                 m_variance_stamp->getHeight());
   }
 
   PixelCoordinate getTopLeft() const {

--- a/SEImplementation/SEImplementation/Plugin/DetectionFrameImages/DetectionFrameImages.h
+++ b/SEImplementation/SEImplementation/Plugin/DetectionFrameImages/DetectionFrameImages.h
@@ -43,6 +43,10 @@ public:
     return m_frame->getImage(layer)->getChunk(x, y, width, height);
   }
 
+  std::shared_ptr<Image<DetectionImage::PixelType>> getImage(FrameImageLayer layer) const {
+    return m_frame->getImage(layer);
+  }
+
   int getWidth() const {
     return m_width;
   }

--- a/SEImplementation/SEImplementation/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp.h
+++ b/SEImplementation/SEImplementation/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp.h
@@ -54,27 +54,32 @@ public:
 
   // Returns the stamp image
   ImageAccessor<DetectionImage::PixelType> getStamp() const {
-    return ImageAccessor<DetectionImage::PixelType>(*m_stamp);
+    return ImageAccessor<DetectionImage::PixelType>(*m_stamp, ImageAccessor<float>::TOP_LEFT, m_stamp->getWidth(),
+                                                    m_stamp->getHeight());
   }
 
   // Returns the filtered stamp image
   ImageAccessor<DetectionImage::PixelType> getFilteredStamp() const {
-    return ImageAccessor<DetectionImage::PixelType>(*m_filtered_stamp);
+    return ImageAccessor<DetectionImage::PixelType>(*m_filtered_stamp, ImageAccessor<float>::TOP_LEFT, m_filtered_stamp->getWidth(),
+                                                    m_filtered_stamp->getHeight());
   }
 
   // Returns the filtered and thresholded stamp image
   ImageAccessor<DetectionImage::PixelType> getThresholdedStamp() const {
-    return ImageAccessor<DetectionImage::PixelType>(*m_thresholded_stamp);
+    return ImageAccessor<DetectionImage::PixelType>(*m_thresholded_stamp, ImageAccessor<float>::TOP_LEFT,
+                                                    m_thresholded_stamp->getWidth(), m_thresholded_stamp->getHeight());
   }
 
   // Returns the threshold map stamp
   ImageAccessor<DetectionImage::PixelType> getThresholdMapStamp() const {
-    return ImageAccessor<DetectionImage::PixelType>(*m_threshold_map_stamp);
+    return ImageAccessor<DetectionImage::PixelType>(*m_threshold_map_stamp, ImageAccessor<float>::TOP_LEFT,
+                                                    m_threshold_map_stamp->getWidth(), m_threshold_map_stamp->getHeight());
   }
 
   // Returns the stamp's associated weight image
   ImageAccessor<WeightImage::PixelType> getVarianceStamp() const {
-    return ImageAccessor<WeightImage::PixelType>(*m_variance_stamp);
+    return ImageAccessor<WeightImage::PixelType>(*m_variance_stamp, ImageAccessor<float>::TOP_LEFT, m_variance_stamp->getWidth(),
+                                                 m_variance_stamp->getHeight());
   }
 
   PixelCoordinate getTopLeft() const {

--- a/SEImplementation/SEImplementation/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp.h
+++ b/SEImplementation/SEImplementation/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp.h
@@ -23,8 +23,9 @@
 #ifndef _SEIMPLEMENTATION_PROPERTY_DETECTIONFRAMESOURCESTAMP_H
 #define _SEIMPLEMENTATION_PROPERTY_DETECTIONFRAMESOURCESTAMP_H
 
-#include "SEFramework/Property/Property.h"
+#include "SEFramework/Image/ImageAccessor.h"
 #include "SEFramework/Image/VectorImage.h"
+#include "SEFramework/Property/Property.h"
 
 namespace SourceXtractor {
 
@@ -36,48 +37,44 @@ namespace SourceXtractor {
 class DetectionFrameSourceStamp : public Property {
 
 public:
-
-  using DetectionVectorImage = VectorImage<DetectionImage::PixelType>;
-  using WeightVectorImage = VectorImage<WeightImage::PixelType>;
-
   /**
    * @brief Destructor
    */
   virtual ~DetectionFrameSourceStamp() = default;
 
-  DetectionFrameSourceStamp(std::shared_ptr<DetectionVectorImage> stamp,
-                            std::shared_ptr<DetectionVectorImage> filtered_stamp,
-                            std::shared_ptr<DetectionVectorImage> thresholded_stamp,
-                            PixelCoordinate top_left,
-                            std::shared_ptr<WeightVectorImage> variance_stamp,
-                            std::shared_ptr<DetectionVectorImage> threshold_map_stamp) :
-    m_stamp(stamp), m_filtered_stamp(filtered_stamp), m_thresholded_stamp(thresholded_stamp),
-    m_threshold_map_stamp(threshold_map_stamp), m_variance_stamp(variance_stamp),
-    m_top_left(top_left) {}
+  DetectionFrameSourceStamp(std::shared_ptr<DetectionImage> stamp, std::shared_ptr<DetectionImage> filtered_stamp,
+                            std::shared_ptr<DetectionImage> thresholded_stamp, PixelCoordinate top_left,
+                            std::shared_ptr<WeightImage> variance_stamp, std::shared_ptr<DetectionImage> threshold_map_stamp)
+      : m_stamp(stamp)
+      , m_filtered_stamp(filtered_stamp)
+      , m_thresholded_stamp(thresholded_stamp)
+      , m_threshold_map_stamp(threshold_map_stamp)
+      , m_variance_stamp(variance_stamp)
+      , m_top_left(top_left) {}
 
   // Returns the stamp image
-  const DetectionVectorImage& getStamp() const {
-    return *m_stamp;
+  ImageAccessor<DetectionImage::PixelType> getStamp() const {
+    return ImageAccessor<DetectionImage::PixelType>(*m_stamp);
   }
 
   // Returns the filtered stamp image
-  const DetectionVectorImage& getFilteredStamp() const {
-    return *m_filtered_stamp;
+  ImageAccessor<DetectionImage::PixelType> getFilteredStamp() const {
+    return ImageAccessor<DetectionImage::PixelType>(*m_filtered_stamp);
   }
 
   // Returns the filtered and thresholded stamp image
-  const DetectionVectorImage& getThresholdedStamp() const {
-    return *m_thresholded_stamp;
+  ImageAccessor<DetectionImage::PixelType> getThresholdedStamp() const {
+    return ImageAccessor<DetectionImage::PixelType>(*m_thresholded_stamp);
   }
 
   // Returns the threshold map stamp
-  const DetectionVectorImage& getThresholdMapStamp() const {
-    return *m_threshold_map_stamp;
+  ImageAccessor<DetectionImage::PixelType> getThresholdMapStamp() const {
+    return ImageAccessor<DetectionImage::PixelType>(*m_threshold_map_stamp);
   }
 
   // Returns the stamp's associated weight image
-  const WeightVectorImage& getVarianceStamp() const {
-    return *m_variance_stamp;
+  ImageAccessor<WeightImage::PixelType> getVarianceStamp() const {
+    return ImageAccessor<WeightImage::PixelType>(*m_variance_stamp);
   }
 
   PixelCoordinate getTopLeft() const {
@@ -85,15 +82,13 @@ public:
   }
 
 private:
-  std::shared_ptr<DetectionVectorImage> m_stamp, m_filtered_stamp;
-  std::shared_ptr<DetectionVectorImage> m_thresholded_stamp, m_threshold_map_stamp;
-  std::shared_ptr<WeightVectorImage> m_variance_stamp;
-  PixelCoordinate m_top_left;
+  std::shared_ptr<DetectionImage> m_stamp, m_filtered_stamp;
+  std::shared_ptr<DetectionImage> m_thresholded_stamp, m_threshold_map_stamp;
+  std::shared_ptr<WeightImage>    m_variance_stamp;
+  PixelCoordinate                 m_top_left;
 
 }; /* End of DetectionFrameSourceStamp class */
 
-
 } /* namespace SourceXtractor */
-
 
 #endif

--- a/SEImplementation/src/lib/Plugin/DetectionFramePixelValues/DetectionFramePixelValuesTask.cpp
+++ b/SEImplementation/src/lib/Plugin/DetectionFramePixelValues/DetectionFramePixelValuesTask.cpp
@@ -19,27 +19,28 @@
  * @date 06/16/16
  * @author mschefer
  */
+
 #include <memory>
 
-#include "SEImplementation/Property/PixelCoordinateList.h"
-#include "SEImplementation/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp.h"
-
+#include "SEFramework/Image/ImageAccessor.h"
 #include "SEImplementation/Plugin/DetectionFramePixelValues/DetectionFramePixelValues.h"
 #include "SEImplementation/Plugin/DetectionFramePixelValues/DetectionFramePixelValuesTask.h"
+#include "SEImplementation/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp.h"
+#include "SEImplementation/Property/PixelCoordinateList.h"
 
 namespace SourceXtractor {
 
 void DetectionFramePixelValuesTask::computeProperties(SourceInterface& source) const {
   const auto& stamp = source.getProperty<DetectionFrameSourceStamp>();
 
-  auto& detection_image = stamp.getStamp();
-  auto& filtered_image = stamp.getFilteredStamp();
-  auto& variance_map = stamp.getVarianceStamp();
+  ImageAccessor<DetectionImage::PixelType> detection_image(stamp.getStamp());
+  ImageAccessor<DetectionImage::PixelType> filtered_image(stamp.getFilteredStamp());
+  ImageAccessor<WeightImage::PixelType>    variance_map(stamp.getVarianceStamp());
 
   auto offset = stamp.getTopLeft();
 
   std::vector<DetectionImage::PixelType> values, filtered_values;
-  std::vector<WeightImage::PixelType> variances;
+  std::vector<WeightImage::PixelType>    variances;
   for (auto pixel_coord : source.getProperty<PixelCoordinateList>().getCoordinateList()) {
     auto offset_coord = pixel_coord - offset;
     values.push_back(detection_image.getValue(offset_coord.m_x, offset_coord.m_y));
@@ -50,5 +51,4 @@ void DetectionFramePixelValuesTask::computeProperties(SourceInterface& source) c
   source.setProperty<DetectionFramePixelValues>(std::move(values), std::move(filtered_values), std::move(variances));
 }
 
-} // SEImplementation namespace
-
+}  // namespace SourceXtractor

--- a/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingTask.cpp
@@ -152,10 +152,10 @@ struct SourceModel {
 
 
 void MoffatModelFittingTask::computeProperties(SourceInterface& source) const {
-  auto& source_stamp = source.getProperty<DetectionFrameSourceStamp>().getStamp();
-  auto& variance_stamp = source.getProperty<DetectionFrameSourceStamp>().getVarianceStamp();
-  auto& thresholded_stamp = source.getProperty<DetectionFrameSourceStamp>().getThresholdedStamp();
-  auto& threshold_map_stamp = source.getProperty<DetectionFrameSourceStamp>().getThresholdMapStamp();
+  auto source_stamp = source.getProperty<DetectionFrameSourceStamp>().getStamp();
+  auto variance_stamp = source.getProperty<DetectionFrameSourceStamp>().getVarianceStamp();
+  auto thresholded_stamp = source.getProperty<DetectionFrameSourceStamp>().getThresholdedStamp();
+  auto threshold_map_stamp = source.getProperty<DetectionFrameSourceStamp>().getThresholdMapStamp();
   PixelCoordinate stamp_top_left = source.getProperty<DetectionFrameSourceStamp>().getTopLeft();
 
   // Computes the minimum flux that a detection should have (min. detection threshold for every pixel)

--- a/SEImplementation/tests/src/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp_test.cpp
+++ b/SEImplementation/tests/src/Plugin/DetectionFrameSourceStamp/DetectionFrameSourceStamp_test.cpp
@@ -55,7 +55,7 @@ BOOST_FIXTURE_TEST_CASE(example_test, DetectionFrameSourceStampFixture) {
   DetectionFrameSourceStampTask task;
   task.computeProperties(source);
 
-  auto& source_stamp = source.getProperty<DetectionFrameSourceStamp>().getStamp();
+  auto source_stamp = source.getProperty<DetectionFrameSourceStamp>().getStamp();
   auto top_left = source.getProperty<DetectionFrameSourceStamp>().getTopLeft();
 
   // Size must be at least the size of the source itself (+ some area around it)


### PR DESCRIPTION
Helps #361.

They seem to reduce the memory footprint quite considerably for some use cases, without impacting the performance.
This is for problem #380.

![lazystamps380](https://user-images.githubusercontent.com/1410577/131457550-9d191249-b470-4259-93ea-081247a6d99e.png)

For other cases, it does reduce a little, and (surprisingly) it is faster. Likely I just got lucky with the node lesta assigned me (though they are all supposed to be the same and I do not think shared, since I use every physical cores: 16). This is the benchmark I use for multi-threading (from the challenge data):

![lazystamps_challenge](https://user-images.githubusercontent.com/1410577/131457731-932df1e3-7549-4093-99f1-4b35de59620a.png)

At the very least, it doesn't seem to slow down things.

Anyhow, maybe wait for merging. I will try with now limiting the queue size and bumping the priority of measurements. It may help more, it may even be better if combined with this (?)