### PR TITLE
added more model fitting info columns

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFitting.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFitting.h
@@ -44,14 +44,21 @@ public:
   FlexibleModelFitting(unsigned int iterations, unsigned int stop_reason,
                        SeFloat chi_squared, SeFloat duration, Flags flags,
                        std::unordered_map<int, double> parameter_values,
-                       std::unordered_map<int, double> parameter_sigmas) :
+                       std::unordered_map<int, double> parameter_sigmas,
+                       std::vector<SeFloat> chi_squared_per_meta,
+                       std::vector<int> iterations_per_meta,
+                       int meta_iterations) :
     m_iterations(iterations),
     m_stop_reason(stop_reason),
     m_chi_squared(chi_squared),
     m_duration(duration),
     m_flags(flags),
     m_parameter_values(parameter_values),
-    m_parameter_sigmas(parameter_sigmas) {}
+    m_parameter_sigmas(parameter_sigmas),
+    m_chi_squared_per_meta(chi_squared_per_meta),
+    m_iterations_per_meta(iterations_per_meta),
+    m_meta_iterations(meta_iterations)
+{}
 
   unsigned int getIterations() const {
     return m_iterations;
@@ -81,12 +88,28 @@ public:
     return m_duration;
   }
 
+  std::vector<SeFloat> getChiSquaredPerMetaIteration() const {
+    return m_chi_squared_per_meta;
+  }
+
+  std::vector<int> getIterationsPerMetaIteration() const {
+    return m_iterations_per_meta;
+  }
+
+  int getMetaIterations() const {
+    return m_meta_iterations;
+  }
+
 private:
   unsigned int m_iterations, m_stop_reason;
   SeFloat m_chi_squared, m_duration;
   Flags m_flags;
   std::unordered_map<int, double> m_parameter_values;
   std::unordered_map<int, double> m_parameter_sigmas;
+
+  std::vector<SeFloat> m_chi_squared_per_meta;
+  std::vector<int> m_iterations_per_meta;
+  int m_meta_iterations;
 };
 
 }

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
@@ -64,6 +64,8 @@ private:
     float duration;
     unsigned int iterations;
     unsigned int stop_reason;
+    std::vector<SeFloat> chi_squared_per_meta;
+    std::vector<int> iterations_per_meta;
   };
 
   struct FittingState {

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingPlugin.cpp
@@ -82,6 +82,33 @@ void FlexibleModelFittingPlugin::registerPlugin(PluginAPI& plugin_api) {
           "Model fitting flags"
   );
 
+  plugin_api.getOutputRegistry().registerColumnConverter<FlexibleModelFitting, std::vector<SeFloat>>(
+            "fmf_chi2_per_meta",
+            [](const FlexibleModelFitting& prop) {
+              return prop.getChiSquaredPerMetaIteration();
+            },
+            "",
+            "Reduced chi^2 per meta-iteration"
+    );
+
+  plugin_api.getOutputRegistry().registerColumnConverter<FlexibleModelFitting, std::vector<int>>(
+            "fmf_iterations_per_meta",
+            [](const FlexibleModelFitting& prop) {
+              return prop.getIterationsPerMetaIteration();
+            },
+            "",
+            "Iterations per meta-iteration"
+    );
+
+  plugin_api.getOutputRegistry().registerColumnConverter<FlexibleModelFitting, int>(
+            "fmf_meta_iterations",
+            [](const FlexibleModelFitting& prop) {
+              return prop.getMetaIterations();
+            },
+            "",
+            "Meta-iterations"
+    );
+
   plugin_api.getOutputRegistry().enableOutput<FlexibleModelFitting>("FlexibleModelFitting");
 }
 

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingTask.cpp
@@ -299,7 +299,9 @@ void FlexibleModelFittingTask::computeProperties(SourceGroupInterface& group) co
       }
       source.setProperty<FlexibleModelFitting>(iterations, stop_reason,
                                                avg_reduced_chi_squared, solution.duration, source_flags,
-                                               parameter_values, parameter_sigmas);
+                                               parameter_values, parameter_sigmas,
+                                               std::vector<SeFloat>({avg_reduced_chi_squared}),
+                                               std::vector<int>({(int) iterations}), (int) 1);
     }
     updateCheckImages(group, pixel_scale, parameter_manager);
 
@@ -325,7 +327,8 @@ void FlexibleModelFittingTask::setDummyProperty(SourceGroupInterface& group,
       dummy_values[parameter->getId()] = std::numeric_limits<double>::quiet_NaN();
     }
     source.setProperty<FlexibleModelFitting>(0, 0, std::numeric_limits<double>::quiet_NaN(), 0., flags,
-                                             dummy_values, dummy_values);
+                                             dummy_values, dummy_values,
+                                             std::vector<SeFloat>(1), std::vector<int>(1), 0);
   }
 }
 


### PR DESCRIPTION
Based on feedback related to iterative model fitting I'm making a few changes to the output of model fitting:

- fmf_iterations will now report the total number of iterations not just the last one
- fmf_meta_iterations added to report the number of meta iterations
- fmf_chi2_per_meta is a vector with the evolution of the reduced chi^2 over the iterations
- fmf_iterations_per_meta is a vector of of the number of iterations for each meta iteration

I think this will make things a bit clearer