### PR TITLE
Feature/onnx rename

### DIFF
--- a/SEImplementation/python/sourcextractor/config/__init__.py
+++ b/SEImplementation/python/sourcextractor/config/__init__.py
@@ -22,7 +22,7 @@ from .model_fitting import (RangeType, Range, Unbounded, print_parameters, Const
                             FreeParameter, DependentParameter,get_pos_parameters,
                             FluxParameterType, get_flux_parameter, add_model,
                             ConstantModel, PointSourceModel, SersicModel, ExponentialModel,
-                            DeVaucouleursModel, OnnxModel, print_model_fitting_info, add_prior, set_max_iterations,
+                            DeVaucouleursModel, ComputeGraphModel, print_model_fitting_info, add_prior, set_max_iterations,
                             pixel_to_world_coordinate, radius_to_wc_angle, get_separation_angle, get_position_angle,
                             get_world_position_parameters, get_world_parameters,
                             set_modified_chi_squared_scale, set_engine, use_iterative_fitting, set_meta_iterations,

--- a/SEImplementation/python/sourcextractor/config/model_fitting.py
+++ b/SEImplementation/python/sourcextractor/config/model_fitting.py
@@ -891,12 +891,14 @@ class DeVaucouleursModel(SersicModelBase):
             return 'DeVaucouleurs[x_coord={}, y_coord={}, flux={}, effective_radius={}, aspect_ratio={}, angle={}]'.format(
                 self.x_coord.id, self.y_coord.id, self.flux.id, self.effective_radius.id, self.aspect_ratio.id, self.angle.id)
 
-class OnnxModel(CoordinateModelBase):
+class ComputeGraphModel(CoordinateModelBase):
     """
-    Onnx model 
+    ComputeGraphModel model 
 
     Parameters
     ----------
+    models: string or list of strings, corresponding to path to Onnx format models,
+     (specifying more than one allows using the most efficient model based on render size.)
     x_coord : ParameterBase or float
         X coordinate (in the detection image)
     y_coord : ParameterBase or float
@@ -953,10 +955,10 @@ class OnnxModel(CoordinateModelBase):
         str
         """
         if show_params:
-            return 'Onnx[x_coord={}, y_coord={}, flux={}, effective_radius={}, aspect_ratio={}, angle={}]'.format(
+            return 'ComputeGraph[x_coord={}, y_coord={}, flux={}, effective_radius={}, aspect_ratio={}, angle={}]'.format(
                 self.x_coord, self.y_coord, self.flux, self.effective_radius, self.aspect_ratio, self.angle)
         else:
-            return 'Onnx[x_coord={}, y_coord={}, flux={}, effective_radius={}, aspect_ratio={}, angle={}]'.format(
+            return 'ComputeGraph[x_coord={}, y_coord={}, flux={}, effective_radius={}, aspect_ratio={}, angle={}]'.format(
                 self.x_coord.id, self.y_coord.id, self.flux.id, self.effective_radius.id, self.aspect_ratio.id, self.angle.id)
 
 

--- a/SEImplementation/src/lib/Configuration/SegmentationConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/SegmentationConfig.cpp
@@ -52,7 +52,7 @@ static const std::string SEGMENTATION_DISABLE_FILTERING {"segmentation-disable-f
 static const std::string SEGMENTATION_FILTER {"segmentation-filter" };
 static const std::string SEGMENTATION_LUTZ_WINDOW_SIZE {"segmentation-lutz-window-size" };
 static const std::string SEGMENTATION_BFS_MAX_DELTA {"segmentation-bfs-max-delta" };
-static const std::string SEGMENTATION_ONNX_MODEL {"segmentation-onnx-model" };
+static const std::string SEGMENTATION_ML_MODEL {"segmentation-ml-model" };
 static const std::string SEGMENTATION_ML_THRESHOLD {"segmentation-ml-threshold" };
 
 SegmentationConfig::SegmentationConfig(long manager_id) : Configuration(manager_id), m_selected_algorithm(Algorithm::UNKNOWN)
@@ -72,7 +72,7 @@ std::map<std::string, Configuration::OptionDescriptionList> SegmentationConfig::
           "Lutz sliding window size (0=disable)"},
       {SEGMENTATION_BFS_MAX_DELTA.c_str(), po::value<int>()->default_value(1000),
           "BFS algorithm max source x/y size (default=1000)"},
-      {SEGMENTATION_ONNX_MODEL.c_str(), po::value<std::string>()->default_value(""),
+      {SEGMENTATION_ML_MODEL.c_str(), po::value<std::string>()->default_value(""),
           "ONNX model to use with machine learning segmentation"},
       {SEGMENTATION_ML_THRESHOLD.c_str(), po::value<double>()->default_value(0.9),
           "Probability threshold for ML detection"},
@@ -110,7 +110,7 @@ void SegmentationConfig::preInitialize(const UserValues& args) {
 
   m_lutz_window_size = args.at(SEGMENTATION_LUTZ_WINDOW_SIZE).as<int>();
   m_bfs_max_delta = args.at(SEGMENTATION_BFS_MAX_DELTA).as<int>();
-  m_onnx_model_path = args.at(SEGMENTATION_ONNX_MODEL).as<std::string>();
+  m_onnx_model_path = args.at(SEGMENTATION_ML_MODEL).as<std::string>();
   m_ml_threshold = args.at(SEGMENTATION_ML_THRESHOLD).as<double>();
 
   if (m_selected_algorithm == Algorithm::ML && m_onnx_model_path == "") {

--- a/SEImplementation/src/lib/Plugin/Onnx/OnnxConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/Onnx/OnnxConfig.cpp
@@ -23,19 +23,20 @@ using namespace Euclid::Configuration;
 
 namespace SourceXtractor {
 
-static const std::string ONNX_MODEL{"onnx-model"};
+static const std::string ML_MEASUREMENT_MODEL{"ml-measurement-model"};
 
 OnnxConfig::OnnxConfig(long manager_id) : Configuration(manager_id) {
 }
 
 auto OnnxConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return {{"ONNX", {
-    {ONNX_MODEL.c_str(), po::value<std::vector<std::string>>()->multitoken(), "ONNX models"}
+    {ML_MEASUREMENT_MODEL.c_str(), po::value<std::vector<std::string>>()->multitoken(),
+        "ONNX-format models for machine learning based measurements"}
   }}};
 }
 
 void OnnxConfig::initialize(const Configuration::Configuration::UserValues& args) {
-  auto i = args.find(ONNX_MODEL);
+  auto i = args.find(ML_MEASUREMENT_MODEL);
   if (i != args.end()) {
     m_onnx_model_paths = i->second.as<std::vector<std::string>>();
   }

--- a/SEImplementation/src/lib/Plugin/Onnx/OnnxPlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/Onnx/OnnxPlugin.cpp
@@ -23,16 +23,16 @@
 namespace SourceXtractor {
 
 static StaticPlugin<OnnxPlugin> onnx_plugin;
-Elements::Logging onnx_logger = Elements::Logging::getLogger("Onnx");
+Elements::Logging onnx_logger = Elements::Logging::getLogger("MLMeasurement");
 
 std::string OnnxPlugin::getIdString() const {
-  return "OnnxPlugin";
+  return "MLMeasurementPlugin";
 }
 
 void OnnxPlugin::registerPlugin(PluginAPI& plugin_api) {
   plugin_api.getTaskFactoryRegistry().registerTaskFactory<OnnxTaskFactory, OnnxProperty>();
   // Note that we do not now the output yet, so we do not register any columns
-  plugin_api.getOutputRegistry().enableOutput<OnnxProperty>("ONNX", true);
+  plugin_api.getOutputRegistry().enableOutput<OnnxProperty>("MLMeasurement", true);
 }
 
 } // end of namespace SourceXtractor


### PR DESCRIPTION
closes #428 

OnnxModel is renamed to ComputeGraphModel

--segmentation-onnx-model -> --segmentation-ml-model

--onnx-model -> --ml-measurement-model

And the Onnx property is now called MLMeasurement

Note: only user visible options have been changed, internal code identifiers stay the same
