### PR TITLE
Throttle queues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(ElementsProject)
 #---------------------------------------------------------------
 
 # Declare project name and version
-elements_project(SourceXtractorPlusPlus 0.16 USE Alexandria 2.21.0)
+elements_project(SourceXtractorPlusPlus 0.16 USE Alexandria 2.22.0)

--- a/SEImplementation/SEImplementation/Configuration/MultiThreadingConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/MultiThreadingConfig.h
@@ -47,8 +47,12 @@ public:
     return m_thread_pool;
   }
 
+  unsigned getMaxQueueSize() const {
+    return m_max_queue_size;
+  }
+
 private:
-  int m_threads_nb;
+  int m_threads_nb, m_max_queue_size;
   std::shared_ptr<Euclid::ThreadPool> m_thread_pool;
 };
 

--- a/SEImplementation/SEImplementation/Measurement/MeasurementFactory.h
+++ b/SEImplementation/SEImplementation/Measurement/MeasurementFactory.h
@@ -55,7 +55,7 @@ private:
   std::shared_ptr<OutputRegistry> m_output_registry;
   std::shared_ptr<Euclid::ThreadPool> m_thread_pool;
 
-  unsigned int m_threads_nb;
+  unsigned int m_threads_nb, m_max_queue;
 };
 
 }

