### PR TITLE
Add more explicit to one-param constructors

### DIFF
--- a/SEImplementation/SEImplementation/Common/OnnxModel.h
+++ b/SEImplementation/SEImplementation/Common/OnnxModel.h
@@ -21,7 +21,7 @@ namespace SourceXtractor {
 class OnnxModel {
 public:
 
-  OnnxModel(const std::string& model_path);
+  explicit OnnxModel(const std::string& model_path);
 
   template<typename T, typename U>
   void run(std::vector<T>& input_data, std::vector<U>& output_data) const {

--- a/SEImplementation/SEImplementation/Deblending/DeblendingFactory.h
+++ b/SEImplementation/SEImplementation/Deblending/DeblendingFactory.h
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file DeblendingFactory.h
  * @author nikoapos
  */
@@ -31,12 +31,12 @@
 namespace SourceXtractor {
 
 class DeblendingFactory : public Configurable {
-  
+
 public:
-  
-  DeblendingFactory(std::shared_ptr<SourceFactory> source_factory) :m_source_factory{source_factory} {
+
+  explicit DeblendingFactory(std::shared_ptr<SourceFactory> source_factory) :m_source_factory{source_factory} {
   }
-  
+
   virtual ~DeblendingFactory() = default;
 
   void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const override {
@@ -46,13 +46,13 @@ public:
   void configure(Euclid::Configuration::ConfigManager& manager) override {
     m_steps = manager.getConfiguration<DeblendStepConfig>().getSteps(m_source_factory);
   }
-  
+
   std::unique_ptr<Deblending> createDeblending() const {
     return std::unique_ptr<Deblending>(new Deblending(m_steps));
   }
-  
+
 private:
-  
+
   std::shared_ptr<SourceFactory> m_source_factory;
   std::vector<std::shared_ptr<DeblendStep>> m_steps;
 

--- a/SEImplementation/SEImplementation/Grouping/GroupingFactory.h
+++ b/SEImplementation/SEImplementation/Grouping/GroupingFactory.h
@@ -42,7 +42,7 @@ class GroupingFactory : public Configurable {
 
 public:
 
-  GroupingFactory(std::shared_ptr<SourceGroupFactory> source_group_factory)
+  explicit GroupingFactory(std::shared_ptr<SourceGroupFactory> source_group_factory)
     : m_source_group_factory(source_group_factory), m_hard_limit(0) {}
 
   virtual ~GroupingFactory() = default;

--- a/SEImplementation/SEImplementation/Grouping/LineSelectionCriteria.h
+++ b/SEImplementation/SEImplementation/Grouping/LineSelectionCriteria.h
@@ -32,7 +32,7 @@ namespace SourceXtractor {
 class LineSelectionCriteria : public SelectionCriteria {
 public:
 
-  LineSelectionCriteria(int line_number) : m_line_number(line_number) {
+  explicit LineSelectionCriteria(int line_number) : m_line_number(line_number) {
   }
 
   virtual bool mustBeProcessed(const SourceInterface& ) const override;

--- a/SEImplementation/SEImplementation/Image/LockedWriteableImage.h
+++ b/SEImplementation/SEImplementation/Image/LockedWriteableImage.h
@@ -17,7 +17,7 @@ namespace SourceXtractor {
 template <typename T>
 class LockedWriteableImage: public WriteableImage<T> {
 protected:
-  LockedWriteableImage(std::shared_ptr<WriteableImage<T>> img) : m_img{img}, m_lock(img->m_write_mutex) {
+  explicit LockedWriteableImage(std::shared_ptr<WriteableImage<T>> img) : m_img{img}, m_lock(img->m_write_mutex) {
   }
 
 public:

--- a/SEImplementation/SEImplementation/Image/WriteableImageInterfaceTraits.h
+++ b/SEImplementation/SEImplementation/Image/WriteableImageInterfaceTraits.h
@@ -81,7 +81,7 @@ struct ImageTraits<WriteableInterfaceTypePtr> {
 
   public:
 
-    WriteableIterator(WriteableInterfaceTypePtr image)
+    explicit WriteableIterator(WriteableInterfaceTypePtr image)
       : m_image{image}, m_accessor{image}, m_x{0}, m_y{0},
         m_width{image->getWidth()},
         m_height{image->getHeight()},

--- a/SEImplementation/SEImplementation/Measurement/MeasurementFactory.h
+++ b/SEImplementation/SEImplementation/Measurement/MeasurementFactory.h
@@ -40,7 +40,7 @@ class MeasurementFactory : public Configurable {
 
 public:
 
-  MeasurementFactory(std::shared_ptr<OutputRegistry> output_registry)
+  explicit MeasurementFactory(std::shared_ptr<OutputRegistry> output_registry)
       : m_output_registry(output_registry), m_threads_nb(0), m_max_queue(0) {}
 
   std::unique_ptr<Measurement> getMeasurement() const;

--- a/SEImplementation/SEImplementation/Output/OutputFactory.h
+++ b/SEImplementation/SEImplementation/Output/OutputFactory.h
@@ -38,8 +38,8 @@ class OutputFactory : public Configurable {
 
 public:
 
-  OutputFactory(std::shared_ptr<OutputRegistry> output_registry) : m_output_registry(output_registry),
-                                                                   m_flush_size(100) {
+  explicit OutputFactory(std::shared_ptr<OutputRegistry> output_registry)
+    : m_output_registry(output_registry), m_flush_size(100) {
   }
 
 
@@ -53,7 +53,7 @@ public:
   void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const override;
 
 private:
-  
+
   std::shared_ptr<OutputRegistry> m_output_registry;
   TableOutput::TableHandler m_table_handler;
   TableOutput::SourceHandler m_source_handler;

--- a/SEImplementation/SEImplementation/Partition/AttractorsPartitionStep.h
+++ b/SEImplementation/SEImplementation/Partition/AttractorsPartitionStep.h
@@ -47,7 +47,7 @@ public:
    */
   virtual ~AttractorsPartitionStep() = default;
 
-  AttractorsPartitionStep(std::shared_ptr<SourceFactory> source_factory) :
+  explicit AttractorsPartitionStep(std::shared_ptr<SourceFactory> source_factory) :
         m_source_factory(source_factory) {}
 
   virtual std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const override;

--- a/SEImplementation/SEImplementation/Partition/MinAreaPartitionStep.h
+++ b/SEImplementation/SEImplementation/Partition/MinAreaPartitionStep.h
@@ -40,7 +40,7 @@ public:
   virtual ~MinAreaPartitionStep() = default;
 
   /// Constructor
-  MinAreaPartitionStep(unsigned int min_pixel_count);
+  explicit MinAreaPartitionStep(unsigned int min_pixel_count);
 
   virtual std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const override;
 


### PR DESCRIPTION
I do not understand why they don't get all reported at once, at each build sonar adds some.