### PR TITLE
Feature/lower resolution

### DIFF
--- a/ModelFitting/ModelFitting/Image/PsfTraits.h
+++ b/ModelFitting/ModelFitting/Image/PsfTraits.h
@@ -31,7 +31,7 @@ namespace ModelFitting {
  * This way they do not have to be modified.
  *
  * PSF types that have this concept should specialize the trait with has_context = true
- * and the appropiate context_t
+ * and the appropriate context_t
  */
 template <typename PsfType>
 struct PsfTraits {

--- a/ModelFitting/ModelFitting/Models/FrameModel.h
+++ b/ModelFitting/ModelFitting/Models/FrameModel.h
@@ -146,14 +146,12 @@ public:
              std::vector<ConstantModel> constant_model_list,
              std::vector<PointModel> point_model_list,
              std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
-             PsfType psf,
-             double down_scaling=1.0);
+             PsfType psf);
   
   FrameModel(double pixel_scale, std::size_t width, std::size_t height,
              std::vector<ConstantModel> constant_model_list,
              std::vector<PointModel> point_model_list,
-             std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
-             double down_scaling=1.0);
+             std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list);
 
 
   FrameModel(FrameModel&&) = default;
@@ -182,7 +180,6 @@ private:
   std::vector<std::shared_ptr<ExtendedModel<ImageType>>> m_extended_model_list;
   psf_container_t m_psf;
   std::unique_ptr<ImageType> m_model_image {};
-  double m_down_scaling;
   
 }; // end of class FrameModel
 

--- a/ModelFitting/ModelFitting/Models/FrameModel.h
+++ b/ModelFitting/ModelFitting/Models/FrameModel.h
@@ -66,9 +66,9 @@ public:
    * @param image
    *    The image to convolve
    */
-  template <typename ImageType>
-  void convolve(size_t, ImageType& image) {
-    PsfType::convolve(image);
+  template<typename... Args>
+  void convolve(size_t, Args&&... args) {
+    PsfType::convolve(std::forward<Args>(args)...);
   }
 };
 
@@ -107,14 +107,14 @@ public:
    * @param image
    *    The image to convolve
    */
-  template <typename ImageType>
-  void convolve(size_t i, ImageType& image) {
+  template<typename... Args>
+  void convolve(size_t i, Args&&... args) {
     auto& context = m_psf_contexts[i];
     if (!context) {
-      context = PsfType::prepare(image);
+      context = PsfType::prepare(std::forward<Args>(args)...);
       m_psf_contexts[i] = std::move(context);
     }
-    PsfType::convolve(image, m_psf_contexts[i]);
+    PsfType::convolve(std::forward<Args>(args)..., m_psf_contexts[i]);
   }
 
 private:
@@ -146,12 +146,14 @@ public:
              std::vector<ConstantModel> constant_model_list,
              std::vector<PointModel> point_model_list,
              std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
-             PsfType psf);
+             PsfType psf,
+             double down_scaling=1.0);
   
   FrameModel(double pixel_scale, std::size_t width, std::size_t height,
              std::vector<ConstantModel> constant_model_list,
              std::vector<PointModel> point_model_list,
-             std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list);
+             std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
+             double down_scaling=1.0);
 
 
   FrameModel(FrameModel&&) = default;
@@ -180,6 +182,7 @@ private:
   std::vector<std::shared_ptr<ExtendedModel<ImageType>>> m_extended_model_list;
   psf_container_t m_psf;
   std::unique_ptr<ImageType> m_model_image {};
+  double m_down_scaling;
   
 }; // end of class FrameModel
 

--- a/ModelFitting/ModelFitting/Models/_impl/FrameModel.icpp
+++ b/ModelFitting/ModelFitting/Models/_impl/FrameModel.icpp
@@ -41,24 +41,28 @@ FrameModel<PsfType, ImageType>::FrameModel(double pixel_scale, std::size_t width
                                            std::vector<ConstantModel> constant_model_list,
                                            std::vector<PointModel> point_model_list,
                                            std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
-                                           PsfType psf)
+                                           PsfType psf,
+                                           double down_scaling)
         : m_pixel_scale{pixel_scale}, m_width{width}, m_height{height},
           m_constant_model_list{std::move(constant_model_list)},
           m_point_model_list{std::move(point_model_list)},
           m_extended_model_list{std::move(extended_model_list)},
-          m_psf{std::move(psf), m_extended_model_list.size()} {
+          m_psf{std::move(psf), m_extended_model_list.size()},
+          m_down_scaling{down_scaling} {
 }
 
 template <typename PsfType, typename ImageType>
 FrameModel<PsfType, ImageType>::FrameModel(double pixel_scale, std::size_t width, std::size_t height,
                                            std::vector<ConstantModel> constant_model_list,
                                            std::vector<PointModel> point_model_list,
-                                           std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list)
+                                           std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
+                                           double down_scaling)
         : m_pixel_scale{pixel_scale}, m_width{width}, m_height{height},
           m_constant_model_list{std::move(constant_model_list)},
           m_point_model_list{std::move(point_model_list)},
           m_extended_model_list{std::move(extended_model_list)},
