### PR TITLE
remove unnecessary any_cast

### DIFF
--- a/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingTask.cpp
+++ b/SEImplementation/src/lib/Plugin/MoffatModelFitting/MoffatModelFittingTask.cpp
@@ -253,7 +253,7 @@ void MoffatModelFittingTask::computeProperties(SourceInterface& source) const {
   // Perform the minimization
   auto engine = LeastSquareEngineManager::create(m_least_squares_engine, m_max_iterations);
   auto solution = engine->solveProblem(manager, res_estimator);
-  size_t iterations = (size_t) boost::any_cast<std::array<double,10>>(solution.underlying_framework_info)[5];
+  size_t iterations = solution.iteration_no;
 
   auto final_stamp = VectorImage<SeFloat>::create(source_stamp.getWidth(), source_stamp.getHeight());
 


### PR DESCRIPTION
Number of iterations was extracted directly from levmar data with any_cast, it seems to cause a crash in some cases (moffat fit failed maybe?) It's no longer necessary to do that.
