### PR TITLE
remove file exists check that prevents cfitsio syntax

### DIFF
--- a/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/ExternalFlag/ExternalFlagConfig.cpp
@@ -75,12 +75,6 @@ void ExternalFlagConfig::preInitialize(const UserValues& args) {
       type = boost::to_upper_copy(args.at(poh::wildcard(FLAG_TYPE, name)).as<std::string>());
     }
     
-    // Check that the file exists
-    auto& filename = args.at(poh::wildcard(FLAG_IMAGE, name)).as<std::string>();
-    if (!fs::exists(filename)) {
-      throw Elements::Exception() << "File " << filename << " does not exist";
-    }
-    
     // Check that the type is a valid option
     if (available_types.count(type) == 0) {
       throw Elements::Exception() << "Invalid option " << poh::wildcard(FLAG_TYPE, name)


### PR DESCRIPTION
closes #418 

The only reason cfitsio HDU syntax was not working for flags was an explicit check for the file existing in the configuration.

Overall we still need to investigate if using cfitsio syntax anywhere is actually guaranteed to work all the time, as it's more of a happy accident than anything planned.