-          m_psf{m_extended_model_list.size()} {
+          m_psf{m_extended_model_list.size()},
+          m_down_scaling{down_scaling} {
 }
 
 template <typename PsfType, typename ImageType>
@@ -89,21 +93,23 @@ void addPointModels(ImageType& image, const std::vector<PointModel>& model_list,
   
 template <typename ImageType, typename PsfType>
 void addExtendedModels(ImageType& image, const std::vector<std::shared_ptr<ExtendedModel<ImageType>>>& model_list,
-                       PsfType& psf, double pixel_scale) {
+                       PsfType& psf, double pixel_scale, double down_scaling) {
   using Traits = ImageTraits<ImageType>;
   auto scale_factor = psf.getPixelScale() / pixel_scale;
   for (size_t i = 0; i < model_list.size(); ++i) {
     auto& model = model_list[i];
-    std::size_t width = std::ceil(model->getWidth() / psf.getPixelScale() + psf.getSize());
-    if (width%2 == 0) {
+    std::size_t width = std::ceil((model->getWidth() / psf.getPixelScale() + psf.getSize()) * down_scaling);
+    if (width % 2 == 0) {
       ++width;
     }
-    std::size_t height = std::ceil(model->getHeight() / psf.getPixelScale() + psf.getSize());
-    if (height%2 == 0) {
+    std::size_t height = std::ceil((model->getHeight() / psf.getPixelScale() + psf.getSize()) * down_scaling);
+    if (height % 2 == 0) {
       ++height;
     }
+
     auto extended_image = model->getRasterizedImage(psf.getPixelScale(), width, height);
     psf.convolve(i, extended_image);
+    //psf.convolve(i, extended_image, down_scaling);
     Traits::addImageToImage(image, extended_image, scale_factor, model->getX(), model->getY());
   }
 }
@@ -127,7 +133,7 @@ template <typename PsfType, typename ImageType>
 void FrameModel<PsfType, ImageType>::rasterToImage(ImageType &model_image) {
   _impl::addConstantModels(model_image, m_constant_model_list);
   _impl::addPointModels(model_image, m_point_model_list, m_psf, m_pixel_scale);
-  _impl::addExtendedModels(model_image, m_extended_model_list, m_psf, m_pixel_scale);
+  _impl::addExtendedModels(model_image, m_extended_model_list, m_psf, m_pixel_scale, m_down_scaling);
 }
 
 template <typename PsfType, typename ImageType>

--- a/ModelFitting/ModelFitting/Models/_impl/FrameModel.icpp
+++ b/ModelFitting/ModelFitting/Models/_impl/FrameModel.icpp
@@ -105,7 +105,6 @@ void addExtendedModels(ImageType& image, const std::vector<std::shared_ptr<Exten
 
     auto extended_image = model->getRasterizedImage(psf.getPixelScale(), width, height);
     psf.convolve(i, extended_image);
-    //psf.convolve(i, extended_image, down_scaling);
     Traits::addImageToImage(image, extended_image, scale_factor, model->getX(), model->getY());
   }
 }

--- a/ModelFitting/ModelFitting/Models/_impl/FrameModel.icpp
+++ b/ModelFitting/ModelFitting/Models/_impl/FrameModel.icpp
@@ -41,28 +41,24 @@ FrameModel<PsfType, ImageType>::FrameModel(double pixel_scale, std::size_t width
                                            std::vector<ConstantModel> constant_model_list,
                                            std::vector<PointModel> point_model_list,
                                            std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
-                                           PsfType psf,
-                                           double down_scaling)
+                                           PsfType psf)
         : m_pixel_scale{pixel_scale}, m_width{width}, m_height{height},
           m_constant_model_list{std::move(constant_model_list)},
           m_point_model_list{std::move(point_model_list)},
           m_extended_model_list{std::move(extended_model_list)},
-          m_psf{std::move(psf), m_extended_model_list.size()},
-          m_down_scaling{down_scaling} {
+          m_psf{std::move(psf), m_extended_model_list.size()} {
 }
 
 template <typename PsfType, typename ImageType>
 FrameModel<PsfType, ImageType>::FrameModel(double pixel_scale, std::size_t width, std::size_t height,
                                            std::vector<ConstantModel> constant_model_list,
                                            std::vector<PointModel> point_model_list,
-                                           std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list,
-                                           double down_scaling)
+                                           std::vector<std::shared_ptr<ExtendedModel<ImageType>>> extended_model_list)
         : m_pixel_scale{pixel_scale}, m_width{width}, m_height{height},
           m_constant_model_list{std::move(constant_model_list)},
           m_point_model_list{std::move(point_model_list)},
           m_extended_model_list{std::move(extended_model_list)},
-          m_psf{m_extended_model_list.size()},
-          m_down_scaling{down_scaling} {
+          m_psf{m_extended_model_list.size()} {
 }
 
 template <typename PsfType, typename ImageType>
@@ -93,16 +89,16 @@ void addPointModels(ImageType& image, const std::vector<PointModel>& model_list,
   
 template <typename ImageType, typename PsfType>
 void addExtendedModels(ImageType& image, const std::vector<std::shared_ptr<ExtendedModel<ImageType>>>& model_list,
-                       PsfType& psf, double pixel_scale, double down_scaling) {
+                       PsfType& psf, double pixel_scale) {
   using Traits = ImageTraits<ImageType>;
   auto scale_factor = psf.getPixelScale() / pixel_scale;
   for (size_t i = 0; i < model_list.size(); ++i) {
     auto& model = model_list[i];
-    std::size_t width = std::ceil((model->getWidth() / psf.getPixelScale() + psf.getSize()) * down_scaling);
+    std::size_t width = std::ceil(model->getWidth() / psf.getPixelScale() + psf.getSize());
     if (width % 2 == 0) {
       ++width;
     }
-    std::size_t height = std::ceil((model->getHeight() / psf.getPixelScale() + psf.getSize()) * down_scaling);
+    std::size_t height = std::ceil(model->getHeight() / psf.getPixelScale() + psf.getSize());
     if (height % 2 == 0) {
       ++height;
     }
@@ -133,7 +129,7 @@ template <typename PsfType, typename ImageType>
 void FrameModel<PsfType, ImageType>::rasterToImage(ImageType &model_image) {
   _impl::addConstantModels(model_image, m_constant_model_list);
   _impl::addPointModels(model_image, m_point_model_list, m_psf, m_pixel_scale);
-  _impl::addExtendedModels(model_image, m_extended_model_list, m_psf, m_pixel_scale, m_down_scaling);
+  _impl::addExtendedModels(model_image, m_extended_model_list, m_psf, m_pixel_scale);
 }
 
 template <typename PsfType, typename ImageType>

--- a/SEFramework/SEFramework/Source/SourceFlags.h
+++ b/SEFramework/SEFramework/Source/SourceFlags.h
@@ -47,7 +47,8 @@ enum class Flags : int64_t {
   ERROR             = 1ll << 10, ///< Error flag: something bad happened during the measurement, model fitting, etc.
   MEMORY            = 1ll << 11, ///< Failed to allocate an object, buffer, etc.
   BAD_PROJECTION    = 1ll << 12, ///< Failed to project some of the coordinates into one of the measurement frames
-  SENTINEL          = 1ll << 13, ///< Used to find the boundary of possible values
+  DOWNSAMPLED       = 1ll << 13, ///< The fit was done on a downsampled image due to exceeding max size
+  SENTINEL          = 1ll << 14, ///< Used to find the boundary of possible values
 };
 
 /// String representation of the flags
@@ -61,7 +62,9 @@ const std::map<Flags, std::string> FlagsStr = {
   {Flags::PARTIAL_FIT, "PARTIAL_FIT"},
   {Flags::INSUFFICIENT_DATA, "INSUFFICIENT_DATA"},
   {Flags::ERROR, "ERROR"},
-  {Flags::MEMORY, "MEMORY"}
+  {Flags::MEMORY, "MEMORY"},
+  {Flags::BAD_PROJECTION, "BAD_PROJECTION"},
+  {Flags::DOWNSAMPLED, "DOWNSAMPLED"}
 };
 
 

--- a/SEImplementation/SEImplementation/Configuration/SamplingConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/SamplingConfig.h
@@ -44,9 +44,15 @@ public:
     return m_scale_factor;
   }
 
+  size_t getMaxFitSize() const {
+    return m_max_fit_size;
+  }
+
+
 private:
   double m_adaptive_target;
   double m_scale_factor;
+  size_t m_max_fit_size;
 };
 
 

--- a/SEImplementation/SEImplementation/Image/DownSampledImagePsf.h
+++ b/SEImplementation/SEImplementation/Image/DownSampledImagePsf.h
@@ -1,0 +1,74 @@
+/** Copyright © 2019-2021 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*
+ * DownSampledImagePsf.h
+ *
+ *  Created on: Nov 5, 2021
+ *      Author: mschefer
+ */
+
+#ifndef _SEIMPLEMENTATION_IMAGE_DOWNSAMPLEDIMAGEPSF_H_
+#define _SEIMPLEMENTATION_IMAGE_DOWNSAMPLEDIMAGEPSF_H_
+
+#include "ElementsKernel/Exception.h"
+#include "AlexandriaKernel/memory_tools.h"
+#include "ModelFitting/Image/PsfTraits.h"
+#include "SEFramework/Image/VectorImage.h"
+#include "SEFramework/Image/ProcessedImage.h"
+#include "SEFramework/Convolution/Convolution.h"
+
+#include "SEImplementation/Image/ImagePsf.h"
+
+namespace SourceXtractor {
+
+class DownSampledImagePsf {
+public:
+
+  DownSampledImagePsf(double pixel_scale, std::shared_ptr<VectorImage<SeFloat>> image, double down_scaling=1.0);
+
+  virtual ~DownSampledImagePsf() = default;
+
+  double getPixelScale(int mip=0) const;
+  std::size_t getSize(int mip=0) const;
+  std::shared_ptr<VectorImage<SourceXtractor::SeFloat>> getScaledKernel(SeFloat scale, int mip=0) const;
+  void convolve(std::shared_ptr<WriteableImage<float>> image, double down_scaling=1.0) const;
+
+private:
+  void generateMips(std::shared_ptr<const VectorImage<SeFloat>> image);
+
+  double m_pixel_scale;
+  double m_down_scaling;
+  std::vector<std::shared_ptr<ImagePsf>> m_psf_mip;
+
+};
+
+} // end of SourceXtractor
+
+//namespace ModelFitting {
+//
+///**
+// * Specialization of PsfTraits, as DFTConvolution has the concept of context
+// */
+//template<>
+//struct PsfTraits<SourceXtractor::DownSampledImagePsf> {
+//  using context_t = typename std::unique_ptr<SourceXtractor::ImagePsf::ConvolutionContext>;
+//  static constexpr bool has_context = true;
+//};
+
+//} // end of ModelFitting
+
+#endif /* _SEIMPLEMENTATION_IMAGE_DOWNSAMPLEDIMAGEPSF_H_ */

--- a/SEImplementation/SEImplementation/Image/DownSampledImagePsf.h
+++ b/SEImplementation/SEImplementation/Image/DownSampledImagePsf.h
@@ -35,6 +35,9 @@
 
 namespace SourceXtractor {
 
+/*
+ * Encapsulates ImagePsf to provide a downscaled version for performance
+ */
 class DownSampledImagePsf {
 public:
 
@@ -42,33 +45,33 @@ public:
 
   virtual ~DownSampledImagePsf() = default;
 
-  double getPixelScale(int mip=0) const;
-  std::size_t getSize(int mip=0) const;
-  std::shared_ptr<VectorImage<SourceXtractor::SeFloat>> getScaledKernel(SeFloat scale, int mip=0) const;
-  void convolve(std::shared_ptr<WriteableImage<float>> image, double down_scaling=1.0) const;
+  double getPixelScale() const;
+  std::size_t getSize() const;
+  std::shared_ptr<VectorImage<SourceXtractor::SeFloat>> getScaledKernel(SeFloat scale) const;
+  void convolve(std::shared_ptr<WriteableImage<float>> image) const;
+
+  // For ConvolutionContext optimization
+  std::unique_ptr<DFTConvolution<SeFloat>::ConvolutionContext> prepare(const std::shared_ptr<const Image<SeFloat>>& model_ptr) const;
+  void convolve(std::shared_ptr<WriteableImage<float>> image, std::unique_ptr<DFTConvolution<SeFloat>::ConvolutionContext>& context) const;
 
 private:
-  void generateMips(std::shared_ptr<const VectorImage<SeFloat>> image);
-
-  double m_pixel_scale;
   double m_down_scaling;
-  std::vector<std::shared_ptr<ImagePsf>> m_psf_mip;
-
+  std::shared_ptr<ImagePsf> m_psf;
 };
 
 } // end of SourceXtractor
 
-//namespace ModelFitting {
-//
-///**
-// * Specialization of PsfTraits, as DFTConvolution has the concept of context
-// */
-//template<>
-//struct PsfTraits<SourceXtractor::DownSampledImagePsf> {
-//  using context_t = typename std::unique_ptr<SourceXtractor::ImagePsf::ConvolutionContext>;
-//  static constexpr bool has_context = true;
-//};
+namespace ModelFitting {
 
-//} // end of ModelFitting
+/**
+ * Specialization of PsfTraits, as DFTConvolution has the concept of context
+ */
+template<>
+struct PsfTraits<SourceXtractor::DownSampledImagePsf> {
+  using context_t = typename std::unique_ptr<SourceXtractor::ImagePsf::ConvolutionContext>;
+  static constexpr bool has_context = true;
+};
+
+} // end of ModelFitting
 
 #endif /* _SEIMPLEMENTATION_IMAGE_DOWNSAMPLEDIMAGEPSF_H_ */

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
@@ -86,7 +86,7 @@ private:
                                  int index, FittingState& state) const;
   int fitSourcePrepareModels(FlexibleModelFittingParameterManager& parameter_manager,
       ModelFitting::ResidualEstimator& res_estimator, int& good_pixels,
-      SourceGroupInterface& group, SourceInterface& source, int index, FittingState& state) const;
+      SourceGroupInterface& group, SourceInterface& source, int index, FittingState& state, double downscaling) const;
   SeFloat fitSourceComputeChiSquared(FlexibleModelFittingParameterManager& parameter_manager,
       SourceGroupInterface& group, SourceInterface& source, int index, FittingState& state) const;
   void fitSourceUpdateState(FlexibleModelFittingParameterManager& parameter_manager, SourceInterface& source,
@@ -107,6 +107,8 @@ private:
   std::vector<std::shared_ptr<FlexibleModelFittingPrior>> m_priors;
 
   double m_scale_factor;
+
+  int m_max_fit_size = 100*100;
 };
 
 }

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
@@ -46,7 +46,8 @@ public:
       double scale_factor=1.0,
       int meta_iterations=3,
       double deblend_factor=1.0,
-      double meta_iteration_stop=0.0001
+      double meta_iteration_stop=0.0001,
+      size_t max_fit_size=100
       );
 
   virtual ~FlexibleModelFittingIterativeTask();
