### PR TITLE
Add pipeline interfaces

### DIFF
--- a/SEFramework/SEFramework/Output/Output.h
+++ b/SEFramework/SEFramework/Output/Output.h
@@ -35,7 +35,7 @@ class Output : public PipelineReceiver<SourceGroupInterface> {
 public:
   virtual ~Output() = default;
 
-  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) override {
+  void receiveSource(std::unique_ptr<SourceGroupInterface> source_group) override {
     for (auto& source : *source_group) {
       outputSource(source);
     }

--- a/SEFramework/SEFramework/Output/Output.h
+++ b/SEFramework/SEFramework/Output/Output.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -24,28 +24,25 @@
 #ifndef _SEFRAMEWORK_PIPELINE_OUTPUT_H_
 #define _SEFRAMEWORK_PIPELINE_OUTPUT_H_
 
-#include "SEUtils/Observable.h"
-#include "SEFramework/Source/SourceInterface.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Source/SourceGroupInterface.h"
+#include "SEFramework/Source/SourceInterface.h"
 
 namespace SourceXtractor {
 
-class Output :
-    public Observer<std::shared_ptr<SourceInterface>>,
-    public Observer<std::shared_ptr<SourceGroupInterface>> {
+class Output : public PipelineReceiver<SourceGroupInterface> {
 
 public:
-
   virtual ~Output() = default;
 
-  void handleMessage(const std::shared_ptr<SourceInterface>& source) override {
-    outputSource(*source);
-  }
-
-  void handleMessage(const std::shared_ptr<SourceGroupInterface>& source_group) override {
+  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) override {
     for (auto& source : *source_group) {
       outputSource(source);
     }
+  }
+
+  void receiveProcessSignal(const ProcessSourcesEvent&) override {
+    // pass
   }
 
   virtual void outputSource(const SourceInterface& source) = 0;

--- a/SEFramework/SEFramework/Pipeline/Deblending.h
+++ b/SEFramework/SEFramework/Pipeline/Deblending.h
@@ -64,7 +64,7 @@ public:
   explicit Deblending(std::vector<std::shared_ptr<DeblendStep>> deblend_steps);
 
   /// Handles a new SourceGroup, applies the DeblendSteps and then notifies the observers with the result
-  void receiveSource(const std::shared_ptr<SourceGroupInterface>& group) override;
+  void receiveSource(std::unique_ptr<SourceGroupInterface> group) override;
 
   void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 

--- a/SEFramework/SEFramework/Pipeline/Deblending.h
+++ b/SEFramework/SEFramework/Pipeline/Deblending.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -23,7 +23,7 @@
 #ifndef _SEFRAMEWORK_PIPELINE_DEBLENDING_H
 #define _SEFRAMEWORK_PIPELINE_DEBLENDING_H
 
-#include "SEUtils/Observable.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Source/SourceGroupInterface.h"
 #include "SEFramework/Task/TaskProvider.h"
 
@@ -53,8 +53,7 @@ public:
  * for deblending the group.
  *
  */
-class Deblending : public Observer<std::shared_ptr<SourceGroupInterface>>,
-  public Observable<std::shared_ptr<SourceGroupInterface>> {
+class Deblending : public PipelineReceiver<SourceGroupInterface>, public PipelineEmitter<SourceGroupInterface> {
 
 public:
 
@@ -65,7 +64,9 @@ public:
   explicit Deblending(std::vector<std::shared_ptr<DeblendStep>> deblend_steps);
 
   /// Handles a new SourceGroup, applies the DeblendSteps and then notifies the observers with the result
-  void handleMessage(const std::shared_ptr<SourceGroupInterface>& group) override;
+  void receiveSource(const std::shared_ptr<SourceGroupInterface>& group) override;
+
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
   /// Returns the set of required properties to compute the deblending
   std::set<PropertyId> requiredProperties() const;

--- a/SEFramework/SEFramework/Pipeline/Measurement.h
+++ b/SEFramework/SEFramework/Pipeline/Measurement.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -25,18 +25,16 @@
 #define _SEFRAMEWORK_PIPELINE_MEASUREMENT_H_
 
 
-#include "SEUtils/Observable.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Source/SourceGroupInterface.h"
 #include "SEFramework/Task/TaskProvider.h"
 
 namespace SourceXtractor {
 
-class Measurement :
-    public Observer<std::shared_ptr<SourceGroupInterface>>,
-    public Observable<std::shared_ptr<SourceGroupInterface>> {
+class Measurement : public PipelineReceiver<SourceGroupInterface>, public PipelineEmitter<SourceGroupInterface> {
 public:
 
-  virtual ~Measurement() = default;
+  ~Measurement() override = default;
 
   virtual void startThreads() = 0;
   virtual void stopThreads() = 0;

--- a/SEFramework/SEFramework/Pipeline/Partition.h
+++ b/SEFramework/SEFramework/Pipeline/Partition.h
@@ -23,7 +23,7 @@
 #ifndef _SEFRAMEWORK_PIPELINE_PARTITION_H
 #define _SEFRAMEWORK_PIPELINE_PARTITION_H
 
-#include "SEUtils/Observable.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Source/SourceInterface.h"
 
 namespace SourceXtractor {
@@ -36,7 +36,6 @@ namespace SourceXtractor {
  */
 class PartitionStep {
 public:
-
   /**
    * @brief Destructor
    */
@@ -54,10 +53,9 @@ public:
  * notified to the Observers one by one.
  *
  */
-class Partition : public Observer<std::shared_ptr<SourceInterface>>, public Observable<std::shared_ptr<SourceInterface>> {
+class Partition : public PipelineReceiver<SourceInterface>, public PipelineEmitter<SourceInterface> {
 
 public:
-
   /**
    * @brief Destructor
    */
@@ -66,8 +64,8 @@ public:
   /// Constructor - takes a vector of PartitionSteps to be applied in order
   explicit Partition(std::vector<std::shared_ptr<PartitionStep>> steps);
 
-  /// Handles a Source (applies PartitionSteps) and notifies the Observers for every Source in the final result
-  void handleMessage(const std::shared_ptr<SourceInterface>& source) override;
+  void receiveSource(const std::shared_ptr<SourceInterface>& source) override;
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
 private:
   std::vector<std::shared_ptr<PartitionStep>> m_steps;
@@ -75,6 +73,5 @@ private:
 }; /* End of Partition class */
 
 } /* namespace SourceXtractor */
-
 
 #endif

--- a/SEFramework/SEFramework/Pipeline/Partition.h
+++ b/SEFramework/SEFramework/Pipeline/Partition.h
@@ -41,7 +41,7 @@ public:
    */
   virtual ~PartitionStep() = default;
 
-  virtual std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const = 0;
+  virtual std::vector<std::unique_ptr<SourceInterface>> partition(std::unique_ptr<SourceInterface> source) const = 0;
 };
 
 /**
@@ -64,7 +64,7 @@ public:
   /// Constructor - takes a vector of PartitionSteps to be applied in order
   explicit Partition(std::vector<std::shared_ptr<PartitionStep>> steps);
 
-  void receiveSource(const std::shared_ptr<SourceInterface>& source) override;
+  void receiveSource(std::unique_ptr<SourceInterface> source) override;
   void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
 private:

--- a/SEFramework/SEFramework/Pipeline/PipelineStage.h
+++ b/SEFramework/SEFramework/Pipeline/PipelineStage.h
@@ -1,0 +1,104 @@
+/** Copyright © 2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _SEFRAMEWORK_PIPELINE_PIPELINESTAGE_H
+#define _SEFRAMEWORK_PIPELINE_PIPELINESTAGE_H
+
+#include "SEFramework/Source/SourceInterface.h"
+#include "SEUtils/Observable.h"
+
+namespace SourceXtractor {
+
+class SelectionCriteria;
+
+/**
+ * @class ProcessSourcesEvent
+ * @brief Event received by SourceGrouping to request the processing of some of the Sources stored.
+ *
+ */
+struct ProcessSourcesEvent {
+
+  const std::shared_ptr<SelectionCriteria> m_selection_criteria;  // Used to identify the Sources to process
+
+  explicit ProcessSourcesEvent(std::shared_ptr<SelectionCriteria> selection_criteria)
+      : m_selection_criteria(std::move(selection_criteria)) {}
+};
+
+/**
+ * Receiver component of a pipeline.
+ * @tparam T
+ */
+template <typename T>
+class PipelineReceiver {
+public:
+  virtual ~PipelineReceiver() = default;
+
+  /**
+   * Receive a source from the previous stage. The receiver owns the object.
+   * @param source
+   */
+  virtual void receiveSource(const std::shared_ptr<T>& source)        = 0;
+
+  /**
+   * Receive a signal to process sources when grouping
+   * @param event
+   */
+  virtual void receiveProcessSignal(const ProcessSourcesEvent& event) = 0;
+};
+
+/**
+ * Emitter component of a pipeline
+ * @tparam T
+ */
+template <typename T>
+class PipelineEmitter : public Observable<T> {
+public:
+  ~PipelineEmitter() override = default;
+
+  /**
+   * Set the next stage of the pipeline. There can be *only one*, so there is a single
+   * pipeline stage owning the object.
+   * @param next
+   */
+  void setNextStage(std::shared_ptr<PipelineReceiver<T>> next) {
+    if (m_next_stage) {
+      throw Elements::Exception() << "Next stage already set";
+    }
+    m_next_stage = std::move(next);
+  }
+
+protected:
+  void sendSource(const std::shared_ptr<T>& source) const {
+    Observable<T>::notifyObservers(*source);
+    if (m_next_stage) {
+      m_next_stage->receiveSource(source);
+    }
+  }
+
+  void sendProcessSignal(const ProcessSourcesEvent& event) const {
+    if (m_next_stage) {
+      m_next_stage->receiveProcessSignal(event);
+    }
+  }
+
+private:
+  std::shared_ptr<PipelineReceiver<T>> m_next_stage;
+};
+
+}  // namespace SourceXtractor
+
+#endif  // _SEFRAMEWORK_PIPELINE_PIPELINESTAGE_H

--- a/SEFramework/SEFramework/Pipeline/PipelineStage.h
+++ b/SEFramework/SEFramework/Pipeline/PipelineStage.h
@@ -51,7 +51,7 @@ public:
    * Receive a source from the previous stage. The receiver owns the object.
    * @param source
    */
-  virtual void receiveSource(const std::shared_ptr<T>& source)        = 0;
+  virtual void receiveSource(std::unique_ptr<T> source)        = 0;
 
   /**
    * Receive a signal to process sources when grouping
@@ -82,10 +82,10 @@ public:
   }
 
 protected:
-  void sendSource(const std::shared_ptr<T>& source) const {
+  void sendSource(std::unique_ptr<T> source) const {
     Observable<T>::notifyObservers(*source);
     if (m_next_stage) {
-      m_next_stage->receiveSource(source);
+      m_next_stage->receiveSource(std::move(source));
     }
   }
 

--- a/SEFramework/SEFramework/Pipeline/Segmentation.h
+++ b/SEFramework/SEFramework/Pipeline/Segmentation.h
@@ -26,18 +26,13 @@
 #include <memory>
 #include <type_traits>
 
-#include "SEFramework/Property/DetectionFrame.h"
-#include "SEFramework/Frame/Frame.h"
-
-#include "SEUtils/Observable.h"
-#include "SEFramework/Source/SourceInterface.h"
-#include "SEFramework/Image/Image.h"
 #include "SEFramework/CoordinateSystem/CoordinateSystem.h"
 #include "SEFramework/Frame/Frame.h"
-
+#include "SEFramework/Image/Image.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Pipeline/SourceGrouping.h"
-
-
+#include "SEFramework/Property/DetectionFrame.h"
+#include "SEFramework/Source/SourceInterface.h"
 
 namespace SourceXtractor {
 
@@ -55,8 +50,7 @@ struct SegmentationProgress {
  * results in a notification of the Segmentation's Observers.
  *
  */
-class Segmentation : public Observable<std::shared_ptr<SourceInterface>>, public Observable<SegmentationProgress>,
-    public Observable<ProcessSourcesEvent> {
+class Segmentation : public PipelineEmitter<SourceInterface> , public Observable<SegmentationProgress> {
 
 public:
   class LabellingListener;
@@ -80,11 +74,6 @@ public:
   /// Processes a Frame notifying Observers with a Source object for each detection
   void processFrame(std::shared_ptr<DetectionImageFrame> frame) const;
 
-protected:
-  void publishSource(std::shared_ptr<SourceInterface> source) const {
-    Observable<std::shared_ptr<SourceInterface>>::notifyObservers(source);
-  }
-
 private:
   std::unique_ptr<Labelling> m_labelling;
   std::shared_ptr<DetectionImageFrame::ImageFilter> m_filter_image_processing;
@@ -99,7 +88,7 @@ public:
 
   void publishSource(std::shared_ptr<SourceInterface> source) const {
     source->setProperty<DetectionFrame>(m_detection_frame);
-    m_segmentation.Observable<std::shared_ptr<SourceInterface>>::notifyObservers(source);
+    m_segmentation.sendSource(source);
   }
 
   void notifyProgress(int position, int total) {
@@ -107,7 +96,7 @@ public:
   }
 
   void requestProcessing(const ProcessSourcesEvent& event) {
-    m_segmentation.Observable<ProcessSourcesEvent>::notifyObservers(event);
+    m_segmentation.sendProcessSignal(event);
   }
 
 private:

--- a/SEFramework/SEFramework/Pipeline/Segmentation.h
+++ b/SEFramework/SEFramework/Pipeline/Segmentation.h
@@ -86,9 +86,9 @@ public:
     m_segmentation(segmentation),
     m_detection_frame(detection_frame) {}
 
-  void publishSource(std::shared_ptr<SourceInterface> source) const {
+  void publishSource(std::unique_ptr<SourceInterface> source) const {
     source->setProperty<DetectionFrame>(m_detection_frame);
-    m_segmentation.sendSource(source);
+    m_segmentation.sendSource(std::move(source));
   }
 
   void notifyProgress(int position, int total) {

--- a/SEFramework/SEFramework/Pipeline/SourceGrouping.h
+++ b/SEFramework/SEFramework/Pipeline/SourceGrouping.h
@@ -103,7 +103,7 @@ public:
   std::set<PropertyId> requiredProperties() const;
 
   /// Handles a new Source
-  void receiveSource(const std::shared_ptr<SourceInterface>& source) override;
+  void receiveSource(std::unique_ptr<SourceInterface> source) override;
 
   /// Handles a ProcessSourcesEvent to trigger the processing of some of the Sources stored in SourceGrouping
   void receiveProcessSignal(const ProcessSourcesEvent& event) override;
@@ -111,7 +111,7 @@ public:
 private:
   std::shared_ptr<GroupingCriteria> m_grouping_criteria;
   std::shared_ptr<SourceGroupFactory> m_group_factory;
-  std::list<std::shared_ptr<SourceGroupInterface>> m_source_groups;
+  std::list<std::unique_ptr<SourceGroupInterface>> m_source_groups;
   unsigned int m_hard_limit;
 
 }; /* End of SourceGrouping class */

--- a/SEFramework/SEFramework/Pipeline/SourceGrouping.h
+++ b/SEFramework/SEFramework/Pipeline/SourceGrouping.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -23,14 +23,13 @@
 #ifndef _SEFRAMEWORK_PIPELINE_SOURCEGROUPING_H
 #define _SEFRAMEWORK_PIPELINE_SOURCEGROUPING_H
 
-#include <memory>
 #include <list>
+#include <memory>
 
-#include "SEUtils/Observable.h"
-
-#include "SEFramework/Source/SourceInterface.h"
-#include "SEFramework/Source/SourceGroupInterface.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Source/SourceGroupFactory.h"
+#include "SEFramework/Source/SourceGroupInterface.h"
+#include "SEFramework/Source/SourceInterface.h"
 
 namespace SourceXtractor {
 
@@ -62,20 +61,6 @@ public:
   }
 };
 
-
-/**
- * @class ProcessSourcesEvent
- * @brief Event received by SourceGrouping to request the processing of some of the Sources stored.
- *
- */
-struct ProcessSourcesEvent {
-
-  const std::shared_ptr<SelectionCriteria> m_selection_criteria;   // Used to identify the Sources to process
-
-  explicit ProcessSourcesEvent(const std::shared_ptr<SelectionCriteria>& selection_criteria)
-    : m_selection_criteria(selection_criteria) {}
-};
-
 /**
  * @class GroupingCriteria
  * @brief Criteria used by SourceGrouping to determine if two sources should be grouped together
@@ -102,8 +87,7 @@ public:
  *  sources they are grouped with as a SourceGroup.
  *
  */
-class SourceGrouping : public Observer<std::shared_ptr<SourceInterface>>,
-    public Observer<ProcessSourcesEvent>, public Observable<std::shared_ptr<SourceGroupInterface>> {
+class SourceGrouping : public PipelineEmitter<SourceGroupInterface>, public PipelineReceiver<SourceInterface> {
 public:
 
   /**
@@ -115,17 +99,16 @@ public:
                  std::shared_ptr<SourceGroupFactory> group_factory,
                  unsigned int hard_limit);
 
-  /// Handles a new Source
-  void handleMessage(const std::shared_ptr<SourceInterface>& source) override;
-
-  /// Handles a ProcessSourcesEvent to trigger the processing of some of the Sources stored in SourceGrouping
-  void handleMessage(const ProcessSourcesEvent& source) override;
-
   /// Returns the set of required properties to compute the grouping
   std::set<PropertyId> requiredProperties() const;
 
-private:
+  /// Handles a new Source
+  void receiveSource(const std::shared_ptr<SourceInterface>& source) override;
 
+  /// Handles a ProcessSourcesEvent to trigger the processing of some of the Sources stored in SourceGrouping
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override;
+
+private:
   std::shared_ptr<GroupingCriteria> m_grouping_criteria;
   std::shared_ptr<SourceGroupFactory> m_group_factory;
   std::list<std::shared_ptr<SourceGroupInterface>> m_source_groups;

--- a/SEFramework/SEFramework/Source/SimpleSourceFactory.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceFactory.h
@@ -40,8 +40,8 @@ public:
 
   SimpleSourceFactory() {}
 
-  std::shared_ptr<SourceInterface> createSource() const override {
-    return std::make_shared<SimpleSource>();
+  std::unique_ptr<SourceInterface> createSource() const override {
+    return std::make_unique<SimpleSource>();
   }
 };
 

--- a/SEFramework/SEFramework/Source/SimpleSourceFactory.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceFactory.h
@@ -26,6 +26,7 @@
 
 #include "SEFramework/Source/SourceFactory.h"
 #include "SEFramework/Source/SimpleSource.h"
+#include <AlexandriaKernel/memory_tools.h>
 
 namespace SourceXtractor {
 
@@ -41,7 +42,7 @@ public:
   SimpleSourceFactory() {}
 
   std::unique_ptr<SourceInterface> createSource() const override {
-    return std::make_unique<SimpleSource>();
+    return Euclid::make_unique<SimpleSource>();
   }
 };
 

--- a/SEFramework/SEFramework/Source/SimpleSourceGroup.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceGroup.h
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file SimpleSourceGroup.h
  * @author nikoapos
  */
@@ -37,45 +37,45 @@ namespace SourceXtractor {
 
 
 class SimpleSourceGroup : public SourceGroupInterface {
-  
+
 public:
-  
+
   virtual ~SimpleSourceGroup() = default;
 
   iterator begin() override;
-  
+
   iterator end() override;
-  
-  const_iterator cbegin() override;
-  
-  const_iterator cend() override;
-  
+
+  const_iterator cbegin() const override;
+
+  const_iterator cend() const override;
+
   const_iterator begin() const override;
-  
+
   const_iterator end() const override;
-  
+
   void addSource(std::shared_ptr<SourceInterface> source) override;
-  
+
   iterator removeSource(iterator pos) override;
-  
+
   unsigned int size() const override;
 
   void merge(const SourceGroupInterface& other) override;
-  
+
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;
 
 protected:
-  
+
   const Property& getProperty(const PropertyId& property_id) const override;
 
   void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) override;
-  
+
 private:
-  
+
   std::list<SourceWrapper> m_sources;
   PropertyHolder m_property_holder;
-  
+
 }; /* End of SimpleSourceGroup class */
 
 } /* namespace SourceXtractor */

--- a/SEFramework/SEFramework/Source/SimpleSourceGroup.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceGroup.h
@@ -54,13 +54,13 @@ public:
 
   const_iterator end() const override;
 
-  void addSource(std::shared_ptr<SourceInterface> source) override;
+  void addSource(std::unique_ptr<SourceInterface> source) override;
 
   iterator removeSource(iterator pos) override;
 
   unsigned int size() const override;
 
-  void merge(const SourceGroupInterface& other) override;
+  void merge(SourceGroupInterface&& other) override;
 
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;

--- a/SEFramework/SEFramework/Source/SimpleSourceGroupFactory.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceGroupFactory.h
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file SimpleSourceGroupFactory.h
  * @author nikoapos
  */
@@ -33,13 +33,13 @@ namespace SourceXtractor {
  */
 
 class SimpleSourceGroupFactory : public SourceGroupFactory {
-  
+
 public:
 
-  std::shared_ptr<SourceGroupInterface> createSourceGroup() const override {
-    return std::make_shared<SimpleSourceGroup>();
+  std::unique_ptr<SourceGroupInterface> createSourceGroup() const override {
+    return std::make_unique<SimpleSourceGroup>();
   }
-  
+
 };
 
 }

--- a/SEFramework/SEFramework/Source/SimpleSourceGroupFactory.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceGroupFactory.h
@@ -24,6 +24,7 @@
 
 #include "SEFramework/Source/SourceGroupFactory.h"
 #include "SEFramework/Source/SimpleSourceGroup.h"
+#include <AlexandriaKernel/memory_tools.h>
 
 namespace SourceXtractor {
 
@@ -37,7 +38,7 @@ class SimpleSourceGroupFactory : public SourceGroupFactory {
 public:
 
   std::unique_ptr<SourceGroupInterface> createSourceGroup() const override {
-    return std::make_unique<SimpleSourceGroup>();
+    return Euclid::make_unique<SimpleSourceGroup>();
   }
 
 };

--- a/SEFramework/SEFramework/Source/SourceFactory.h
+++ b/SEFramework/SEFramework/Source/SourceFactory.h
@@ -40,7 +40,7 @@ class SourceFactory {
 public:
   virtual ~SourceFactory() = default;
 
-  virtual std::shared_ptr<SourceInterface> createSource() const = 0;
+  virtual std::unique_ptr<SourceInterface> createSource() const = 0;
 };
 
 }

--- a/SEFramework/SEFramework/Source/SourceGroupFactory.h
+++ b/SEFramework/SEFramework/Source/SourceGroupFactory.h
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file SourceGroupFactory.h
  * @author nikoapos
  */
@@ -38,7 +38,7 @@ class SourceGroupFactory {
 public:
   virtual ~SourceGroupFactory() = default;
 
-  virtual std::shared_ptr<SourceGroupInterface> createSourceGroup() const = 0;
+  virtual std::unique_ptr<SourceGroupInterface> createSourceGroup() const = 0;
 };
 
 }

--- a/SEFramework/SEFramework/Source/SourceGroupInterface.h
+++ b/SEFramework/SEFramework/Source/SourceGroupInterface.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file SourceGroupInterface.h
  * @author nikoapos
  */
@@ -35,7 +35,7 @@ namespace SourceXtractor {
  */
 
 class SourceGroupInterface : protected SourceInterface {
-  
+
   template <typename Collection>
   using CollectionType = typename std::iterator_traits<typename Collection::iterator>::value_type;
 
@@ -46,7 +46,7 @@ class SourceGroupInterface : protected SourceInterface {
   struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
 
 public:
-  
+
   class SourceWrapper : public SourceInterface {
   public:
 
@@ -83,16 +83,16 @@ public:
 
   virtual iterator begin() = 0;
   virtual iterator end() = 0;
-  virtual const_iterator cbegin() = 0;
-  virtual const_iterator cend() = 0;
+  virtual const_iterator cbegin() const = 0;
+  virtual const_iterator cend() const = 0;
   virtual const_iterator begin() const = 0;
   virtual const_iterator end() const = 0;
-  
+
   virtual void addSource(std::shared_ptr<SourceInterface> source) = 0;
   virtual iterator removeSource(iterator pos) = 0;
   virtual void merge(const SourceGroupInterface& other) = 0;
   virtual unsigned int size() const = 0;
-  
+
   /// Convenient method to add all the sources of a collection
   template <typename SourceCollection>
   void addAllSources(const SourceCollection& sources) {
@@ -104,7 +104,7 @@ public:
       addSource(source);
     }
   }
-  
+
   // We introduce the get/setProperty methods from the SourceInterface in the
   // public symbols so they become part of the SourceGroupInterface. The group
   // implementations must implement the methods with the PropertyId
@@ -112,8 +112,8 @@ public:
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;
   using SourceInterface::setIndexedProperty;
-  
-}; // end of SourceGroupInterface class 
+
+}; // end of SourceGroupInterface class
 
 } /* namespace SourceXtractor */
 

--- a/SEFramework/SEFramework/Source/SourceGroupInterface.h
+++ b/SEFramework/SEFramework/Source/SourceGroupInterface.h
@@ -39,20 +39,16 @@ class SourceGroupInterface : protected SourceInterface {
   template <typename Collection>
   using CollectionType = typename std::iterator_traits<typename Collection::iterator>::value_type;
 
-  // This is used to determine if a type is a kind of std::shared_ptr
-  template <class T>
-  struct is_shared_ptr : std::false_type {};
-  template <class T>
-  struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
-
 public:
 
   class SourceWrapper : public SourceInterface {
   public:
 
-    explicit SourceWrapper(std::shared_ptr<SourceInterface> source) : m_source(source) {}
+    explicit SourceWrapper(std::unique_ptr<SourceInterface> source) : m_source(std::move(source)) {}
 
-    SourceWrapper(const SourceWrapper& source) : m_source(source.m_source) {}
+    SourceWrapper(const SourceWrapper& source) = delete;
+
+    SourceWrapper(SourceWrapper&&) = default;
 
     const Property& getProperty(const PropertyId& property_id) const override {
       return m_source->getProperty(property_id);
@@ -75,7 +71,7 @@ public:
     using SourceInterface::setIndexedProperty;
 
   private:
-    std::shared_ptr<SourceInterface> m_source;
+    std::unique_ptr<SourceInterface> m_source;
   };
 
   using iterator = std::list<SourceWrapper>::iterator;
@@ -88,21 +84,20 @@ public:
   virtual const_iterator begin() const = 0;
   virtual const_iterator end() const = 0;
 
-  virtual void addSource(std::shared_ptr<SourceInterface> source) = 0;
+  virtual void addSource(std::unique_ptr<SourceInterface> source) = 0;
   virtual iterator removeSource(iterator pos) = 0;
-  virtual void merge(const SourceGroupInterface& other) = 0;
+  virtual void merge(SourceGroupInterface&& other) = 0;
   virtual unsigned int size() const = 0;
 
   /// Convenient method to add all the sources of a collection
   template <typename SourceCollection>
-  void addAllSources(const SourceCollection& sources) {
-    static_assert(is_shared_ptr<CollectionType<SourceCollection>>::value,
-        "SourceCollection must be a collection of std::shared_ptr");
+  void addAllSources(SourceCollection&& sources) {
     static_assert(std::is_base_of<SourceInterface, typename CollectionType<SourceCollection>::element_type>::value,
         "SourceCollection must be a collection of std::shared_ptr to SourceInterface or a type that inherits from it");
     for (auto& source : sources) {
-      addSource(source);
+      addSource(std::move(source));
     }
+    sources.clear();
   }
 
   // We introduce the get/setProperty methods from the SourceInterface in the

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -42,7 +42,7 @@ namespace SourceXtractor {
 class SourceGroupWithOnDemandProperties : public SourceGroupInterface {
 
 public:
-  
+
   explicit SourceGroupWithOnDemandProperties(std::shared_ptr<TaskProvider> task_provider);
 
   /**
@@ -51,41 +51,41 @@ public:
   virtual ~SourceGroupWithOnDemandProperties() = default;
 
   iterator begin() override;
-  
+
   iterator end() override;
-  
-  const_iterator cbegin() override;
-  
-  const_iterator cend() override;
-  
+
+  const_iterator cbegin() const override;
+
+  const_iterator cend() const override;
+
   const_iterator begin() const override;
-  
+
   const_iterator end() const override;
-  
+
   void addSource(std::shared_ptr<SourceInterface> source) override;
-  
+
   iterator removeSource(iterator pos) override;
-  
+
   void merge(const SourceGroupInterface& other) override;
-  
+
   unsigned int size() const override;
 
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;
 
 protected:
-  
+
   const Property& getProperty(const PropertyId& property_id) const override;
 
   void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) override;
 
 private:
-  
+
   class EntangledSource;
   std::list<SourceWrapper> m_sources;
   PropertyHolder m_property_holder;
   std::shared_ptr<TaskProvider> m_task_provider;
-  
+
   void clearGroupProperties();
 
 }; /* End of SourceGroup class */
@@ -93,9 +93,9 @@ private:
 
 
 class SourceGroupWithOnDemandProperties::EntangledSource : public SourceInterface {
-  
+
 public:
-  
+
   EntangledSource(std::shared_ptr<SourceInterface> source, SourceGroupWithOnDemandProperties& group);
 
   virtual ~EntangledSource() = default;
@@ -103,15 +103,15 @@ public:
   const Property& getProperty(const PropertyId& property_id) const override;
 
   void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) override;
-  
+
   bool operator<(const EntangledSource& other) const;
 
 private:
-  
+
   PropertyHolder m_property_holder;
   std::shared_ptr<SourceInterface> m_source;
   SourceGroupWithOnDemandProperties& m_group;
-  
+
   friend void SourceGroupWithOnDemandProperties::clearGroupProperties();
   friend void SourceGroupWithOnDemandProperties::merge(const SourceGroupInterface&);
 

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
@@ -62,11 +62,11 @@ public:
 
   const_iterator end() const override;
 
-  void addSource(std::shared_ptr<SourceInterface> source) override;
+  void addSource(std::unique_ptr<SourceInterface> source) override;
 
   iterator removeSource(iterator pos) override;
 
-  void merge(const SourceGroupInterface& other) override;
+  void merge(SourceGroupInterface&& other) override;
 
   unsigned int size() const override;
 
@@ -113,7 +113,7 @@ private:
   SourceGroupWithOnDemandProperties& m_group;
 
   friend void SourceGroupWithOnDemandProperties::clearGroupProperties();
-  friend void SourceGroupWithOnDemandProperties::merge(const SourceGroupInterface&);
+  friend void SourceGroupWithOnDemandProperties::merge(SourceGroupInterface&&);
 
 };
 

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandPropertiesFactory.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandPropertiesFactory.h
@@ -24,6 +24,7 @@
 
 #include "SEFramework/Source/SourceGroupFactory.h"
 #include "SEFramework/Source/SourceGroupWithOnDemandProperties.h"
+#include <AlexandriaKernel/memory_tools.h>
 
 namespace SourceXtractor {
 
@@ -40,7 +41,7 @@ public:
         m_task_provider(task_provider) {}
 
   std::unique_ptr<SourceGroupInterface> createSourceGroup() const override {
-    return std::make_unique<SourceGroupWithOnDemandProperties>(m_task_provider);
+    return Euclid::make_unique<SourceGroupWithOnDemandProperties>(m_task_provider);
   }
 
 private:

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandPropertiesFactory.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandPropertiesFactory.h
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file SourceGroupWithOnDemandPropertiesFactory.h
  * @author nikoapos
  */
@@ -33,20 +33,20 @@ namespace SourceXtractor {
  */
 
 class SourceGroupWithOnDemandPropertiesFactory : public SourceGroupFactory {
-  
+
 public:
-  
+
   explicit SourceGroupWithOnDemandPropertiesFactory(std::shared_ptr<TaskProvider> task_provider) :
         m_task_provider(task_provider) {}
 
-  std::shared_ptr<SourceGroupInterface> createSourceGroup() const override {
-    return std::make_shared<SourceGroupWithOnDemandProperties>(m_task_provider);
+  std::unique_ptr<SourceGroupInterface> createSourceGroup() const override {
+    return std::make_unique<SourceGroupWithOnDemandProperties>(m_task_provider);
   }
-  
+
 private:
-  
+
   std::shared_ptr<TaskProvider> m_task_provider;
-  
+
 };
 
 }

--- a/SEFramework/SEFramework/Source/SourceWithOnDemandPropertiesFactory.h
+++ b/SEFramework/SEFramework/Source/SourceWithOnDemandPropertiesFactory.h
@@ -39,8 +39,8 @@ public:
   explicit SourceWithOnDemandPropertiesFactory(std::shared_ptr<TaskProvider> task_provider) :
         m_task_provider(task_provider) {}
 
-  std::shared_ptr<SourceInterface> createSource() const override {
-    return std::make_shared<SourceWithOnDemandProperties>(m_task_provider);
+  std::unique_ptr<SourceInterface> createSource() const override {
+    return std::make_unique<SourceWithOnDemandProperties>(m_task_provider);
   }
 
 private:

--- a/SEFramework/SEFramework/Source/SourceWithOnDemandPropertiesFactory.h
+++ b/SEFramework/SEFramework/Source/SourceWithOnDemandPropertiesFactory.h
@@ -26,6 +26,7 @@
 
 #include "SEFramework/Source/SourceFactory.h"
 #include "SEFramework/Source/SourceWithOnDemandProperties.h"
+#include <AlexandriaKernel/memory_tools.h>
 
 namespace SourceXtractor {
 
@@ -40,7 +41,7 @@ public:
         m_task_provider(task_provider) {}
 
   std::unique_ptr<SourceInterface> createSource() const override {
-    return std::make_unique<SourceWithOnDemandProperties>(m_task_provider);
+    return Euclid::make_unique<SourceWithOnDemandProperties>(m_task_provider);
   }
 
 private:

--- a/SEFramework/src/lib/Pipeline/Deblending.cpp
+++ b/SEFramework/src/lib/Pipeline/Deblending.cpp
@@ -28,7 +28,7 @@ Deblending::Deblending(std::vector<std::shared_ptr<DeblendStep>> deblend_steps)
   : m_deblend_steps(std::move(deblend_steps)) {
 }
 
-void Deblending::receiveSource(const std::shared_ptr<SourceGroupInterface>& group) {
+void Deblending::receiveSource(std::unique_ptr<SourceGroupInterface> group) {
 
   // Applies every DeblendStep to the SourceGroup
   for (auto& step : m_deblend_steps) {
@@ -37,7 +37,7 @@ void Deblending::receiveSource(const std::shared_ptr<SourceGroupInterface>& grou
 
   // If the SourceGroup still contains sources, we notify the observers
   if (group->begin() != group->end()) {
-    sendSource(group);
+    sendSource(std::move(group));
   }
 }
 

--- a/SEFramework/src/lib/Pipeline/Deblending.cpp
+++ b/SEFramework/src/lib/Pipeline/Deblending.cpp
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -28,8 +28,8 @@ Deblending::Deblending(std::vector<std::shared_ptr<DeblendStep>> deblend_steps)
   : m_deblend_steps(std::move(deblend_steps)) {
 }
 
-void Deblending::handleMessage(const std::shared_ptr<SourceGroupInterface>& group) {
-  
+void Deblending::receiveSource(const std::shared_ptr<SourceGroupInterface>& group) {
+
   // Applies every DeblendStep to the SourceGroup
   for (auto& step : m_deblend_steps) {
     step->deblend(*group);
@@ -37,7 +37,7 @@ void Deblending::handleMessage(const std::shared_ptr<SourceGroupInterface>& grou
 
   // If the SourceGroup still contains sources, we notify the observers
   if (group->begin() != group->end()) {
-    notifyObservers(group);
+    sendSource(group);
   }
 }
 
@@ -48,6 +48,10 @@ std::set<PropertyId> Deblending::requiredProperties() const {
     std::copy(step_props.begin(), step_props.end(), std::inserter(properties, properties.end()));
   }
   return properties;
+}
+
+void Deblending::receiveProcessSignal(const ProcessSourcesEvent& event) {
+  sendProcessSignal(event);
 }
 
 } // SEFramework namespace

--- a/SEFramework/src/lib/Pipeline/Partition.cpp
+++ b/SEFramework/src/lib/Pipeline/Partition.cpp
@@ -28,14 +28,14 @@ Partition::Partition(std::vector<std::shared_ptr<PartitionStep>> steps)
   : m_steps(std::move(steps)) {
 }
 
-void Partition::receiveSource(const std::shared_ptr<SourceInterface>& input_source) {
+void Partition::receiveSource(std::unique_ptr<SourceInterface> input_source) {
   // The input of the current step
-  std::vector<std::shared_ptr<SourceInterface>> step_input_sources;
-  step_input_sources.emplace_back(input_source);
+  std::vector<std::unique_ptr<SourceInterface>> step_input_sources;
+  step_input_sources.emplace_back(std::move(input_source));
 
   // Applies all the steps
   for (const auto& step : m_steps) {
-    std::vector<std::shared_ptr<SourceInterface>> step_output_sources;
+    std::vector<std::unique_ptr<SourceInterface>> step_output_sources;
     // For each Source in pour input list
     for (auto& source : step_input_sources) {
       // applies the current step

--- a/SEFramework/src/lib/Pipeline/Partition.cpp
+++ b/SEFramework/src/lib/Pipeline/Partition.cpp
@@ -28,19 +28,21 @@ Partition::Partition(std::vector<std::shared_ptr<PartitionStep>> steps)
   : m_steps(std::move(steps)) {
 }
 
-void Partition::handleMessage(const std::shared_ptr<SourceInterface>& source) {
+void Partition::receiveSource(const std::shared_ptr<SourceInterface>& input_source) {
   // The input of the current step
-  std::vector<std::shared_ptr<SourceInterface>> step_input_sources { source };
+  std::vector<std::shared_ptr<SourceInterface>> step_input_sources;
+  step_input_sources.emplace_back(input_source);
 
   // Applies all the steps
   for (const auto& step : m_steps) {
     std::vector<std::shared_ptr<SourceInterface>> step_output_sources;
     // For each Source in pour input list
-    for (const auto& source : step_input_sources) {
+    for (auto& source : step_input_sources) {
       // applies the current step
-      const auto partition_output = step->partition(source);
+      auto partition_output = step->partition(std::move(source));
       // then merges the result
-      step_output_sources.insert(step_output_sources.end(), partition_output.begin(), partition_output.end());
+      step_output_sources.insert(step_output_sources.end(), std::make_move_iterator(partition_output.begin()),
+                                 std::make_move_iterator(partition_output.end()));
     }
 
     // the output of that step is then used as the input of the next
@@ -48,9 +50,12 @@ void Partition::handleMessage(const std::shared_ptr<SourceInterface>& source) {
   }
 
   // Observers are then notified of the output of the last step
-  for (const auto& source : step_input_sources) {
-    notifyObservers(source);
+  for (auto& source : step_input_sources) {
+    sendSource(std::move(source));
   }
+}
+void Partition::receiveProcessSignal(const ProcessSourcesEvent& event) {
+  sendProcessSignal(event);
 }
 
 } // SEFramework namespace

--- a/SEFramework/src/lib/Pipeline/PipelineStage.cpp
+++ b/SEFramework/src/lib/Pipeline/PipelineStage.cpp
@@ -1,0 +1,17 @@
+/** Copyright ©  2022 Université de Genève, LMU Munich - Faculty of Physics,
+ * IAP-CNRS/Sorbonne Université
+ *
+ *  This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 3.0 of the License, or (at your
+ * option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */

--- a/SEFramework/src/lib/Pipeline/Segmentation.cpp
+++ b/SEFramework/src/lib/Pipeline/Segmentation.cpp
@@ -39,7 +39,7 @@ void Segmentation::processFrame(std::shared_ptr<DetectionImageFrame> frame) cons
   }
 
   // Flush source grouping buffer
-  Observable<ProcessSourcesEvent>::notifyObservers(ProcessSourcesEvent(std::make_shared<SelectAllCriteria>()));
+  sendProcessSignal(ProcessSourcesEvent(std::make_shared<SelectAllCriteria>()));
 }
 
 }

--- a/SEFramework/src/lib/Pipeline/SourceGrouping.cpp
+++ b/SEFramework/src/lib/Pipeline/SourceGrouping.cpp
@@ -65,7 +65,7 @@ void SourceGrouping::receiveSource(std::unique_ptr<SourceInterface> source) {
         matched_group = group_it->get();
         matched_group->addSource(std::move(source));
       } else {
-        matched_group->merge(**group_it);
+        matched_group->merge(std::move(**group_it));
         groups_to_remove.emplace_back(group_it);
       }
     }

--- a/SEFramework/src/lib/Source/EntangledSource.cpp
+++ b/SEFramework/src/lib/Source/EntangledSource.cpp
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file EntangledSource.cpp
  * @author nikoapos
  */

--- a/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
+++ b/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
@@ -47,8 +47,8 @@ SimpleSourceGroup::const_iterator SimpleSourceGroup::end() const {
   return m_sources.cend();
 }
 
-void SimpleSourceGroup::addSource(std::shared_ptr<SourceInterface> source) {
-  m_sources.emplace_back(SourceWrapper(source));
+void SimpleSourceGroup::addSource(std::unique_ptr<SourceInterface> source) {
+  m_sources.emplace_back(SourceWrapper(std::move(source)));
 }
 
 SourceGroupInterface::iterator SimpleSourceGroup::removeSource(iterator pos) {
@@ -56,11 +56,12 @@ SourceGroupInterface::iterator SimpleSourceGroup::removeSource(iterator pos) {
   return next_iter;
 }
 
-void SimpleSourceGroup::merge(const SourceGroupInterface& other) {
-  auto& other_group = dynamic_cast<const SimpleSourceGroup&>(other);
+void SimpleSourceGroup::merge(SourceGroupInterface&& other) {
+  auto& other_group = dynamic_cast<SimpleSourceGroup&>(other);
   for (auto& source : other_group.m_sources) {
-    this->m_sources.emplace_back(source);
+    this->m_sources.emplace_back(std::move(source));
   }
+  other_group.m_sources.clear();
   m_property_holder.clear();
 }
 

--- a/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
+++ b/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -14,7 +14,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/* 
+/*
  * @file SimpleSourceGroup.cpp
  * @author nikoapos
  */
@@ -31,11 +31,11 @@ SimpleSourceGroup::iterator SimpleSourceGroup::end() {
   return m_sources.end();
 }
 
-SimpleSourceGroup::const_iterator SimpleSourceGroup::cbegin() {
+SimpleSourceGroup::const_iterator SimpleSourceGroup::cbegin() const {
   return m_sources.cbegin();
 }
 
-SimpleSourceGroup::const_iterator SimpleSourceGroup::cend() {
+SimpleSourceGroup::const_iterator SimpleSourceGroup::cend() const {
   return m_sources.cend();
 }
 

--- a/SEFramework/src/lib/Source/SourceGroupWithOnDemandProperties.cpp
+++ b/SEFramework/src/lib/Source/SourceGroupWithOnDemandProperties.cpp
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -37,11 +37,11 @@ SourceGroupWithOnDemandProperties::iterator SourceGroupWithOnDemandProperties::e
   return m_sources.end();
 }
 
-SourceGroupWithOnDemandProperties::const_iterator SourceGroupWithOnDemandProperties::cbegin() {
+SourceGroupWithOnDemandProperties::const_iterator SourceGroupWithOnDemandProperties::cbegin() const {
   return m_sources.cbegin();
 }
 
-SourceGroupWithOnDemandProperties::const_iterator SourceGroupWithOnDemandProperties::cend() {
+SourceGroupWithOnDemandProperties::const_iterator SourceGroupWithOnDemandProperties::cend() const {
   return m_sources.cend();
 }
 

--- a/SEFramework/tests/src/Pipeline/Deblending_test.cpp
+++ b/SEFramework/tests/src/Pipeline/Deblending_test.cpp
@@ -75,16 +75,20 @@ public:
 
 struct DeblendingFixture {
   std::shared_ptr<ExampleDeblendStep> example_deblend_step {new ExampleDeblendStep};
-  std::shared_ptr<SourceInterface> source_a {new SimpleSource};
-  std::shared_ptr<SourceInterface> source_b {new SimpleSource};
-  std::shared_ptr<SourceInterface> source_c {new SimpleSource};
   std::unique_ptr<SourceGroupInterface> source_group {new SimpleSourceGroup};
   std::shared_ptr<TestGroupObserver> test_group_observer {new TestGroupObserver};
 
   DeblendingFixture() {
-    source_group->addSource(source_a);
-    source_group->addSource(source_b);
-    source_group->addSource(source_c);
+    std::unique_ptr<SourceInterface> source_a {new SimpleSource};
+    std::unique_ptr<SourceInterface> source_b {new SimpleSource};
+    std::unique_ptr<SourceInterface> source_c {new SimpleSource};
+    source_a->setProperty<SimpleIntProperty>(1);
+    source_b->setProperty<SimpleIntProperty>(2);
+    source_c->setProperty<SimpleIntProperty>(3);
+
+    source_group->addSource(std::move(source_a));
+    source_group->addSource(std::move(source_b));
+    source_group->addSource(std::move(source_c));
   }
 };
 
@@ -95,10 +99,6 @@ BOOST_AUTO_TEST_SUITE (Deblending_test)
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE( deblending_test_a, DeblendingFixture ) {
-  source_a->setProperty<SimpleIntProperty>(1);
-  source_b->setProperty<SimpleIntProperty>(2);
-  source_c->setProperty<SimpleIntProperty>(3);
-
   Deblending deblending({example_deblend_step});
   deblending.addObserver(test_group_observer);
 
@@ -119,10 +119,6 @@ BOOST_FIXTURE_TEST_CASE( deblending_test_a, DeblendingFixture ) {
 
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE( deblending_test_b, DeblendingFixture ) {
-  source_a->setProperty<SimpleIntProperty>(1);
-  source_b->setProperty<SimpleIntProperty>(2);
-  source_c->setProperty<SimpleIntProperty>(3);
-
   // we want to execute step twice
   Deblending deblending({example_deblend_step, example_deblend_step});
   deblending.addObserver(test_group_observer);

--- a/SEFramework/tests/src/Pipeline/Deblending_test.cpp
+++ b/SEFramework/tests/src/Pipeline/Deblending_test.cpp
@@ -78,7 +78,7 @@ struct DeblendingFixture {
   std::shared_ptr<SourceInterface> source_a {new SimpleSource};
   std::shared_ptr<SourceInterface> source_b {new SimpleSource};
   std::shared_ptr<SourceInterface> source_c {new SimpleSource};
-  std::shared_ptr<SourceGroupInterface> source_group {new SimpleSourceGroup};
+  std::unique_ptr<SourceGroupInterface> source_group {new SimpleSourceGroup};
   std::shared_ptr<TestGroupObserver> test_group_observer {new TestGroupObserver};
 
   DeblendingFixture() {
@@ -102,7 +102,7 @@ BOOST_FIXTURE_TEST_CASE( deblending_test_a, DeblendingFixture ) {
   Deblending deblending({example_deblend_step});
   deblending.addObserver(test_group_observer);
 
-  deblending.receiveSource(source_group);
+  deblending.receiveSource(std::move(source_group));
 
   BOOST_CHECK_EQUAL(test_group_observer->m_groups.size(), 1);
   auto group = test_group_observer->m_groups.front();
@@ -127,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE( deblending_test_b, DeblendingFixture ) {
   Deblending deblending({example_deblend_step, example_deblend_step});
   deblending.addObserver(test_group_observer);
 
-  deblending.receiveSource(source_group);
+  deblending.receiveSource(std::move(source_group));
 
   BOOST_CHECK(test_group_observer->m_groups.size() == 1);
   auto group = test_group_observer->m_groups.front();

--- a/SEFramework/tests/src/Pipeline/Partition_test.cpp
+++ b/SEFramework/tests/src/Pipeline/Partition_test.cpp
@@ -63,9 +63,9 @@ public:
   }
 };
 
-class MockSourceObserver : public Observer<std::shared_ptr<SourceInterface>> {
+class MockSourceObserver : public Observer<SourceInterface> {
 public:
-  MOCK_METHOD1(handleMessage, void (const std::shared_ptr<SourceInterface>&));
+  MOCK_METHOD1(handleMessage, void (const SourceInterface&));
 };
 
 struct RefineSourceFixture {
@@ -86,13 +86,13 @@ BOOST_FIXTURE_TEST_CASE( default_behavior_test, RefineSourceFixture ) {
   Partition partition( {} );
 
   // We expect to get our Source back unchanged
-  EXPECT_CALL(*mock_observer, handleMessage(source)).Times(1);
+  EXPECT_CALL(*mock_observer, handleMessage(testing::Ref(*source))).Times(1);
 
   // Add the Observer
   partition.addObserver(mock_observer);
 
   // And process the Source
-  partition.handleMessage(source);
+  partition.receiveSource(source);
 }
 
 //-----------------------------------------------------------------------------
@@ -102,13 +102,13 @@ BOOST_FIXTURE_TEST_CASE( nop_step_test, RefineSourceFixture ) {
   Partition partition( { nop_step } );
 
   // We expect to get our Source back unchanged
-  EXPECT_CALL(*mock_observer, handleMessage(source)).Times(1);
+  EXPECT_CALL(*mock_observer, handleMessage(testing::Ref(*source))).Times(1);
 
   // Add the Observer
   partition.addObserver(mock_observer);
 
   // And process the Source
-  partition.handleMessage(source);
+  partition.receiveSource(source);
 }
 
 BOOST_FIXTURE_TEST_CASE( example_step_test, RefineSourceFixture ) {
@@ -119,7 +119,7 @@ BOOST_FIXTURE_TEST_CASE( example_step_test, RefineSourceFixture ) {
   EXPECT_CALL(*mock_observer, handleMessage(_)).Times(4);
 
   partition.addObserver(mock_observer);
-  partition.handleMessage(source);
+  partition.receiveSource(source);
 }
 
 //-----------------------------------------------------------------------------

--- a/SEFramework/tests/src/Pipeline/SourceGrouping_test.cpp
+++ b/SEFramework/tests/src/Pipeline/SourceGrouping_test.cpp
@@ -76,9 +76,9 @@ struct SourceGroupingFixture {
   std::shared_ptr<SourceGrouping> source_grouping_limit {
     new SourceGrouping(std::unique_ptr<GroupingCriteria>(new TestGroupingCriteria), group_factory, 2)};
 
-  std::shared_ptr<SourceInterface> source_a {new SimpleSource};
-  std::shared_ptr<SourceInterface> source_b {new SimpleSource};
-  std::shared_ptr<SourceInterface> source_c {new SimpleSource};
+  std::unique_ptr<SourceInterface> source_a {new SimpleSource};
+  std::unique_ptr<SourceInterface> source_b {new SimpleSource};
+  std::unique_ptr<SourceInterface> source_c {new SimpleSource};
 
   std::shared_ptr<SourceGroupObserver> source_group_observer {new SourceGroupObserver};
   std::shared_ptr<SourceGroupObserver> source_group_observer_limit {new SourceGroupObserver};
@@ -106,9 +106,9 @@ BOOST_FIXTURE_TEST_CASE( source_grouping_test, SourceGroupingFixture ) {
   source_b->setProperty<SimpleIntProperty>(2);
   source_c->setProperty<SimpleIntProperty>(1);
 
-  source_grouping->receiveSource(source_a);
-  source_grouping->receiveSource(source_b);
-  source_grouping->receiveSource(source_c);
+  source_grouping->receiveSource(std::move(source_a));
+  source_grouping->receiveSource(std::move(source_b));
+  source_grouping->receiveSource(std::move(source_c));
 
   source_grouping->receiveProcessSignal(ProcessSourcesEvent { select_all_criteria } );
 
@@ -135,13 +135,13 @@ BOOST_FIXTURE_TEST_CASE( process_sources_test, SourceGroupingFixture ) {
   source_b->setProperty<SimpleIntProperty>(2);
   source_c->setProperty<SimpleIntProperty>(1);
 
-  source_grouping->receiveSource(source_a);
-  source_grouping->receiveSource(source_b);
+  source_grouping->receiveSource(std::move(source_a));
+  source_grouping->receiveSource(std::move(source_b));
 
   // Process all sources currently in source_grouping
   source_grouping->receiveProcessSignal(ProcessSourcesEvent { select_all_criteria } );
 
-  source_grouping->receiveSource(source_c);
+  source_grouping->receiveSource(std::move(source_c));
 
   // Process all sources
   source_grouping->receiveProcessSignal(ProcessSourcesEvent { select_all_criteria } );
@@ -171,9 +171,9 @@ BOOST_FIXTURE_TEST_CASE( grouping_limit, SourceGroupingFixture ) {
   source_b->setProperty<SimpleIntProperty>(1);
   source_c->setProperty<SimpleIntProperty>(1);
 
-  source_grouping_limit->receiveSource(source_a);
-  source_grouping_limit->receiveSource(source_b);
-  source_grouping_limit->receiveSource(source_c);
+  source_grouping_limit->receiveSource(std::move(source_a));
+  source_grouping_limit->receiveSource(std::move(source_b));
+  source_grouping_limit->receiveSource(std::move(source_c));
 
   source_grouping_limit->receiveProcessSignal(ProcessSourcesEvent { select_all_criteria } );
 

--- a/SEFramework/tests/src/Source/SourceGroupWithOnDemandProperties_test.cpp
+++ b/SEFramework/tests/src/Source/SourceGroupWithOnDemandProperties_test.cpp
@@ -95,14 +95,15 @@ private:
 struct SourceGroupFixture {
 
   std::shared_ptr<MockTaskProvider> mock_registry {std::make_shared<MockTaskProvider>()};
-  std::shared_ptr<SourceWithOnDemandProperties> source_a {new SourceWithOnDemandProperties(mock_registry)};
-  std::shared_ptr<SourceWithOnDemandProperties> source_b {new SourceWithOnDemandProperties(mock_registry)};
   SourceGroupWithOnDemandProperties group {mock_registry};
 
   const int magic_number = 42;
-  
+
   SourceGroupFixture() {
-    group.addAllSources(std::vector<std::shared_ptr<SourceInterface>>{source_a, source_b});
+    std::vector<std::unique_ptr<SourceInterface>> sources;
+    sources.emplace_back(new SourceWithOnDemandProperties(mock_registry));
+    sources.emplace_back(new SourceWithOnDemandProperties(mock_registry));
+    group.addAllSources(std::move(sources));
   }
 
 };
@@ -130,7 +131,7 @@ BOOST_FIXTURE_TEST_CASE( example_test, SourceGroupFixture ) {
 
   auto& same_property = group.getProperty<GroupProperty>();
   BOOST_CHECK_EQUAL(same_property.m_value, magic_number);
-  
+
 }
 
 //-----------------------------------------------------------------------------

--- a/SEImplementation/SEImplementation/CheckImages/DetectionIdCheckImage.h
+++ b/SEImplementation/SEImplementation/CheckImages/DetectionIdCheckImage.h
@@ -30,12 +30,12 @@
 
 namespace SourceXtractor {
 
-class DetectionIdCheckImage : public Observer<std::shared_ptr<SourceInterface>> {
+class DetectionIdCheckImage : public Observer<SourceInterface> {
 public:
 
-  DetectionIdCheckImage() {}
+  DetectionIdCheckImage() = default;
 
-  virtual void handleMessage(const std::shared_ptr<SourceInterface>& source);
+  void handleMessage(const SourceInterface& source) override;
 };
 
 }

--- a/SEImplementation/SEImplementation/CheckImages/GroupIdCheckImage.h
+++ b/SEImplementation/SEImplementation/CheckImages/GroupIdCheckImage.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -30,11 +30,11 @@
 
 namespace SourceXtractor {
 
-class GroupIdCheckImage : public Observer<std::shared_ptr<SourceGroupInterface>> {
+class GroupIdCheckImage : public Observer<SourceGroupInterface> {
 public:
   GroupIdCheckImage() {}
 
-  virtual void handleMessage(const std::shared_ptr<SourceGroupInterface>& group);
+  void handleMessage(const SourceGroupInterface& group) override;
 };
 
 

--- a/SEImplementation/SEImplementation/CheckImages/MoffatCheckImage.h
+++ b/SEImplementation/SEImplementation/CheckImages/MoffatCheckImage.h
@@ -30,12 +30,12 @@
 
 namespace SourceXtractor {
 
-class MoffatCheckImage : public Observer<std::shared_ptr<SourceGroupInterface>> {
+class MoffatCheckImage : public Observer<SourceGroupInterface> {
 public:
 
   MoffatCheckImage() {}
 
-  virtual void handleMessage(const std::shared_ptr<SourceGroupInterface>& group);
+  void handleMessage(const SourceGroupInterface& group) override;
 };
 
 

--- a/SEImplementation/SEImplementation/CheckImages/SourceIdCheckImage.h
+++ b/SEImplementation/SEImplementation/CheckImages/SourceIdCheckImage.h
@@ -30,12 +30,12 @@
 
 namespace SourceXtractor {
 
-class SourceIdCheckImage : public Observer<std::shared_ptr<SourceGroupInterface>> {
+class SourceIdCheckImage : public Observer<SourceGroupInterface> {
 public:
 
-  SourceIdCheckImage() {}
+  SourceIdCheckImage() = default;
 
-  virtual void handleMessage(const std::shared_ptr<SourceGroupInterface>& group);
+  void handleMessage(const SourceGroupInterface& group) override;
 };
 
 

--- a/SEImplementation/SEImplementation/Deblending/Cleaning.h
+++ b/SEImplementation/SEImplementation/Deblending/Cleaning.h
@@ -50,7 +50,7 @@ private:
   SourceGroupInterface::iterator findMostInfluentialSource(
       SourceInterface& source, const std::vector<SourceGroupInterface::iterator>& candidates) const;
 
-  std::shared_ptr<SourceInterface> mergeSources(SourceInterface& parent,
+  std::unique_ptr<SourceInterface> mergeSources(SourceInterface& parent,
       const std::vector<SourceGroupInterface::iterator> children) const;
 
   std::shared_ptr<SourceFactory> m_source_factory;

--- a/SEImplementation/SEImplementation/Measurement/DummyMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/DummyMeasurement.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -31,13 +31,17 @@ namespace SourceXtractor {
 class DummyMeasurement : public Measurement {
 public:
 
-  void handleMessage(const std::shared_ptr<SourceGroupInterface>& source_group) override {
-    notifyObservers(source_group);
+  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) override {
+    sendSource(source_group);
+
+  }
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override {
+    sendProcessSignal(event);
   }
 
-  virtual void startThreads() {};
-  virtual void stopThreads() {};
-  virtual void synchronizeThreads() {};
+  void startThreads() override {};
+  void stopThreads() override {};
+  void synchronizeThreads() override {};
 };
 
 }

--- a/SEImplementation/SEImplementation/Measurement/DummyMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/DummyMeasurement.h
@@ -31,8 +31,8 @@ namespace SourceXtractor {
 class DummyMeasurement : public Measurement {
 public:
 
-  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) override {
-    sendSource(source_group);
+  void receiveSource(std::unique_ptr<SourceGroupInterface> source_group) override {
+    sendSource(std::move(source_group));
 
   }
   void receiveProcessSignal(const ProcessSourcesEvent& event) override {

--- a/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
@@ -48,7 +48,7 @@ public:
 
   ~MultithreadedMeasurement() override;
 
-  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) override;
+  void receiveSource(std::unique_ptr<SourceGroupInterface> source_group) override;
   void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
   void startThreads() override;
@@ -67,7 +67,7 @@ private:
   std::atomic_bool m_input_done, m_abort_raised;
 
   std::condition_variable m_new_output;
-  std::list<std::pair<int, std::shared_ptr<SourceGroupInterface>>> m_output_queue;
+  std::list<std::pair<int, std::unique_ptr<SourceGroupInterface>>> m_output_queue;
   std::mutex m_output_queue_mutex;
   Euclid::Semaphore m_semaphore;
 };

--- a/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
+++ b/SEImplementation/SEImplementation/Measurement/MultithreadedMeasurement.h
@@ -46,9 +46,10 @@ public:
         m_group_counter(0),
         m_input_done(false), m_abort_raised(false), m_semaphore(max_queue_size) {}
 
-  virtual ~MultithreadedMeasurement();
+  ~MultithreadedMeasurement() override;
 
-  void handleMessage(const std::shared_ptr<SourceGroupInterface>& source_group) override;
+  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) override;
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
   void startThreads() override;
   void stopThreads() override;

--- a/SEImplementation/SEImplementation/Partition/AttractorsPartitionStep.h
+++ b/SEImplementation/SEImplementation/Partition/AttractorsPartitionStep.h
@@ -50,7 +50,7 @@ public:
   explicit AttractorsPartitionStep(std::shared_ptr<SourceFactory> source_factory) :
         m_source_factory(source_factory) {}
 
-  std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const override;
+  std::vector<std::unique_ptr<SourceInterface>> partition(std::unique_ptr<SourceInterface> source) const override;
 
 private:
   std::shared_ptr<SourceFactory> m_source_factory;

--- a/SEImplementation/SEImplementation/Partition/MinAreaPartitionStep.h
+++ b/SEImplementation/SEImplementation/Partition/MinAreaPartitionStep.h
@@ -42,7 +42,7 @@ public:
   /// Constructor
   explicit MinAreaPartitionStep(unsigned int min_pixel_count);
 
-  std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const override;
+  std::vector<std::unique_ptr<SourceInterface>> partition(std::unique_ptr<SourceInterface> source) const override;
 
 
 private:

--- a/SEImplementation/SEImplementation/Partition/MultiThresholdPartitionStep.h
+++ b/SEImplementation/SEImplementation/Partition/MultiThresholdPartitionStep.h
@@ -52,11 +52,11 @@ public:
 
   virtual ~MultiThresholdPartitionStep() = default;
 
-  virtual std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const;
+  virtual std::vector<std::unique_ptr<SourceInterface>> partition(std::unique_ptr<SourceInterface> source) const;
 
 private:
-  std::vector<std::shared_ptr<SourceInterface>> reassignPixels(
-      const std::vector<std::shared_ptr<SourceInterface>>& sources,
+  std::vector<std::unique_ptr<SourceInterface>> reassignPixels(
+      const std::vector<std::unique_ptr<SourceInterface>>& sources,
       const std::vector<PixelCoordinate>& pixel_coords,
       std::shared_ptr<VectorImage<DetectionImage::PixelType>> image,
       const std::vector<std::shared_ptr<MultiThresholdNode>>& source_nodes,

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModePartitionStep.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModePartitionStep.h
@@ -38,7 +38,7 @@ public:
   /// Constructor
   explicit AssocModePartitionStep(bool match_required);
 
-  std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const override;
+  std::vector<std::unique_ptr<SourceInterface>> partition(std::unique_ptr<SourceInterface> source) const override;
 
 
 private:

--- a/SEImplementation/SEImplementation/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.h
+++ b/SEImplementation/SEImplementation/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.h
@@ -42,7 +42,7 @@ public:
   /// Constructor
   CoreThresholdPartitionStep(double snr_level, unsigned int min_pixel_count);
 
-  std::vector<std::shared_ptr<SourceInterface>> partition(std::shared_ptr<SourceInterface> source) const override;
+  std::vector<std::unique_ptr<SourceInterface>> partition(std::unique_ptr<SourceInterface> source) const override;
 
 
 private:

--- a/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
+++ b/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
@@ -57,7 +57,7 @@ public:
    * Once they are done, the message will be passed along.
    * @param message
    */
-  void receiveSource(const std::shared_ptr<SourceInterface>& source) override;
+  void receiveSource(std::unique_ptr<SourceInterface> source) override;
 
   /**
    * Handle ProcessSourcesEvent. All sources received prior to this message need to
@@ -114,7 +114,7 @@ private:
   /// Notifies there is a new source done processing
   std::condition_variable m_new_output;
   /// Finished sources
-  std::map<intptr_t, std::shared_ptr<SourceInterface>> m_finished_sources;
+  std::map<intptr_t, std::unique_ptr<SourceInterface>> m_finished_sources;
   /// Queue of received ProcessSourceEvent, order preserved
   std::deque<ProcessSourcesEvent> m_event_queue;
   /// Queue of type of received events. Used to pass downstream events respecting the received order

--- a/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
+++ b/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
@@ -22,8 +22,7 @@
 #include "AlexandriaKernel/ThreadPool.h"
 #include "AlexandriaKernel/Semaphore.h"
 #include "SEFramework/Source/SourceInterface.h"
-#include "SEFramework/Pipeline/SourceGrouping.h"
-#include "SEUtils/Observable.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 
 namespace SourceXtractor {
 
@@ -38,10 +37,7 @@ namespace SourceXtractor {
  * Then, they will be released and sent along.
  *
  */
-class Prefetcher : public Observer<std::shared_ptr<SourceInterface>>,
-                   public Observable<std::shared_ptr<SourceInterface>>,
-                   public Observer<ProcessSourcesEvent>,
-                   public Observable<ProcessSourcesEvent> {
+class Prefetcher : public PipelineReceiver<SourceInterface>, public PipelineEmitter<SourceInterface> {
 public:
 
   /**
@@ -61,14 +57,14 @@ public:
    * Once they are done, the message will be passed along.
    * @param message
    */
-  void handleMessage(const std::shared_ptr<SourceInterface>& message) override;
+  void receiveSource(const std::shared_ptr<SourceInterface>& source) override;
 
   /**
    * Handle ProcessSourcesEvent. All sources received prior to this message need to
    * be processed before sources coming after are passed along.
    * @param message
    */
-  void handleMessage(const ProcessSourcesEvent& message) override;
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
   /**
    * Tell the prefetcher to compute this property

--- a/SEImplementation/src/lib/CheckImages/DetectionIdCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/DetectionIdCheckImage.cpp
@@ -30,14 +30,14 @@
 
 namespace SourceXtractor {
 
-void DetectionIdCheckImage::handleMessage(const std::shared_ptr<SourceInterface>& source) {
-  auto hdu_index = source->getProperty<DetectionFrameInfo>().getHduIndex();
+void DetectionIdCheckImage::handleMessage(const SourceInterface& source) {
+  auto hdu_index = source.getProperty<DetectionFrameInfo>().getHduIndex();
   auto check_image = CheckImages::getInstance().getSegmentationImage(hdu_index);
   if (check_image != nullptr) {
-    auto coordinates = source->getProperty<PixelCoordinateList>();
+    const auto& coordinates = source.getProperty<PixelCoordinateList>();
 
     // get the ID for each detected source
-    const auto& source_id = source->getProperty<SourceId>().getDetectionId();
+    const auto& source_id = source.getProperty<SourceId>().getDetectionId();
 
     // iterate over the pixels and set the detection_id value
     for (auto& coord : coordinates.getCoordinateList()) {

--- a/SEImplementation/src/lib/CheckImages/GroupIdCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/GroupIdCheckImage.cpp
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -32,14 +32,14 @@
 
 namespace SourceXtractor {
 
-void GroupIdCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface>& group) {
-  auto hdu_index = group->cbegin()->getProperty<DetectionFrameInfo>().getHduIndex();
+void GroupIdCheckImage::handleMessage(const SourceGroupInterface& group) {
+  auto hdu_index = group.cbegin()->getProperty<DetectionFrameInfo>().getHduIndex();
   auto check_image = CheckImages::getInstance().getGroupImage(hdu_index);
   if (check_image) {
     // get the ID of the group
-    auto group_id = group->getProperty<GroupInfo>().getGroupId();
+    auto group_id = group.getProperty<GroupInfo>().getGroupId();
 
-    for (auto& source : *group) {
+    for (auto& source : group) {
       auto& coordinates = source.getProperty<PixelCoordinateList>();
 
       // iterate over the pixels and set the group_id value

--- a/SEImplementation/src/lib/CheckImages/MoffatCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/MoffatCheckImage.cpp
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -37,13 +37,13 @@ namespace SourceXtractor {
 
 using namespace ModelFitting;
 
-void MoffatCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface>& group) {
-  auto hdu_index = group->cbegin()->getProperty<DetectionFrameInfo>().getHduIndex();
+void MoffatCheckImage::handleMessage(const SourceGroupInterface& group) {
+  auto hdu_index = group.cbegin()->getProperty<DetectionFrameInfo>().getHduIndex();
   auto check_image = CheckImages::getInstance().getMoffatImage(hdu_index);
   ImageAccessor<SeFloat> check_accessor(check_image);
 
   if (check_image != nullptr) {
-    for (auto& source : *group) {
+    for (auto& source : group) {
       auto& model = source.getProperty<MoffatModelEvaluator>();
 
       if (model.getIterations() == 0) {

--- a/SEImplementation/src/lib/CheckImages/SourceIdCheckImage.cpp
+++ b/SEImplementation/src/lib/CheckImages/SourceIdCheckImage.cpp
@@ -30,12 +30,12 @@
 
 namespace SourceXtractor {
 
-void SourceIdCheckImage::handleMessage(const std::shared_ptr<SourceGroupInterface>& group) {
-  auto hdu_index = group->cbegin()->getProperty<DetectionFrameInfo>().getHduIndex();
+void SourceIdCheckImage::handleMessage(const SourceGroupInterface& group) {
+  auto hdu_index = group.cbegin()->getProperty<DetectionFrameInfo>().getHduIndex();
   auto check_image = CheckImages::getInstance().getPartitionImage(hdu_index);
   if (check_image != nullptr) {
-    for (auto& source : *group) {
-      auto coordinates = source.getProperty<PixelCoordinateList>();
+    for (auto& source : group) {
+      const auto& coordinates = source.getProperty<PixelCoordinateList>();
 
       // get the ID for each (multithresholded) source
       const auto& source_id = source.getProperty<SourceID>().getId();

--- a/SEImplementation/src/lib/Deblending/Cleaning.cpp
+++ b/SEImplementation/src/lib/Deblending/Cleaning.cpp
@@ -70,13 +70,13 @@ void Cleaning::deblend(SourceGroupInterface& group) const {
       for (auto merging_pair : merging_map) {
         if (merging_pair.second.size() > 0) {
           auto new_source = mergeSources(*merging_pair.first, merging_pair.second);
-          group.addSource(new_source);
+          group.addSource(std::move(new_source));
           group.removeSource(merging_pair.first);
         }
       }
     } else if (remaining_sources.size() == 1) {
       auto new_source = mergeSources(*remaining_sources[0], sources_to_clean);
-      group.addSource(new_source);
+      group.addSource(std::move(new_source));
       group.removeSource(remaining_sources[0]);
     }
 
@@ -144,7 +144,7 @@ SourceGroupInterface::iterator Cleaning::findMostInfluentialSource(
   return most_influential_source;
 }
 
-std::shared_ptr<SourceInterface> Cleaning::mergeSources(SourceInterface& parent,
+std::unique_ptr<SourceInterface> Cleaning::mergeSources(SourceInterface& parent,
     const std::vector<SourceGroupInterface::iterator> children) const {
 
   // Start with a copy of the pixel list of the parent

--- a/SEImplementation/src/lib/Measurement/MultithreadedMeasurement.cpp
+++ b/SEImplementation/src/lib/Measurement/MultithreadedMeasurement.cpp
@@ -73,9 +73,7 @@ void MultithreadedMeasurement::synchronizeThreads() {
   }
 }
 
-
-void
-MultithreadedMeasurement::handleMessage(const std::shared_ptr<SourceGroupInterface>& source_group) {
+void MultithreadedMeasurement::receiveSource(const std::shared_ptr<SourceGroupInterface>& source_group) {
   // Force computation of SourceID here, where the order is still deterministic
   for (auto& source : *source_group) {
     source.getProperty<SourceID>();
@@ -125,7 +123,7 @@ void MultithreadedMeasurement::outputThreadLoop() {
 
     // Process the output queue
     while (!m_output_queue.empty()) {
-      notifyObservers(m_output_queue.front().second);
+      sendSource(m_output_queue.front().second);
       m_output_queue.pop_front();
     }
 
@@ -134,4 +132,8 @@ void MultithreadedMeasurement::outputThreadLoop() {
       break;
     }
   }
+}
+
+void MultithreadedMeasurement::receiveProcessSignal(const ProcessSourcesEvent& event) {
+  sendProcessSignal(event);
 }

--- a/SEImplementation/src/lib/Output/OutputFactory.cpp
+++ b/SEImplementation/src/lib/Output/OutputFactory.cpp
@@ -32,7 +32,6 @@
 #include "SEImplementation/Output/AsciiOutput.h"
 #include "SEImplementation/Output/FitsOutput.h"
 #include "SEImplementation/Output/LdacOutput.h"
-
 #include "SEImplementation/Output/OutputFactory.h"
 
 using Euclid::make_unique;

--- a/SEImplementation/src/lib/Partition/MinAreaPartitionStep.cpp
+++ b/SEImplementation/src/lib/Partition/MinAreaPartitionStep.cpp
@@ -28,12 +28,13 @@ namespace SourceXtractor {
 MinAreaPartitionStep::MinAreaPartitionStep(unsigned int min_pixel_count) : m_min_pixel_count (min_pixel_count) {
 }
 
-std::vector<std::shared_ptr<SourceInterface>> MinAreaPartitionStep::partition(std::shared_ptr<SourceInterface> source) const {
-  if (source->getProperty<PixelCoordinateList>().getCoordinateList().size() < m_min_pixel_count) {
-    return {};
-  } else {
-    return { source };
+std::vector<std::unique_ptr<SourceInterface>>
+MinAreaPartitionStep::partition(std::unique_ptr<SourceInterface> source) const {
+  std::vector<std::unique_ptr<SourceInterface>> sources;
+  if (source->getProperty<PixelCoordinateList>().getCoordinateList().size() >= m_min_pixel_count) {
+    sources.emplace_back(std::move(source));
   }
+  return sources;
 }
 
 } // SEImplementation namespace

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModePartitionStep.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModePartitionStep.cpp
@@ -20,15 +20,15 @@
 
 namespace SourceXtractor {
 
-AssocModePartitionStep::AssocModePartitionStep(bool match_required) : m_match_required(match_required) {
-}
+AssocModePartitionStep::AssocModePartitionStep(bool match_required) : m_match_required(match_required) {}
 
-std::vector<std::shared_ptr<SourceInterface>> AssocModePartitionStep::partition(std::shared_ptr<SourceInterface> source) const {
+std::vector<std::unique_ptr<SourceInterface>>
+AssocModePartitionStep::partition(std::unique_ptr<SourceInterface> source) const {
+  std::vector<std::unique_ptr<SourceInterface>> sources;
   if (source->getProperty<AssocMode>().getMatch() ^ !m_match_required) {
-    return { source };
-  } else {
-    return {};
+    sources.emplace_back(std::move(source));
   }
+  return sources;
 }
 
 } // SourceXtractor namespace

--- a/SEImplementation/src/lib/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.cpp
+++ b/SEImplementation/src/lib/Plugin/CoreThresholdPartition/CoreThresholdPartitionStep.cpp
@@ -31,7 +31,7 @@ CoreThresholdPartitionStep::CoreThresholdPartitionStep(double snr_level, unsigne
     m_snr_level(snr_level), m_min_pixel_count(min_pixel_count) {
 }
 
-std::vector<std::shared_ptr<SourceInterface>> CoreThresholdPartitionStep::partition(std::shared_ptr<SourceInterface> source) const {
+std::vector<std::unique_ptr<SourceInterface>> CoreThresholdPartitionStep::partition(std::unique_ptr<SourceInterface> source) const {
   long int n_snr_level(0);
 
   // get the SNR image
@@ -44,11 +44,11 @@ std::vector<std::shared_ptr<SourceInterface>> CoreThresholdPartitionStep::partit
       n_snr_level += 1;
 
   // check whether the pixel # is above the threshold
-  if (n_snr_level < m_min_pixel_count) {
-    return {};
-  } else {
-    return { source };
+  std::vector<std::unique_ptr<SourceInterface>> sources;
+  if (n_snr_level >= m_min_pixel_count) {
+    sources.emplace_back(std::move(source));
   }
+  return sources;
 }
 
 } // SEImplementation namespace

--- a/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
+++ b/SEImplementation/src/lib/Prefetcher/Prefetcher.cpp
@@ -51,7 +51,7 @@ Prefetcher::~Prefetcher() {
     wait();
 }
 
-void Prefetcher::receiveSource(const std::shared_ptr<SourceInterface>& message) {
+void Prefetcher::receiveSource(std::unique_ptr<SourceInterface> message) {
   m_semaphore.acquire();
 
   intptr_t source_addr = reinterpret_cast<intptr_t>(message.get());
@@ -61,16 +61,20 @@ void Prefetcher::receiveSource(const std::shared_ptr<SourceInterface>& message) 
   }
 
   // Pre-fetch in separate threads
-  m_thread_pool->submit([this, source_addr, message]() {
+  auto lambda = [this, source_addr, message = std::move(message)]() mutable {
     for (auto& prop : m_prefetch_set) {
       message->getProperty(prop);
     }
     {
       std::lock_guard<std::mutex> lock(m_queue_mutex);
-      m_finished_sources.emplace(source_addr, message);
+      m_finished_sources.emplace(source_addr, std::move(message));
     }
     m_new_output.notify_one();
-  });
+  };
+  auto lambda_copyable = [lambda = std::make_shared<decltype(lambda)>(std::move(lambda))](){
+    (*lambda)();
+  };
+  m_thread_pool->submit(lambda_copyable);
 }
 
 void Prefetcher::requestProperty(const PropertyId& property_id) {
@@ -115,7 +119,7 @@ void Prefetcher::outputLoop() {
       logger.debug() << "Source " << next.m_source_addr << " sent downstream";
       {
         ReverseLock<decltype(output_lock)> release_lock(output_lock);
-        sendSource(processed->second);
+        sendSource(std::move(processed->second));
       }
       m_finished_sources.erase(processed);
       m_received.pop_front();

--- a/SEImplementation/src/lib/Segmentation/BFSSegmentation.cpp
+++ b/SEImplementation/src/lib/Segmentation/BFSSegmentation.cpp
@@ -103,7 +103,7 @@ void BFSSegmentation::labelSource(PixelCoordinate pc,
   auto source = m_source_factory->createSource();
   source->setProperty<PixelCoordinateList>(source_pixels);
   source->setProperty<SourceId>();
-  listener.publishSource(source);
+  listener.publishSource(std::move(source));
 }
 
 std::vector<BFSSegmentation::Tile> BFSSegmentation::getTiles(const DetectionImage& image) const {

--- a/SEImplementation/src/lib/Segmentation/LutzSegmentation.cpp
+++ b/SEImplementation/src/lib/Segmentation/LutzSegmentation.cpp
@@ -51,7 +51,7 @@ public:
     auto source = m_source_factory->createSource();
     source->setProperty<PixelCoordinateList>(pixel_group.pixel_list);
     source->setProperty<SourceId>();
-    m_listener.publishSource(source);
+    m_listener.publishSource(std::move(source));
   }
 
   void notifyProgress(int line, int total) override {

--- a/SEImplementation/src/lib/Segmentation/MLSegmentation.cpp
+++ b/SEImplementation/src/lib/Segmentation/MLSegmentation.cpp
@@ -68,7 +68,7 @@ public:
     auto source = m_source_factory->createSource();
     source->setProperty<PixelCoordinateList>(pixel_group.pixel_list);
     source->setProperty<SourceId>();
-    m_listener.publishSource(source);
+    m_listener.publishSource(std::move(source));
   }
 
   void notifyProgress(int line, int total) override {

--- a/SEImplementation/tests/src/Partition/AttractorsPartitionStep_test.cpp
+++ b/SEImplementation/tests/src/Partition/AttractorsPartitionStep_test.cpp
@@ -56,13 +56,13 @@ struct AttractorsPartitionFixture {
   };
 };
 
-class SourceObserver : public Observer<std::shared_ptr<SourceInterface>> {
+class SourceObserver : public Observer<SourceInterface> {
 public:
-  virtual void handleMessage(const std::shared_ptr<SourceInterface>& source) override {
-      m_list.push_back(source);
+  virtual void handleMessage(const SourceInterface& source) override {
+      m_list.push_back(source.getProperty<DetectionFrame>());
   }
 
-  std::list<std::shared_ptr<SourceInterface>> m_list;
+  std::list<DetectionFrame> m_list;
 };
 
 using namespace SourceXtractor;
@@ -89,12 +89,12 @@ BOOST_FIXTURE_TEST_CASE( attractors_test, AttractorsPartitionFixture ) {
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.handleMessage(source);
+  partition.receiveSource(source);
   BOOST_CHECK(source_observer->m_list.size() == 1);
   source_observer->m_list.clear();
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_two_sources, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.handleMessage(source);
+  partition.receiveSource(source);
   BOOST_CHECK(source_observer->m_list.size() == 2);
   source_observer->m_list.clear();
 }

--- a/SEImplementation/tests/src/Partition/MinAreaPartitionStep_test.cpp
+++ b/SEImplementation/tests/src/Partition/MinAreaPartitionStep_test.cpp
@@ -37,13 +37,13 @@ struct MinAreaPartitionFixture {
   std::shared_ptr<MinAreaPartitionStep> min_area_step {new MinAreaPartitionStep(min_pixels)};
 };
 
-class SourceObserver : public Observer<std::shared_ptr<SourceInterface>> {
+class SourceObserver : public Observer<SourceInterface> {
 public:
-  virtual void handleMessage(const std::shared_ptr<SourceInterface>& source) override {
-      m_list.push_back(source);
+  virtual void handleMessage(const SourceInterface& source) override {
+      m_list.push_back(source.getProperty<PixelCoordinateList>());
   }
 
-  std::list<std::shared_ptr<SourceInterface>> m_list;
+  std::list<PixelCoordinateList> m_list;
 };
 
 //-----------------------------------------------------------------------------
@@ -60,7 +60,7 @@ BOOST_FIXTURE_TEST_CASE( source_filtered_test, MinAreaPartitionFixture ) {
   auto source_observer = std::make_shared<SourceObserver>();
   partition.addObserver(source_observer);
 
-  partition.handleMessage(source);
+  partition.receiveSource(source);
 
   BOOST_CHECK(source_observer->m_list.empty());
 }
@@ -73,7 +73,7 @@ BOOST_FIXTURE_TEST_CASE( source_ok_test, MinAreaPartitionFixture ) {
   auto source_observer = std::make_shared<SourceObserver>();
   partition.addObserver(source_observer);
 
-  partition.handleMessage(source);
+  partition.receiveSource(source);
 
   BOOST_CHECK(source_observer->m_list.size() == 1);
 }

--- a/SEImplementation/tests/src/Partition/MinAreaPartitionStep_test.cpp
+++ b/SEImplementation/tests/src/Partition/MinAreaPartitionStep_test.cpp
@@ -33,7 +33,7 @@ using namespace SourceXtractor;
 
 struct MinAreaPartitionFixture {
   const static int min_pixels = 3;
-  std::shared_ptr<SimpleSource> source {new SimpleSource};
+  std::unique_ptr<SimpleSource> source {new SimpleSource};
   std::shared_ptr<MinAreaPartitionStep> min_area_step {new MinAreaPartitionStep(min_pixels)};
 };
 
@@ -60,7 +60,7 @@ BOOST_FIXTURE_TEST_CASE( source_filtered_test, MinAreaPartitionFixture ) {
   auto source_observer = std::make_shared<SourceObserver>();
   partition.addObserver(source_observer);
 
-  partition.receiveSource(source);
+  partition.receiveSource(std::move(source));
 
   BOOST_CHECK(source_observer->m_list.empty());
 }
@@ -73,7 +73,7 @@ BOOST_FIXTURE_TEST_CASE( source_ok_test, MinAreaPartitionFixture ) {
   auto source_observer = std::make_shared<SourceObserver>();
   partition.addObserver(source_observer);
 
-  partition.receiveSource(source);
+  partition.receiveSource(std::move(source));
 
   BOOST_CHECK(source_observer->m_list.size() == 1);
 }

--- a/SEImplementation/tests/src/Partition/MultiThresholdPartitionStep_test.cpp
+++ b/SEImplementation/tests/src/Partition/MultiThresholdPartitionStep_test.cpp
@@ -86,13 +86,13 @@ struct MultiThresholdPartitionFixture {
   }
 };
 
-class SourceObserver : public Observer<std::shared_ptr<SourceInterface>> {
+class SourceObserver : public Observer<SourceInterface> {
 public:
-  virtual void handleMessage(const std::shared_ptr<SourceInterface>& source) override {
-      m_list.push_back(source);
+  virtual void handleMessage(const SourceInterface& source) override {
+      m_list.push_back(source.getProperty<DetectionFrameSourceStamp>());
   }
 
-  std::list<std::shared_ptr<SourceInterface>> m_list;
+  std::list<DetectionFrameSourceStamp> m_list;
 };
 
 using namespace SourceXtractor;
@@ -125,7 +125,7 @@ BOOST_FIXTURE_TEST_CASE( multithreshold_test, MultiThresholdPartitionFixture ) {
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.handleMessage(source);
+  partition.receiveSource(source);
   BOOST_CHECK(source_observer->m_list.size() == 1);
 }
 
@@ -151,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE( multithreshold_test_2, MultiThresholdPartitionFixture )
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.handleMessage(source);
+  partition.receiveSource(source);
   BOOST_CHECK(source_observer->m_list.size() == 2);
 }
 
@@ -177,7 +177,7 @@ BOOST_FIXTURE_TEST_CASE( multithreshold_test_3, MultiThresholdPartitionFixture )
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.handleMessage(source);
+  partition.receiveSource(source);
   BOOST_CHECK(source_observer->m_list.size() == 1);
 }
 //-----------------------------------------------------------------------------

--- a/SEImplementation/tests/src/Partition/MultiThresholdPartitionStep_test.cpp
+++ b/SEImplementation/tests/src/Partition/MultiThresholdPartitionStep_test.cpp
@@ -70,7 +70,7 @@ public:
 struct MultiThresholdPartitionFixture {
   std::shared_ptr<TaskFactoryRegistry> task_factory_registry {new TaskFactoryRegistry};
   std::shared_ptr<TaskProvider> task_provider {new TaskProvider(task_factory_registry)};
-  std::shared_ptr<SourceWithOnDemandProperties> source {new SourceWithOnDemandProperties(task_provider)};
+  std::unique_ptr<SourceWithOnDemandProperties> source {new SourceWithOnDemandProperties(task_provider)};
   std::shared_ptr<MultiThresholdPartitionStep> multithreshold_step {
     new MultiThresholdPartitionStep(std::make_shared<SourceWithOnDemandPropertiesFactory>(task_provider), 0.005, 32, 1)
   };
@@ -125,7 +125,7 @@ BOOST_FIXTURE_TEST_CASE( multithreshold_test, MultiThresholdPartitionFixture ) {
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.receiveSource(source);
+  partition.receiveSource(std::move(source));
   BOOST_CHECK(source_observer->m_list.size() == 1);
 }
 
@@ -151,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE( multithreshold_test_2, MultiThresholdPartitionFixture )
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.receiveSource(source);
+  partition.receiveSource(std::move(source));
   BOOST_CHECK(source_observer->m_list.size() == 2);
 }
 
@@ -177,7 +177,7 @@ BOOST_FIXTURE_TEST_CASE( multithreshold_test_3, MultiThresholdPartitionFixture )
   partition.addObserver(source_observer);
 
   source->setProperty<DetectionFrameSourceStamp>(stamp_one_source, nullptr, nullptr, PixelCoordinate(0,0), nullptr, nullptr);
-  partition.receiveSource(source);
+  partition.receiveSource(std::move(source));
   BOOST_CHECK(source_observer->m_list.size() == 1);
 }
 //-----------------------------------------------------------------------------

--- a/SEImplementation/tests/src/Plugin/Jacobian/JacobianGroupTask_test.cpp
+++ b/SEImplementation/tests/src/Plugin/Jacobian/JacobianGroupTask_test.cpp
@@ -32,6 +32,7 @@
 #include "SEImplementation/Plugin/Jacobian/JacobianTask.h"
 #include "SEImplementation/Plugin/Jacobian/Jacobian.h"
 #include "SEUtils/TestUtils.h"
+#include <AlexandriaKernel/memory_tools.h>
 
 using namespace SourceXtractor;
 
@@ -98,7 +99,7 @@ BOOST_AUTO_TEST_SUITE (JacobianGroupTask_test)
 BOOST_AUTO_TEST_CASE (JacobianIdentity_test) {
   auto jacobian_task = JacobianGroupTask(0);
 
-  auto source = std::make_shared<SimpleSource>();
+  auto source = Euclid::make_unique<SimpleSource>();
   auto measurement_coord_system = std::make_shared<NoopCoordinateSystem>();
   auto detection_coord_system = std::make_shared<NoopCoordinateSystem>();
   source->setProperty<MeasurementFrameCoordinates>(measurement_coord_system);
@@ -110,7 +111,7 @@ BOOST_AUTO_TEST_CASE (JacobianIdentity_test) {
   BOOST_CHECK_EQUAL(150, measurement_center.m_y);
 
   SimpleSourceGroup group;
-  group.addSource(source);
+  group.addSource(std::move(source));
 
   group.setProperty<DetectionFrameGroupStamp>(
     ConstantImage<SeFloat>::create(100, 100, 0), nullptr, PixelCoordinate{100, 100}, nullptr
@@ -133,7 +134,7 @@ BOOST_AUTO_TEST_CASE (JacobianIdentity_test) {
 BOOST_AUTO_TEST_CASE (JacobianScale_test) {
   auto jacobian_task = JacobianGroupTask(0);
 
-  auto source = std::make_shared<SimpleSource>();
+  auto source = Euclid::make_unique<SimpleSource>();
   auto measurement_coord_system = std::make_shared<ScaleCoordinateSystem>(2);
   auto detection_coord_system = std::make_shared<NoopCoordinateSystem>();
   source->setProperty<MeasurementFrameCoordinates>(measurement_coord_system);
@@ -145,7 +146,7 @@ BOOST_AUTO_TEST_CASE (JacobianScale_test) {
   BOOST_CHECK_EQUAL(300, measurement_center.m_y);
 
   SimpleSourceGroup group;
-  group.addSource(source);
+  group.addSource(std::move(source));
 
   group.setProperty<DetectionFrameGroupStamp>(
     ConstantImage<SeFloat>::create(100, 100, 0), nullptr, PixelCoordinate{100, 100}, nullptr
@@ -168,7 +169,7 @@ BOOST_AUTO_TEST_CASE (JacobianScale_test) {
 BOOST_AUTO_TEST_CASE (JacobianShear_test) {
   auto jacobian_task = JacobianGroupTask(0);
 
-  auto source = std::make_shared<SimpleSource>();
+  auto source = Euclid::make_unique<SimpleSource>();
   auto measurement_coord_system = std::make_shared<ShearCoordinates>();
   auto detection_coord_system = std::make_shared<NoopCoordinateSystem>();
   source->setProperty<MeasurementFrameCoordinates>(measurement_coord_system);
@@ -180,7 +181,7 @@ BOOST_AUTO_TEST_CASE (JacobianShear_test) {
   BOOST_CHECK_EQUAL(150, measurement_center.m_y);
 
   SimpleSourceGroup group;
-  group.addSource(source);
+  group.addSource(std::move(source));
 
   group.setProperty<DetectionFrameGroupStamp>(
     ConstantImage<SeFloat>::create(100, 100, 0), nullptr, PixelCoordinate{100, 100}, nullptr

--- a/SEImplementation/tests/src/Segmentation/LutzSegmentation_test.cpp
+++ b/SEImplementation/tests/src/Segmentation/LutzSegmentation_test.cpp
@@ -32,13 +32,13 @@
 
 using namespace SourceXtractor;
 
-class SourceObserver : public Observer<std::shared_ptr<SourceInterface>> {
+class SourceObserver : public Observer<SourceInterface> {
 public:
-  virtual void handleMessage(const std::shared_ptr<SourceInterface>& source) override {
-    m_list.push_back(source);
+  virtual void handleMessage(const SourceInterface& source) override {
+    m_list.push_back(source.getProperty<PixelCoordinateList>());
   }
 
-  std::list<std::shared_ptr<SourceInterface>> m_list;
+  std::list<PixelCoordinateList> m_list;
 };
 
 
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_CASE( lutz_test, LutzFixture ) {
   Segmentation segmentation(nullptr);
   segmentation.setLabelling<LutzSegmentation>(std::make_shared<SimpleSourceFactory>());
 
-  segmentation.Observable<std::shared_ptr<SourceInterface>>::addObserver(source_observer);
+  segmentation.Observable<SourceInterface>::addObserver(source_observer);
 
   auto detection_frame = std::make_shared<DetectionImageFrame>(image);
 
@@ -165,7 +165,7 @@ BOOST_FIXTURE_TEST_CASE( lutz_test, LutzFixture ) {
   // and remove that group
   for (auto& source : source_observer->m_list) {
     auto check_image = VectorImage<DetectionImage::PixelType>::create(10, 10, std::vector<DetectionImage::PixelType>(100, 0.0));
-    for (auto& pixel : source->getProperty<PixelCoordinateList>().getCoordinateList()) {
+    for (auto& pixel : source.getCoordinateList()) {
       BOOST_CHECK_CLOSE(check_image->getValue(pixel), 0.0, 0.00001);
       check_image->setValue(pixel, 1.0);
     }

--- a/SEMain/SEMain/ProgressMediator.h
+++ b/SEMain/SEMain/ProgressMediator.h
@@ -51,8 +51,8 @@ typedef Observable<bool> DoneObservable;
 class ProgressMediator: public ProgressObservable, public DoneObservable {
 public:
   typedef Observer<SegmentationProgress> segmentation_observer_t;
-  typedef Observer<std::shared_ptr<SourceInterface>> source_observer_t;
-  typedef Observer<std::shared_ptr<SourceGroupInterface>> group_observer_t;
+  typedef Observer<SourceInterface>      source_observer_t;
+  typedef Observer<SourceGroupInterface> group_observer_t;
 
   ~ProgressMediator() = default;
 

--- a/SEMain/SEMain/Sorter.h
+++ b/SEMain/SEMain/Sorter.h
@@ -35,11 +35,11 @@ public:
   Sorter();
   virtual ~Sorter() = default;
 
-  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source) override;
+  void receiveSource(std::unique_ptr<SourceGroupInterface> source) override;
   void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
 private:
-  std::map<int, std::shared_ptr<SourceGroupInterface>> m_output_buffer;
+  std::map<int, std::unique_ptr<SourceGroupInterface>> m_output_buffer;
   int m_output_next;
 };
 

--- a/SEMain/SEMain/Sorter.h
+++ b/SEMain/SEMain/Sorter.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -24,19 +24,19 @@
 #ifndef _SEMAIN_SORTER_H_
 #define _SEMAIN_SORTER_H_
 
-#include "SEUtils/Observable.h"
+#include "SEFramework/Pipeline/PipelineStage.h"
 #include "SEFramework/Source/SourceGroupInterface.h"
 
 namespace SourceXtractor {
 
-class Sorter: public Observer<std::shared_ptr<SourceGroupInterface>>,
-              public Observable<std::shared_ptr<SourceGroupInterface>> {
+class Sorter: public PipelineReceiver<SourceGroupInterface>, public PipelineEmitter<SourceGroupInterface> {
 public:
 
   Sorter();
   virtual ~Sorter() = default;
 
-  void handleMessage(const std::shared_ptr<SourceGroupInterface>& message) override;
+  void receiveSource(const std::shared_ptr<SourceGroupInterface>& source) override;
+  void receiveProcessSignal(const ProcessSourcesEvent& event) override;
 
 private:
   std::map<int, std::shared_ptr<SourceGroupInterface>> m_output_buffer;

--- a/SEMain/src/lib/ProgressMediator.cpp
+++ b/SEMain/src/lib/ProgressMediator.cpp
@@ -47,28 +47,28 @@ private:
   std::mutex& m_mutex;
 };
 
-class ProgressMediator::SourceCounter : public Observer<std::shared_ptr<SourceInterface>> {
+class ProgressMediator::SourceCounter : public Observer<SourceInterface> {
 public:
-  SourceCounter(ProgressMediator& progress_listener, std::atomic_int& counter) :
-    m_progress_listener(progress_listener), m_counter(counter) {}
+  SourceCounter(ProgressMediator& progress_listener, std::atomic_int& counter)
+      : m_progress_listener(progress_listener), m_counter(counter) {}
 
-  void handleMessage(const std::shared_ptr<SourceInterface>&) override {
+  void handleMessage(const SourceInterface&) override {
     ++m_counter;
     m_progress_listener.update();
   }
 
 private:
   ProgressMediator& m_progress_listener;
-  std::atomic_int& m_counter;
+  std::atomic_int&  m_counter;
 };
 
-class ProgressMediator::GroupCounter : public Observer<std::shared_ptr<SourceGroupInterface>> {
+class ProgressMediator::GroupCounter : public Observer<SourceGroupInterface> {
 public:
-  GroupCounter(ProgressMediator& progress_listener, std::atomic_int& counter) :
-    m_progress_listener(progress_listener), m_counter(counter) {}
+  GroupCounter(ProgressMediator& progress_listener, std::atomic_int& counter)
+      : m_progress_listener(progress_listener), m_counter(counter) {}
 
-  void handleMessage(const std::shared_ptr<SourceGroupInterface>& group) override {
-    m_counter += group->size();
+  void handleMessage(const SourceGroupInterface& group) override {
+    m_counter += group.size();
     m_progress_listener.update();
   }
 

--- a/SEMain/src/lib/Sorter.cpp
+++ b/SEMain/src/lib/Sorter.cpp
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -27,7 +27,7 @@ static unsigned int extractSourceId(const SourceInterface &i) {
 Sorter::Sorter(): m_output_next{1} {
 }
 
-void Sorter::handleMessage(const std::shared_ptr<SourceGroupInterface> &message) {
+void Sorter::receiveSource(const std::shared_ptr<SourceGroupInterface>& message) {
   std::vector<unsigned int> source_ids(message->size());
   std::transform(message->cbegin(), message->cend(), source_ids.begin(), extractSourceId);
   std::sort(source_ids.begin(), source_ids.end());
@@ -38,10 +38,12 @@ void Sorter::handleMessage(const std::shared_ptr<SourceGroupInterface> &message)
   while (!m_output_buffer.empty() && m_output_buffer.begin()->first == m_output_next) {
     auto &next_group = m_output_buffer.begin()->second;
     m_output_next += next_group->size();
-    notifyObservers(next_group);
+    sendSource(next_group);
     m_output_buffer.erase(m_output_buffer.begin());
   }
 }
-
+void Sorter::receiveProcessSignal(const ProcessSourcesEvent& event) {
+  sendProcessSignal(event);
+}
 
 } // end SourceXtractor

--- a/SEMain/src/lib/Sorter.cpp
+++ b/SEMain/src/lib/Sorter.cpp
@@ -27,18 +27,18 @@ static unsigned int extractSourceId(const SourceInterface &i) {
 Sorter::Sorter(): m_output_next{1} {
 }
 
-void Sorter::receiveSource(const std::shared_ptr<SourceGroupInterface>& message) {
+void Sorter::receiveSource(std::unique_ptr<SourceGroupInterface> message) {
   std::vector<unsigned int> source_ids(message->size());
   std::transform(message->cbegin(), message->cend(), source_ids.begin(), extractSourceId);
   std::sort(source_ids.begin(), source_ids.end());
 
   auto first_source_id = source_ids.front();
-  m_output_buffer.emplace(first_source_id, message);
+  m_output_buffer.emplace(first_source_id, std::move(message));
 
   while (!m_output_buffer.empty() && m_output_buffer.begin()->first == m_output_next) {
     auto &next_group = m_output_buffer.begin()->second;
     m_output_next += next_group->size();
-    sendSource(next_group);
+    sendSource(std::move(next_group));
     m_output_buffer.erase(m_output_buffer.begin());
   }
 }


### PR DESCRIPTION
I have tried to use ownership semantics so the interfaces are more clear. i.e., observers get a const reference, so it is clear they must not hold onto sources.
Sources are passed along pipeline stages with `std::unique_ptr` so there can be only one proper owner.

tsan does not complain and the example from Martin does not crash anymore on my vm.