### PR TITLE
Fix build on macos (clang)

### DIFF
--- a/SEFramework/SEFramework/FFT/FFT.h
+++ b/SEFramework/SEFramework/FFT/FFT.h
@@ -154,8 +154,8 @@ struct FFT {
  */
 int fftRoundDimension(int size);
 
-extern template class FFT<float>;
-extern template class FFT<double>;
+extern template struct FFT<float>;
+extern template struct FFT<double>;
 
 }  // namespace SourceXtractor
 

--- a/SEFramework/src/lib/FFT/FFT.cpp
+++ b/SEFramework/src/lib/FFT/FFT.cpp
@@ -109,9 +109,9 @@ int fftRoundDimension(int size) {
 
 template <typename T>
 auto FFT<T>::createForwardPlan(int width, int height, std::vector<T>& inout) -> plan_ptr_t {
-  int phy_height = height;
-  int phy_width  = 2 * (width / 2 + 1);
-  int mem_size = phy_height * phy_width;
+  size_t phy_height = height;
+  size_t phy_width  = 2 * (width / 2 + 1);
+  size_t mem_size = phy_height * phy_width;
 
   // Make sure the buffers are big enough
   if (inout.size() < mem_size) {
@@ -149,9 +149,9 @@ auto FFT<T>::createForwardPlan(int width, int height, std::vector<T>& inout) -> 
 
 template <typename T>
 auto FFT<T>::createInversePlan(int width, int height, std::vector<T>& inout) -> plan_ptr_t {
-  int phy_height = height;
-  int phy_width  = 2 * (width / 2 + 1);
-  int mem_size = phy_height * phy_width;
+  size_t phy_height = height;
+  size_t phy_width  = 2 * (width / 2 + 1);
+  size_t mem_size = phy_height * phy_width;
 
   // Make sure the buffers are big enough
   if (inout.size() < mem_size) {
@@ -197,7 +197,7 @@ void FFT<T>::executeInverse(plan_ptr_t& plan, std::vector<T>& inout) {
   fftw_traits::func_execute_inv(plan.get(), reinterpret_cast<complex_t*>(inout.data()), inout.data());
 }
 
-template class FFT<float>;
-template class FFT<double>;
+template struct FFT<float>;
+template struct FFT<double>;
 
 }  // namespace SourceXtractor

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/OnnxCompactModel.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/OnnxCompactModel.h
@@ -75,7 +75,7 @@ public:
     std::vector<float> output_data(render_size * render_size);
 
     for (auto const& it : m_params) {
-      input_data_arrays[it.first] = std::vector<float>( { it.second->getValue() } );
+      input_data_arrays[it.first] = std::vector<float>( { static_cast<float>(it.second->getValue()) } );
     }
 
     input_data_arrays["x"] = std::vector<float>(render_size * render_size);

--- a/SEImplementation/src/lib/Configuration/ModelFittingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/ModelFittingConfig.cpp
@@ -274,14 +274,14 @@ void ModelFittingConfig::initializeInner() {
     py::dict parameters = py::extract<py::dict>(p.second.attr("params"));
     py::list names = parameters.keys();
     for (int i = 0; i < py::len(names); ++i) {
-      std::string name(py::extract<char const*>(names[i]));
+      std::string name = py::extract<std::string>(names[i]);
       params[name] = m_parameters[py::extract<int>(parameters[names[i]].attr("id"))];
     }
 
     std::vector<std::shared_ptr<OnnxModel>> onnx_models;
     py::list models = py::extract<py::list>(p.second.attr("models"));
     for (int i = 0; i < py::len(models); ++i) {
-      std::string model_filename(py::extract<char const*>(models[i]));
+      std::string model_filename = py::extract<std::string>(models[i]);
       onnx_models.emplace_back(std::make_shared<OnnxModel>(model_filename));
 
       if (onnx_models.back()->getOutputType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||


### PR DESCRIPTION
I have managed to build onnxruntime for mac, so the code that requires ONNX is now built on mac too.
However, clang seems to disambiguate the lines I have modified in the model fitting config as function declarations, not as constructors. This fixes this.

Btw, were you using `py::extract<const char*>` instead of `std::string` for any particular reason? It also complains unless I use `py::extract<std::string>` (which works in other places of our code, as for the exceptions)