@@ -82,8 +83,7 @@ private:
       std::shared_ptr<const Image<SeFloat>> model, std::shared_ptr<const Image<SeFloat>> weights, int& data_points) const;
   int fitSourcePrepareParameters(FlexibleModelFittingParameterManager& parameter_manager,
                                  ModelFitting::EngineParameterManager& engine_parameter_manager,
-                                 SourceGroupInterface& group, SourceInterface& source,
-                                 int index, FittingState& state) const;
+                                 SourceInterface& source, int index, FittingState& state) const;
   int fitSourcePrepareModels(FlexibleModelFittingParameterManager& parameter_manager,
       ModelFitting::ResidualEstimator& res_estimator, int& good_pixels,
       SourceGroupInterface& group, SourceInterface& source, int index, FittingState& state, double downscaling) const;
@@ -98,17 +98,15 @@ private:
   std::string m_least_squares_engine;
   unsigned int m_max_iterations;
   double m_modified_chi_squared_scale;
+  double m_scale_factor;
   int m_meta_iterations;
   double m_deblend_factor;
   double m_meta_iteration_stop;
+  size_t m_max_fit_size;
 
   std::vector<std::shared_ptr<FlexibleModelFittingParameter>> m_parameters;
   std::vector<std::shared_ptr<FlexibleModelFittingFrame>> m_frames;
   std::vector<std::shared_ptr<FlexibleModelFittingPrior>> m_priors;
