### PR TITLE
Improve access locality during the raster

### DIFF
--- a/ModelFitting/ModelFitting/Models/_impl/CompactExponentialModel.icpp
+++ b/ModelFitting/ModelFitting/Models/_impl/CompactExponentialModel.icpp
@@ -54,11 +54,11 @@ ImageType CompactExponentialModel<ImageType>::getRasterizedImage(double pixel_sc
 
   float area_correction = (1.0 / fabs(m_jacobian[0] * m_jacobian[3] - m_jacobian[1] * m_jacobian[2])) * pixel_scale * pixel_scale;
 
-  for (int x=0; x<(int)size_x; ++x) {
-    int dx = x - size_x / 2;
-    for (int y=0; y<(int)size_y; ++y) {
-      int dy = y - size_y / 2;
-      if (dx*dx + dy*dy < m_sharp_radius_squared) {
+  for (int y = 0; y < (int)size_y; ++y) {
+    int dy = y - size_y / 2;
+    for (int x = 0; x < (int)size_x; ++x) {
+      int dx = x - size_x / 2;
+      if (dx * dx + dy * dy < m_sharp_radius_squared) {
         Traits::at(image, x, y) = adaptiveSamplePixel(model_eval, dx, dy, 7, 0.01) * area_correction;
       } else {
         Traits::at(image, x, y) = model_eval.evaluateModel(dx, dy) * area_correction;

--- a/ModelFitting/ModelFitting/Models/_impl/CompactSersicModel.icpp
+++ b/ModelFitting/ModelFitting/Models/_impl/CompactSersicModel.icpp
@@ -59,12 +59,11 @@ ImageType CompactSersicModel<ImageType>::getRasterizedImage(double pixel_scale, 
 
   float area_correction = (1.0 / fabs(m_jacobian[0] * m_jacobian[3] - m_jacobian[1] * m_jacobian[2])) * pixel_scale * pixel_scale;
 
-
-  for (int x=0; x<(int)size_x; ++x) {
-    int dx = x - size_x / 2;
-    for (int y=0; y<(int)size_y; ++y) {
-      int dy = y - size_y / 2;
-      if (dx*dx + dy*dy < m_sharp_radius_squared) {
+  for (int y = 0; y < (int)size_y; ++y) {
+    int dy = y - size_y / 2;
+    for (int x = 0; x < (int)size_x; ++x) {
+      int dx = x - size_x / 2;
+      if (dx * dx + dy * dy < m_sharp_radius_squared) {
         Traits::at(image, x, y) = adaptiveSamplePixel(model_eval, dx, dy, 7, 0.01) * area_correction;
       } else {
         Traits::at(image, x, y) = model_eval.evaluateModel(dx, dy) * area_correction;

--- a/ModelFitting/ModelFitting/Models/_impl/ExtendedModel.icpp
+++ b/ModelFitting/ModelFitting/Models/_impl/ExtendedModel.icpp
@@ -41,9 +41,9 @@ namespace _impl {
     ssize_t size_x = Traits::width(image);
     ssize_t size_y = Traits::height(image);
     for (auto& sample : component.getSharpSampling()) {
-      ssize_t image_x = std::get<0>(sample) / pixel_scale + size_x/2.;
-      ssize_t image_y = std::get<1>(sample) / pixel_scale + size_y/2.;
-      if (image_x>=0 && image_x<size_x && image_y>=0 && image_y<size_y) {
+      ssize_t image_x = std::get<0>(sample) / pixel_scale + size_x / 2.;
+      ssize_t image_y = std::get<1>(sample) / pixel_scale + size_y / 2.;
+      if (image_x >= 0 && image_x < size_x && image_y >= 0 && image_y < size_y) {
         Traits::at(image, image_x, image_y) += std::get<2>(sample);
       }
     }
@@ -54,17 +54,18 @@ namespace _impl {
     using Traits = ImageTraits<ImageType>;
     auto size_x = Traits::width(image);
     auto size_y = Traits::height(image);
-    for (std::size_t x=0; x<size_x; ++x) {
-      double x_model = x - (size_x-1) / 2.;
-      x_model *= pixel_scale;
-      for (std::size_t y=0; y<size_y; ++y) {
-        double y_model = y - (size_y-1) / 2.;
-        y_model *= pixel_scale;
-        if (!component.insideSharpRegion(x_model-pixel_scale/2., y_model-pixel_scale/2.) ||
-            !component.insideSharpRegion(x_model-pixel_scale/2., y_model+pixel_scale/2.) ||
-            !component.insideSharpRegion(x_model+pixel_scale/2., y_model-pixel_scale/2.) ||
-            !component.insideSharpRegion(x_model+pixel_scale/2., y_model+pixel_scale/2.)) {
-          Traits::at(image, x, y) = component.getValue(x_model, y_model) * pixel_scale*pixel_scale;
+    for (std::size_t y = 0; y < size_y; ++y) {
+      double y_model = y - (size_y - 1) / 2.;
+      y_model *= pixel_scale;
+      for (std::size_t x = 0; x < size_x; ++x) {
+        double x_model = x - (size_x - 1) / 2.;
+        x_model *= pixel_scale;
+
+        if (!component.insideSharpRegion(x_model - pixel_scale / 2., y_model - pixel_scale / 2.) ||
+            !component.insideSharpRegion(x_model - pixel_scale / 2., y_model + pixel_scale / 2.) ||
+            !component.insideSharpRegion(x_model + pixel_scale / 2., y_model - pixel_scale / 2.) ||
+            !component.insideSharpRegion(x_model + pixel_scale / 2., y_model + pixel_scale / 2.)) {
+          Traits::at(image, x, y) = component.getValue(x_model, y_model) * pixel_scale * pixel_scale;
         }
       }
     }


### PR DESCRIPTION
For the case #382 this reduces ~1h the runtime (from 21:07 to 20:08)
Ok, it is just 5%, but 1h CPU is something, you would save almost half a dollar on EC2 😅 