--- a/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
@@ -39,11 +39,12 @@ class MultithreadedMeasurement : public Measurement {
 public:
 
   using SourceToRowConverter = std::function<Euclid::Table::Row(const SourceInterface&)>;
-  MultithreadedMeasurement(SourceToRowConverter source_to_row, const std::shared_ptr<Euclid::ThreadPool>& thread_pool)
+  MultithreadedMeasurement(SourceToRowConverter source_to_row, const std::shared_ptr<Euclid::ThreadPool>& thread_pool,
+                           unsigned max_queue_size)
       : m_source_to_row(source_to_row),
         m_thread_pool(thread_pool),
         m_group_counter(0),
-        m_input_done(false), m_abort_raised(false), m_semaphore(1000) {}
+        m_input_done(false), m_abort_raised(false), m_semaphore(max_queue_size) {}
 
   virtual ~MultithreadedMeasurement();
 

--- a/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
@@ -15,7 +15,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 /*
- * Multithreadedmeasurement->h
+ * Multithreadedmeasurement.h
  *
  *  Created on: May 17, 2018
  *      Author: mschefer
@@ -29,7 +29,8 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
-#include <AlexandriaKernel/ThreadPool.h>
+#include "AlexandriaKernel/ThreadPool.h"
+#include "AlexandriaKernel/Semaphore.h"
 #include "SEFramework/Pipeline/Measurement.h"
 
 namespace SourceXtractor {
@@ -42,7 +43,7 @@ public:
       : m_source_to_row(source_to_row),
         m_thread_pool(thread_pool),
         m_group_counter(0),
-        m_input_done(false), m_abort_raised(false) {}
+        m_input_done(false), m_abort_raised(false), m_semaphore(1000) {}
 
   virtual ~MultithreadedMeasurement();
 
@@ -65,6 +66,7 @@ private:
   std::condition_variable m_new_output;
   std::list<std::pair<int, std::shared_ptr<SourceGroupInterface>>> m_output_queue;
   std::mutex m_output_queue_mutex;
+  Euclid::Semaphore m_semaphore;
 };
 
 }

--- a/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
+++ b/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
@@ -20,6 +20,7 @@
 
 #include <condition_variable>
 #include "AlexandriaKernel/ThreadPool.h"
+#include "AlexandriaKernel/Semaphore.h"
 #include "SEFramework/Source/SourceInterface.h"
 #include "SEFramework/Pipeline/SourceGrouping.h"
 #include "SEUtils/Observable.h"
@@ -120,6 +121,9 @@ private:
 
   /// Termination condition for the output loop
   std::atomic_bool m_stop;
+
+  /// Keep the queue under control
+  Euclid::Semaphore m_semaphore;
 
   void requestProperty(const PropertyId& property_id);
   void outputLoop();

--- a/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
+++ b/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
@@ -49,7 +49,7 @@ public:
    * @param thread_pool
    *    Alexandria thread pool
    */
-  Prefetcher(const std::shared_ptr<Euclid::ThreadPool>& thread_pool);
+  Prefetcher(const std::shared_ptr<Euclid::ThreadPool>& thread_pool, unsigned max_queue_size);
 
   /**
    * Destructor

--- a/SEImplementation/src/lib/Configuration/MultiThreadingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MultiThreadingConfig.cpp
@@ -31,13 +31,15 @@ namespace po = boost::program_options;
 namespace SourceXtractor {
 
 static const std::string THREADS_NB {"thread-count"};
+static const std::string MAX_QUEUE_SIZE {"thread-max-queue-size"};
 
 MultiThreadingConfig::MultiThreadingConfig(long manager_id) : Configuration(manager_id), m_threads_nb(-1) {
 }
 
 auto MultiThreadingConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return { {"Multi-threading", {
-      {THREADS_NB.c_str(), po::value<int>()->default_value(-1), "Number of worker threads (-1=automatic, 0=disable all multithreading)"}
+      {THREADS_NB.c_str(), po::value<int>()->default_value(-1), "Number of worker threads (-1=automatic, 0=disable all multithreading)"},
+      {MAX_QUEUE_SIZE.c_str(), po::value<int>()->default_value(1000), "Limit the size of the internal queues"}
   }}};
 }
 
@@ -51,6 +53,11 @@ void MultiThreadingConfig::initialize(const UserValues& args) {
   }
   if (m_threads_nb > 0) {
     m_thread_pool = std::make_shared<Euclid::ThreadPool>(m_threads_nb);
+  }
+
+  m_max_queue_size = args.at(MAX_QUEUE_SIZE).as<int>();
+  if (m_max_queue_size <= 0) {
+    throw Elements::Exception(MAX_QUEUE_SIZE + " must be strictly positive");
   }
 }
 

--- a/SEImplementation/src/lib/Measurement/MeasurementFactory.cpp
+++ b/SEImplementation/src/lib/Measurement/MeasurementFactory.cpp
@@ -34,7 +34,7 @@ namespace SourceXtractor {
 std::unique_ptr<Measurement> MeasurementFactory::getMeasurement() const {
   if (m_threads_nb > 0) {
     auto source_to_row = m_output_registry->getSourceToRowConverter(m_output_properties);
-    return std::unique_ptr<Measurement>(new MultithreadedMeasurement(source_to_row, m_thread_pool));
+    return std::unique_ptr<Measurement>(new MultithreadedMeasurement(source_to_row, m_thread_pool, m_max_queue));
   } else {
     return std::unique_ptr<Measurement>(new DummyMeasurement());
   }
@@ -49,6 +49,7 @@ void MeasurementFactory::configure(Euclid::Configuration::ConfigManager& manager
   m_output_properties = manager.getConfiguration<OutputConfig>().getOutputProperties();
   m_threads_nb = manager.getConfiguration<MultiThreadingConfig>().getThreadsNb();
   m_thread_pool = manager.getConfiguration<MultiThreadingConfig>().getThreadPool();
+  m_max_queue = manager.getConfiguration<MultiThreadingConfig>().getMaxQueueSize();
 }
 
 }

--- a/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
+++ b/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
@@ -42,7 +42,7 @@ private:
 };
 
 Prefetcher::Prefetcher(const std::shared_ptr<Euclid::ThreadPool>& thread_pool)
-  : m_thread_pool(thread_pool), m_stop(false) {
+  : m_thread_pool(thread_pool), m_stop(false), m_semaphore(1000) {
   m_output_thread = Euclid::make_unique<std::thread>(&Prefetcher::outputLoop, this);
 }
 
@@ -52,6 +52,8 @@ Prefetcher::~Prefetcher() {
 }
 
 void Prefetcher::handleMessage(const std::shared_ptr<SourceInterface>& message) {
+  m_semaphore.acquire();
+
   intptr_t source_addr = reinterpret_cast<intptr_t>(message.get());
   {
     std::lock_guard<std::mutex> queue_lock(m_queue_mutex);
@@ -117,6 +119,7 @@ void Prefetcher::outputLoop() {
       }
       m_finished_sources.erase(processed);
       m_received.pop_front();
+      m_semaphore.release();
     }
 
     if (m_stop && m_received.empty()) {

--- a/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
+++ b/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
@@ -41,8 +41,8 @@ private:
   Lock& m_lock;
 };
 
-Prefetcher::Prefetcher(const std::shared_ptr<Euclid::ThreadPool>& thread_pool)
-  : m_thread_pool(thread_pool), m_stop(false), m_semaphore(1000) {
+Prefetcher::Prefetcher(const std::shared_ptr<Euclid::ThreadPool>& thread_pool, unsigned max_queue_size)
+  : m_thread_pool(thread_pool), m_stop(false), m_semaphore(max_queue_size) {
   m_output_thread = Euclid::make_unique<std::thread>(&Prefetcher::outputLoop, this);
 }
 

--- a/SEMain/src/program/SourceXtractor.cpp
+++ b/SEMain/src/program/SourceXtractor.cpp
@@ -366,7 +366,7 @@ public:
     // Prefetcher
     std::shared_ptr<Prefetcher> prefetcher;
     if (thread_pool) {
-      prefetcher = std::make_shared<Prefetcher>(thread_pool);
+      prefetcher = std::make_shared<Prefetcher>(thread_pool, multithreading_config.getMaxQueueSize());
     }
 
     // Rest of the stagees


### PR DESCRIPTION
Avoid piling up sources on the internal queues in order to keep memory consumption lower.
This can reduce considerably the memory footprint (see #361).

Need Alexandria 2.22.0, so I do not know if you want to have that released first?