-
-  double m_scale_factor;
-
-  int m_max_fit_size = 100*100;
 };
 
 }

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingTaskFactory.h
@@ -59,6 +59,7 @@ private:
   std::vector<std::shared_ptr<FlexibleModelFittingPrior>> m_priors;
 
   double m_scale_factor {1.0};
+  double m_max_fit_size {100};
 };
 
 }

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/OnnxCompactModel.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/OnnxCompactModel.h
@@ -38,7 +38,7 @@ public:
 
   virtual ~OnnxCompactModel() = default;
 
-  double getValue(double x, double y) const override {
+  double getValue(double, double) const override {
     return 0.0; // unused
   }
 

--- a/SEImplementation/src/lib/Configuration/SamplingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/SamplingConfig.cpp
@@ -24,11 +24,12 @@ namespace po = boost::program_options;
 
 namespace SourceXtractor {
 
-static const std::string SAMPLING_ADAPTIVE_TARGET {"sampling-adaptive-target"};
+//static const std::string SAMPLING_ADAPTIVE_TARGET {"sampling-adaptive-target"};
 static const std::string SAMPLING_SCALE_FACTOR {"sampling-scale-factor"};
+static const std::string SAMPLING_MAX_FIT_SIZE {"sampling-max-fit-size"};
 
 SamplingConfig::SamplingConfig(long manager_id) : Configuration(manager_id),
-    m_adaptive_target(0.001), m_scale_factor(1.0) {}
+    m_adaptive_target(0.001), m_scale_factor(1.0), m_max_fit_size(1000) {}
 
 auto SamplingConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return {{"Model Fitting Sampling",
@@ -36,7 +37,9 @@ auto SamplingConfig::getProgramOptions() -> std::map<std::string, OptionDescript
 //        {SAMPLING_ADAPTIVE_TARGET.c_str(), po::value<double>()->default_value(0.001),
 //         "Adaptive sampling will stop when difference is less than this"},
         {SAMPLING_SCALE_FACTOR.c_str(), po::value<double>()->default_value(1.0),
-         "Scaling factor for the rendering of models (e.g. 2 = twice the resolution)"}
+         "Scaling factor for the rendering of models (e.g. 2 = twice the resolution)"},
+        {SAMPLING_MAX_FIT_SIZE.c_str(), po::value<size_t>()->default_value(1000),
+         "Size of maximum fit area before downsampling (in pixels, one side)"}
       }
   }};
 }
