### PR TITLE
flux_scale^2 is applied to weight_threshold

### DIFF
--- a/SEImplementation/src/lib/Configuration/WeightImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/WeightImageConfig.cpp
@@ -131,7 +131,7 @@ void WeightImageConfig::initialize(const UserValues& args) {
     m_weight_threshold = computeWeightThreshold(m_weight_type, threshold);
     if (flux_scale != 1. && m_absolute_weight){
 	// adjust the m_weight_threshold
-	m_weight_threshold *= flux_scale;
+	m_weight_threshold *= flux_scale * flux_scale;
     }
   } else {
     m_weight_threshold = std::numeric_limits<WeightImage::PixelType>::max();


### PR DESCRIPTION
That should fix this. I did only a quick testing and a data set ran over the modified line. But the general mechanics did not change.

