### PR TITLE
Disable ML segmentation if ONNX is not found

### DIFF
--- a/SEImplementation/CMakeLists.txt
+++ b/SEImplementation/CMakeLists.txt
@@ -63,29 +63,36 @@ file(GLOB SE_PYTHON_SRC src/lib/PythonConfig/*.cpp)
 list(REMOVE_ITEM SE_PYTHON_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/PythonConfig/PythonModule.cpp)
 
 file(GLOB PLUGIN_SRC src/lib/Plugin/*/*.cpp)
+file(GLOB SEGMENTATION_SRC src/lib/Segmentation/*.cpp)
+file(GLOB COMMON_SRC src/lib/Common/*.cpp)
 
 if(NOT OnnxRuntime_FOUND)
   message("ONNX Runtime not found")
   file(GLOB ONNXPLUGIN_SRC src/lib/Plugin/Onn*/*.cpp)
+  file(GLOB ML_SEGMENTATION_SRC src/lib/Segmentation/ML*.cpp)
+  file(GLOB ONNX_COMMON_SRC src/lib/Common/Onnx*.cpp)
   list(REMOVE_ITEM PLUGIN_SRC ${ONNXPLUGIN_SRC})
+  list(REMOVE_ITEM SEGMENTATION_SRC ${ML_SEGMENTATION_SRC})
+  list(REMOVE_ITEM COMMON_SRC ${ONNX_COMMON_SRC})
 else()
   list(APPEND OPT_INCLUDES ${OnnxRuntime_INCLUDE_DIRS})
   list(APPEND OPT_LIBRARIES OnnxRuntime)
+  add_definitions(-DWITH_ML_SEGMENTATION)
 endif()
 
 elements_add_library(SEImplementation
-			src/lib/Background/*.cpp
-			src/lib/Background/*/*.cpp
+            src/lib/Background/*.cpp
+            src/lib/Background/*/*.cpp
             src/lib/Partition/*.cpp
-            src/lib/Segmentation/*.cpp
+            ${SEGMENTATION_SRC}
             src/lib/Grouping/*.cpp
             src/lib/Configuration/*.cpp
             src/lib/Output/*.cpp
-           	src/lib/Measurement/*.cpp
-           	src/lib/CheckImages/*.cpp
+            src/lib/Measurement/*.cpp
+            src/lib/CheckImages/*.cpp
             src/lib/Deblending/*.cpp
             src/lib/Image/*.cpp
-            src/lib/Common/*.cpp
+            ${COMMON_SRC}
             src/lib/Prefetcher/*.cpp
             ${PLUGIN_SRC}
             ${SE_PYTHON_SRC}

--- a/SEImplementation/src/lib/Configuration/SegmentationConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/SegmentationConfig.cpp
@@ -85,7 +85,11 @@ void SegmentationConfig::preInitialize(const UserValues& args) {
   } else if (algorithm_name == "BFS") {
     m_selected_algorithm = Algorithm::BFS;
   } else if (algorithm_name == "ML") {
+#ifdef WITH_ML_SEGMENTATION
     m_selected_algorithm = Algorithm::ML;
+#else
+    throw Elements::Exception() << "SourceXtractor++ has not been compiled with ONNX support";
+#endif
   } else {
     throw Elements::Exception() << "Unknown segmentation algorithm : " << algorithm_name;
   }

--- a/SEImplementation/src/lib/Segmentation/SegmentationFactory.cpp
+++ b/SEImplementation/src/lib/Segmentation/SegmentationFactory.cpp
@@ -31,9 +31,12 @@
 #include "SEImplementation/Segmentation/BackgroundConvolution.h"
 #include "SEImplementation/Segmentation/LutzSegmentation.h"
 #include "SEImplementation/Segmentation/BFSSegmentation.h"
-#include "SEImplementation/Segmentation/MLSegmentation.h"
-
 #include "SEImplementation/Segmentation/SegmentationFactory.h"
+
+#ifdef WITH_ML_SEGMENTATION
+#include "SEImplementation/Segmentation/MLSegmentation.h"
+#endif
+
 
 using namespace Euclid::Configuration;
 
@@ -71,10 +74,12 @@ std::shared_ptr<Segmentation> SegmentationFactory::createSegmentation() const {
       segmentation->setLabelling<BFSSegmentation>(
           std::make_shared<SourceWithOnDemandPropertiesFactory>(m_task_provider), m_bfs_max_delta);
       break;
+#ifdef WITH_ML_SEGMENTATION
     case SegmentationConfig::Algorithm::ML:
       segmentation->setLabelling<MLSegmentation>(
           std::make_shared<SourceWithOnDemandPropertiesFactory>(m_task_provider), m_model_path, m_ml_threshold);
       break;
+#endif
     case SegmentationConfig::Algorithm::UNKNOWN:
     default:
       throw Elements::Exception("Unknown segmentation algorithm.");


### PR DESCRIPTION
ONNX Runtime is not available when building in conda, and I am not sure about Euclid.
Compilation of the ML segmentation should be conditionally disabled.