@@ -47,6 +50,7 @@ void SamplingConfig::preInitialize(const UserValues& args) {
 void SamplingConfig::initialize(const UserValues& args) {
 //  m_adaptive_target = args.at(SAMPLING_ADAPTIVE_TARGET).as<double>();
   m_scale_factor = args.at(SAMPLING_SCALE_FACTOR).as<double>();
+  m_max_fit_size = args.at(SAMPLING_MAX_FIT_SIZE).as<size_t>();
 }
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/src/lib/Image/DownSampledImagePsf.cpp
+++ b/SEImplementation/src/lib/Image/DownSampledImagePsf.cpp
@@ -1,0 +1,136 @@
+/** Copyright © 2019-2021 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*
+ * DownSampledImagePsf.cpp
+ *
+ *  Created on: Nov 9, 2021
+ *      Author: mschefer
+ */
+
+#include "SEImplementation/Image/ImageInterfaceTraits.h"
+#include "SEImplementation/Image/DownSampledImagePsf.h"
+
+namespace SourceXtractor {
+
+namespace {
+
+void renormalize(std::shared_ptr<VectorImage<SeFloat>> image, double flux) {
+  double acc = 0.0;
+
+  for (int y=0; y<image->getHeight(); y++) {
+    for (int x=0; x<image->getWidth(); x++) {
+      acc += image->getValue(x, y);
+    }
+  }
+
+  if (acc > 0.0) {
+    double scale = flux / acc;
+    for (int y=0; y<image->getHeight(); y++) {
+      for (int x=0; x<image->getWidth(); x++) {
+        image->setValue(x, y, image->getValue(x, y) * scale);
+      }
+    }
+  }
+}
+
+}
+
+DownSampledImagePsf::DownSampledImagePsf(
+    double pixel_scale, std::shared_ptr<VectorImage<SeFloat>> image, double down_scaling)
+    : m_pixel_scale(pixel_scale), m_down_scaling(down_scaling) {
+
+  using Traits = ::ModelFitting::ImageTraits<std::shared_ptr<VectorImage<SeFloat>>>;
+
+  if (image->getWidth() != image->getHeight()) {
+    throw Elements::Exception() << "PSF kernel must be square but was "
+                                << image->getWidth() << " x " << image->getHeight();
+  }
+  if (image->getWidth() % 2 == 0) {
+    throw Elements::Exception() << "PSF kernel must have odd size, but got "
+                                << image->getWidth();
+  }
+
+  if (down_scaling != 1.0) {
+    int new_size = image->getWidth() * down_scaling;
+    new_size += (new_size % 2 == 0) ? 1 : 0;
+
+    auto new_image = Traits::factory(new_size, new_size);
+    Traits::addImageToImage(new_image, image, down_scaling, new_size / 2.0, new_size / 2.0);
+    renormalize(new_image, 1.0);
+
+    m_psf_mip.emplace_back(std::make_shared<ImagePsf>(pixel_scale, new_image));
+  } else {
+    m_psf_mip.emplace_back(std::make_shared<ImagePsf>(pixel_scale, image));
+  }
+
+  //generateMips(image);
+}
+
+double DownSampledImagePsf::getPixelScale(int mip) const {
+  return m_psf_mip.at(mip)->getPixelScale();
+}
+
+std::size_t DownSampledImagePsf::getSize(int mip) const {
+  return m_psf_mip.at(mip)->getWidth();
+}
+
+std::shared_ptr<VectorImage<SourceXtractor::SeFloat>> DownSampledImagePsf::getScaledKernel(SeFloat scale, int mip) const {
+  return VectorImage<SeFloat>::create(*MultiplyImage<SourceXtractor::SeFloat>::create(m_psf_mip.at(mip)->getKernel(), scale));
+}
+
+void DownSampledImagePsf::convolve(std::shared_ptr<WriteableImage<float>> image, double down_scaling) const {
+  m_psf_mip.at(0)->convolve(image);
+}
+
+void DownSampledImagePsf::generateMips(std::shared_ptr<const VectorImage<SeFloat>> image) {
+  int mip_size = image->getWidth();
+
+  auto prev_image = image;
+
+  for (int mip = 3; ; mip += 3) {
+    mip_size = (mip_size + 2) / 3;
+    mip_size += (mip_size % 2 == 0) ? 1 : 0;
+
+    if (mip_size <= 1) {
+      break;
+    }
+
+    auto new_image = VectorImage<SeFloat>::create(mip_size, mip_size);
+    for (int y = 0; y < mip_size; y++) {
+      for (int x = 0; x < mip_size; x++) {
+        int ox = x * 3;
+        int oy = y * 3;
+
+        double acc = 0.0;
+        for (int dy = 0; dy < 3; dy++) {
+          for (int dx = 0; dx < 3; dx++) {
+            if (ox + dx >= 0 && oy + dy >= 0) {
+              acc += prev_image->getValue(ox + dx, oy + dy);
+            }
+          }
+        }
+
+        new_image->setValue(x, y, acc);
+      }
+    }
+
+    m_psf_mip.emplace_back(std::make_shared<ImagePsf>(m_pixel_scale / mip, image));
+  }
+}
+
+}
+

--- a/SEImplementation/src/lib/Image/DownSampledImagePsf.cpp
+++ b/SEImplementation/src/lib/Image/DownSampledImagePsf.cpp
@@ -21,37 +21,17 @@
  *      Author: mschefer
  */
 
+#include <numeric>
+#include <iostream>
+
 #include "SEImplementation/Image/ImageInterfaceTraits.h"
 #include "SEImplementation/Image/DownSampledImagePsf.h"
 
 namespace SourceXtractor {
 
-namespace {
-
-void renormalize(std::shared_ptr<VectorImage<SeFloat>> image, double flux) {
-  double acc = 0.0;
-
-  for (int y=0; y<image->getHeight(); y++) {
-    for (int x=0; x<image->getWidth(); x++) {
-      acc += image->getValue(x, y);
-    }
-  }
-
-  if (acc > 0.0) {
-    double scale = flux / acc;
-    for (int y=0; y<image->getHeight(); y++) {
-      for (int x=0; x<image->getWidth(); x++) {
-        image->setValue(x, y, image->getValue(x, y) * scale);
-      }
-    }
-  }
-}
-
-}
-
 DownSampledImagePsf::DownSampledImagePsf(
     double pixel_scale, std::shared_ptr<VectorImage<SeFloat>> image, double down_scaling)
-    : m_pixel_scale(pixel_scale), m_down_scaling(down_scaling) {
+    : m_down_scaling(down_scaling) {
 
   using Traits = ::ModelFitting::ImageTraits<std::shared_ptr<VectorImage<SeFloat>>>;
 
@@ -70,67 +50,45 @@ DownSampledImagePsf::DownSampledImagePsf(
 
     auto new_image = Traits::factory(new_size, new_size);
     Traits::addImageToImage(new_image, image, down_scaling, new_size / 2.0, new_size / 2.0);
-    renormalize(new_image, 1.0);
 
-    m_psf_mip.emplace_back(std::make_shared<ImagePsf>(pixel_scale, new_image));
+    // renormalize psf
+    auto psf_sum = std::accumulate(new_image->getData().begin(), new_image->getData().end(), 0.);
+    for (auto& pixel : new_image->getData()) {
+      pixel /= psf_sum;
+    }
+
+    m_psf = std::make_shared<ImagePsf>(pixel_scale / down_scaling, new_image);
   } else {
-    m_psf_mip.emplace_back(std::make_shared<ImagePsf>(pixel_scale, image));
-  }
-
-  //generateMips(image);
-}
-
-double DownSampledImagePsf::getPixelScale(int mip) const {
-  return m_psf_mip.at(mip)->getPixelScale();
-}
-
-std::size_t DownSampledImagePsf::getSize(int mip) const {
-  return m_psf_mip.at(mip)->getWidth();
-}
-
-std::shared_ptr<VectorImage<SourceXtractor::SeFloat>> DownSampledImagePsf::getScaledKernel(SeFloat scale, int mip) const {
-  return VectorImage<SeFloat>::create(*MultiplyImage<SourceXtractor::SeFloat>::create(m_psf_mip.at(mip)->getKernel(), scale));
-}
-
-void DownSampledImagePsf::convolve(std::shared_ptr<WriteableImage<float>> image, double down_scaling) const {
-  m_psf_mip.at(0)->convolve(image);
-}
-
-void DownSampledImagePsf::generateMips(std::shared_ptr<const VectorImage<SeFloat>> image) {
-  int mip_size = image->getWidth();
-
-  auto prev_image = image;
-
-  for (int mip = 3; ; mip += 3) {
-    mip_size = (mip_size + 2) / 3;
-    mip_size += (mip_size % 2 == 0) ? 1 : 0;
-
-    if (mip_size <= 1) {
-      break;
-    }
-
-    auto new_image = VectorImage<SeFloat>::create(mip_size, mip_size);
-    for (int y = 0; y < mip_size; y++) {
-      for (int x = 0; x < mip_size; x++) {
-        int ox = x * 3;
-        int oy = y * 3;
-
-        double acc = 0.0;
-        for (int dy = 0; dy < 3; dy++) {
-          for (int dx = 0; dx < 3; dx++) {
-            if (ox + dx >= 0 && oy + dy >= 0) {
-              acc += prev_image->getValue(ox + dx, oy + dy);
-            }
-          }
-        }
-
-        new_image->setValue(x, y, acc);
-      }
-    }
-
-    m_psf_mip.emplace_back(std::make_shared<ImagePsf>(m_pixel_scale / mip, image));
+    m_psf = std::make_shared<ImagePsf>(pixel_scale, image);
   }
 }
+
+double DownSampledImagePsf::getPixelScale() const {
+  return m_psf->getPixelScale();
+}
+
+std::size_t DownSampledImagePsf::getSize() const {
+  return m_psf->getWidth();
+}
+
+std::shared_ptr<VectorImage<SourceXtractor::SeFloat>> DownSampledImagePsf::getScaledKernel(SeFloat scale) const {
+  return m_psf->getScaledKernel(scale);
+}
+
+void DownSampledImagePsf::convolve(std::shared_ptr<WriteableImage<float>> image) const {
+  m_psf->convolve(image);
+}
+
+std::unique_ptr<DFTConvolution<SeFloat>::ConvolutionContext> DownSampledImagePsf::prepare(
+    const std::shared_ptr<const Image<SeFloat>>& model_ptr) const {
+  return m_psf->prepare(model_ptr);
+}
+
+void DownSampledImagePsf::convolve(std::shared_ptr<WriteableImage<float>> image,
+    std::unique_ptr<DFTConvolution<SeFloat>::ConvolutionContext>& context) const{
+  m_psf->convolve(image, context);
+}
+
 
 }
 

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.cpp
@@ -104,13 +104,6 @@ std::shared_ptr<VectorImage<SeFloat>> createImageCopy(SourceInterface& source, i
   auto image = VectorImage<SeFloat>::create(frame_images.getImageChunk(
       LayerSubtractedImage, rect.getTopLeft().m_x, rect.getTopLeft().m_y, rect.getWidth(), rect.getHeight()));
 
-//  if (scale_factor != 1.0) {
-//    using Traits = ImageTraits<std::shared_ptr<VectorImage<SeFloat>>>;
-//    auto scaled_image = VectorImage<SeFloat>::create(rect.getWidth() * scale_factor, rect.getHeight() * scale_factor);
-//    Traits::addImageToImage(scaled_image, image, scale_factor, 0, 0);
-//    image = scaled_image;
-//  }
-//
   return image;
 }
 

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.cpp
@@ -472,7 +472,8 @@ void FlexibleModelFittingIterativeTask::fitSource(SourceGroupInterface& group, S
     if (isFrameValid(source, frame_index)) {
       auto psf_property = source.getProperty<SourcePsfProperty>(frame_index);
       auto stamp_rect = getFittingRect(source, frame_index);
-      fit_size = std::max(fit_size, stamp_rect.getWidth() * stamp_rect.getHeight() / psf_property.getPixelSampling());
+      fit_size = std::max(fit_size, stamp_rect.getWidth() * stamp_rect.getHeight() /
+          (psf_property.getPixelSampling() * psf_property.getPixelSampling()));
     }
   }
 

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
@@ -248,8 +248,8 @@ void FlexibleModelFittingTask::computeProperties(SourceGroupInterface& group) co
     auto stop_reason = solution.engine_stop_reason;
     switch (solution.status_flag) {
       case LeastSquareSummary::MEMORY:
-        group_flags |= Flags::MEMORY;
-        // fall through
+        group_flags |= (Flags::MEMORY | Flags::ERROR);
+        break;
       case LeastSquareSummary::ERROR:
         group_flags |= Flags::ERROR;
         break;

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTaskFactory.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<Task> FlexibleModelFittingTaskFactory::createTask(const Property
     if (m_use_iterative_fitting) {
       return std::make_shared<FlexibleModelFittingIterativeTask>(m_least_squares_engine, m_max_iterations,
           m_modified_chi_squared_scale, m_parameters, m_frames, m_priors, m_scale_factor,
-          m_meta_iterations, m_deblend_factor, m_meta_iteration_stop);
+          m_meta_iterations, m_deblend_factor, m_meta_iteration_stop, m_max_fit_size);
     } else {
       return std::make_shared<FlexibleModelFittingTask>(m_least_squares_engine, m_max_iterations,
           m_modified_chi_squared_scale, m_parameters, m_frames, m_priors, m_scale_factor);
@@ -89,6 +89,7 @@ void FlexibleModelFittingTaskFactory::configure(Euclid::Configuration::ConfigMan
   m_outputs = model_fitting_config.getOutputs();
 
   m_scale_factor = sampling_config.getScaleFactor();
+  m_max_fit_size = sampling_config.getMaxFitSize();
 }
 
 void FlexibleModelFittingTaskFactory::registerPropertyInstances(OutputRegistry& registry) {


### PR DESCRIPTION
Adaptive downgrade of model fitting resolution. Set a maximum sizeof the fitting area with --sampling-max-fit-size

For example --sampling-max-fit-size=500 means that the maximum fitting area should be a square of 500x500 or the equivalent area. We take into consideration the scale of the psf for that calculation. If the number of pixel is more than twice that area we begin scaling the psf and model rendering (to avoid rescaling for small differences)

Now --sampling-scaling-factor to increase or decrease the resolution should also be working correctly.
