### PR TITLE
new defaults

### DIFF
--- a/SEImplementation/python/sourcextractor/config/model_fitting.py
+++ b/SEImplementation/python/sourcextractor/config/model_fitting.py
@@ -527,8 +527,8 @@ sersic_model_dict = {}
 exponential_model_dict = {}
 de_vaucouleurs_model_dict = {}
 onnx_model_dict = {}
-params_dict = {"max_iterations": 100, "modified_chi_squared_scale": 10, "engine": "", "use_iterative_fitting": False, "meta_iterations": 3,
-               "deblend_factor": 1, "meta_iteration_stop": 0.0001}
+params_dict = {"max_iterations": 200, "modified_chi_squared_scale": 10, "engine": "", "use_iterative_fitting": True, "meta_iterations": 5,
+               "deblend_factor": 0.95, "meta_iteration_stop": 0.0001}
 
 
 def set_max_iterations(iterations):

--- a/SEImplementation/src/lib/Configuration/GroupingConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/GroupingConfig.cpp
@@ -50,7 +50,7 @@ GroupingConfig::GroupingConfig(long manager_id)
 
 std::map<std::string, Configuration::OptionDescriptionList> GroupingConfig::getProgramOptions() {
   return { {"Grouping", {
-      {GROUPING_ALGORITHM.c_str(), po::value<std::string>()->default_value(GROUPING_ALGORITHM_NONE),
+      {GROUPING_ALGORITHM.c_str(), po::value<std::string>()->default_value(GROUPING_ALGORITHM_SPLIT),
           "Grouping algorithm to be used [none|overlap|split|moffat]."},
       {GROUPING_HARD_LIMIT.c_str(), po::value<unsigned int>()->default_value(0),
           "Maximum number of sources in a single group (0 = unlimited)"},

--- a/SEImplementation/src/lib/Configuration/MultiThresholdPartitionConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MultiThresholdPartitionConfig.cpp
@@ -45,7 +45,7 @@ MultiThresholdPartitionConfig::MultiThresholdPartitionConfig(long manager_id) : 
 
 auto MultiThresholdPartitionConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return { {"Multi-thresholding", {
-      {MTHRESH_USE.c_str(), po::bool_switch(), "activates multithreshold partitioning"},
+      {MTHRESH_USE.c_str(), po::value<bool>()->default_value(true), "activates/deactivates multithreshold partitioning"},
       {MTHRESH_THRESHOLDS_NB.c_str(), po::value<int>()->default_value(32), "# of thresholds"},
       {MTHRESH_MIN_AREA.c_str(), po::value<int>()->default_value(3), "min area in pixels to consider partitioning"},
       {MTHRESH_MIN_CONTRAST.c_str(), po::value<double>()->default_value(0.005), "min contrast of for partitioning"}


### PR DESCRIPTION
Multithreshold active by default, --partition-multithreshold now a boolean option instead of a switch
Grouping algorithm set to SPLIT by default

Default python model fitting options set to use_iterative_fitting=true, max_iterations = 200, meta_iterations=5, deblend_factor=0.95

