### PR TITLE
Feature/assoc world coord

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
@@ -71,19 +71,18 @@ public:
     return m_assoc_radius;
   }
 
-  const std::vector<CatalogEntry>& getCatalog() const {
-    return m_catalog;
+  const std::vector<std::vector<CatalogEntry>>& getCatalogs() const {
+    return m_catalogs;
   }
 
 private:
-
-  void readTable(const Euclid::Table::Table& table, const std::vector<int>& columns,
+  std::vector<CatalogEntry> readTable(const Euclid::Table::Table& table, const std::vector<int>& columns,
       const std::vector<int>& copy_columns, std::shared_ptr<CoordinateSystem> coordinate_system);
 
   AssocMode m_assoc_mode;
   double m_assoc_radius;
 
-  std::vector<CatalogEntry> m_catalog;
+  std::vector<std::vector<CatalogEntry>> m_catalogs;
 };
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
@@ -75,6 +75,10 @@ public:
     return m_catalogs;
   }
 
+  const std::vector<int>& getColumnsIdx() const {
+    return m_columns_idx;
+  }
+
 private:
   void readConfig(const UserValues& args);
   void readCatalogs(const UserValues& args);
@@ -86,6 +90,7 @@ private:
   double m_assoc_radius;
 
   std::vector<std::vector<CatalogEntry>> m_catalogs;
+  std::vector<int> m_columns_idx;
 };
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
@@ -76,6 +76,9 @@ public:
   }
 
 private:
+  void readConfig(const UserValues& args);
+  void readCatalogs(const UserValues& args);
+
   std::vector<CatalogEntry> readTable(const Euclid::Table::Table& table, const std::vector<int>& columns,
       const std::vector<int>& copy_columns, std::shared_ptr<CoordinateSystem> coordinate_system);
 

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
@@ -77,8 +77,8 @@ public:
 
 private:
 
-  void readTable(const Euclid::Table::Table& table,
-      const std::vector<int>& columns, const std::vector<int>& copy_columns);
+  void readTable(const Euclid::Table::Table& table, const std::vector<int>& columns,
+      const std::vector<int>& copy_columns, std::shared_ptr<CoordinateSystem> coordinate_system);
 
   AssocMode m_assoc_mode;
   double m_assoc_radius;

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTask.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTask.h
@@ -37,12 +37,12 @@ public:
   /// Destructor
   virtual ~AssocModeTask() = default;
 
-  AssocModeTask(const std::vector<AssocModeConfig::CatalogEntry>& catalog, AssocModeConfig::AssocMode assoc_type, double radius);
+  AssocModeTask(const std::vector<std::vector<AssocModeConfig::CatalogEntry>>& catalogs, AssocModeConfig::AssocMode assoc_type, double radius);
 
   void computeProperties(SourceInterface& source) const override;
 
 private:
-  KdTree<AssocModeConfig::CatalogEntry> m_catalog;
+  std::vector<KdTree<AssocModeConfig::CatalogEntry>> m_catalogs;
   AssocModeConfig::AssocMode m_assoc_mode;
   double m_radius;
 };

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTaskFactory.h
@@ -38,6 +38,7 @@ public:
 
   // TaskFactory implementation
   std::shared_ptr<Task> createTask(const PropertyId& property_id) const override;
+  void                  registerPropertyInstances(OutputRegistry& registry) override;
 
 private:
   std::vector<std::pair<std::string, unsigned int>> m_auto_names;
@@ -45,6 +46,7 @@ private:
   AssocModeConfig::AssocMode m_assoc_mode;
   double m_assoc_radius;
   std::vector<std::vector<AssocModeConfig::CatalogEntry>> m_catalogs;
+  bool m_add_property_instances = false;
 };
 
 }

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTaskFactory.h
@@ -44,7 +44,7 @@ private:
 
   AssocModeConfig::AssocMode m_assoc_mode;
   double m_assoc_radius;
-  std::vector<AssocModeConfig::CatalogEntry> m_catalog;
+  std::vector<std::vector<AssocModeConfig::CatalogEntry>> m_catalogs;
 };
 
 }

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -115,7 +115,7 @@ std::map<std::string, Configuration::OptionDescriptionList> AssocModeConfig::get
       {ASSOC_MODE.c_str(), po::value<std::string>()->default_value("NEAREST"),
           "Assoc mode [FIRST, NEAREST, MEAN, MAG_MEAN, SUM, MAG_SUM, MIN, MAX]"},
       {ASSOC_RADIUS.c_str(), po::value<double>()->default_value(2.0),
-          "Assoc radius"},
+          "Assoc radius (Always in pixels of the detection image)"},
       {ASSOC_FILTER.c_str(), po::value<std::string>()->default_value("ALL"),
           "Assoc catalog filter setting: ALL, MATCHED, UNMATCHED"},
       {ASSOC_COPY.c_str(), po::value<std::string>()->default_value(""),
@@ -246,8 +246,12 @@ std::vector<AssocModeConfig::CatalogEntry> AssocModeConfig::readTable(
         catalog.back().assoc_columns.emplace_back(boost::get<int>(row[column]));
       } else if (row[column].type() == typeid(double)) {
         catalog.back().assoc_columns.emplace_back(boost::get<double>(row[column]));
-      } else {
-        throw Elements::Exception() << "Wrong type in assoc column";
+      } else if (row[column].type() == typeid(int64_t)) {
+        catalog.back().assoc_columns.emplace_back(boost::get<int64_t>(row[column]));
+      } else if (row[column].type() == typeid(SeFloat)) {
+        catalog.back().assoc_columns.emplace_back(boost::get<SeFloat>(row[column]));
+      } else{
+        throw Elements::Exception() << "Wrong type in assoc column (must be a numeric type)";
       }
     }
   }

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModePlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModePlugin.cpp
@@ -42,15 +42,6 @@ void AssocModePlugin::registerPlugin(PluginAPI& plugin_api) {
     "Assoc match"
   );
 
-  plugin_api.getOutputRegistry().registerColumnConverter<AssocMode, NdArray<SeFloat>>(
-    "assoc_values",
-    [](const AssocMode &prop) {
-      return prop.getAssocValues();
-    },
-    "",
-    "Assoc catalog values"
-  );
-
   plugin_api.getOutputRegistry().enableOutput<AssocMode>("AssocMode");
 }
 

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeTaskFactory.cpp
@@ -39,14 +39,14 @@ void AssocModeTaskFactory::reportConfigDependencies(Euclid::Configuration::Confi
 void AssocModeTaskFactory::configure(Euclid::Configuration::ConfigManager &manager) {
   auto config = manager.getConfiguration<AssocModeConfig>();
 
-  m_catalog = config.getCatalog();
+  m_catalogs = config.getCatalogs();
   m_assoc_radius = config.getAssocRadius();
   m_assoc_mode = config.getAssocMode();
 }
 
 std::shared_ptr<Task> AssocModeTaskFactory::createTask(const PropertyId &property_id) const {
   if (property_id.getTypeId() == typeid(AssocMode)) {
-    return std::make_shared<AssocModeTask>(m_catalog, m_assoc_mode, m_assoc_radius);
+    return std::make_shared<AssocModeTask>(m_catalogs, m_assoc_mode, m_assoc_radius);
   } else {
     return nullptr;
   }

--- a/SEImplementation/tests/src/Plugin/AssocMode/AssocMode_test.cpp
+++ b/SEImplementation/tests/src/Plugin/AssocMode/AssocMode_test.cpp
@@ -22,6 +22,7 @@
 #include "SEFramework/Source/SimpleSource.h"
 
 #include "SEImplementation/Plugin/PixelCentroid/PixelCentroid.h"
+#include "SEImplementation/Plugin/DetectionFrameInfo/DetectionFrameInfo.h"
 #include "SEImplementation/Plugin/AssocMode/AssocMode.h"
 #include "SEImplementation/Plugin/AssocMode/AssocModeTask.h"
 
@@ -29,15 +30,18 @@ using namespace SourceXtractor;
 
 struct AssocModeFixture {
   SimpleSource source;
-  std::vector<AssocModeConfig::CatalogEntry> catalog {
+  std::vector<std::vector<AssocModeConfig::CatalogEntry>> catalog { {
     { {110, 100}, 1.0, {2.0, 3.0} },
     { {50, 50}, 1.0, {2.0, 3.0} },
     { {50, 60}, 0.5, {4.0, 5.0} },
     { {60, 60}, 3.0, {6.0, 7.0} },
     { {60, 50}, 2.0, {8.0, 9.0} }
-  };
+  } };
 
-  AssocModeFixture() {}
+  AssocModeFixture() {
+    // Initialize DetectionFrameInfo with dummy info and hdu_index=0
+    source.setProperty<DetectionFrameInfo>(200, 200, 1.0, 65000, 1000000, 20);
+  }
 };
 
 //-----------------------------------------------------------------------------
@@ -178,7 +182,7 @@ BOOST_FIXTURE_TEST_CASE(CheckLargeCatalog, AssocModeFixture) {
 
   {
     source.setProperty<PixelCentroid>(0, 0);
-    AssocModeTask assoc_mode_task(large_catalog, AssocModeConfig::AssocMode::SUM, 150.0);
+    AssocModeTask assoc_mode_task( { large_catalog }, AssocModeConfig::AssocMode::SUM, 150.0);
     assoc_mode_task.computeProperties(source);
 
     auto assoc_mode_property = source.getProperty<AssocMode>();
@@ -187,7 +191,7 @@ BOOST_FIXTURE_TEST_CASE(CheckLargeCatalog, AssocModeFixture) {
   }
   {
     source.setProperty<PixelCentroid>(0, 1000);
-    AssocModeTask assoc_mode_task(large_catalog, AssocModeConfig::AssocMode::SUM, 150.0);
+    AssocModeTask assoc_mode_task( { large_catalog }, AssocModeConfig::AssocMode::SUM, 150.0);
     assoc_mode_task.computeProperties(source);
 
     auto assoc_mode_property = source.getProperty<AssocMode>();
@@ -196,7 +200,7 @@ BOOST_FIXTURE_TEST_CASE(CheckLargeCatalog, AssocModeFixture) {
   }
   {
     source.setProperty<PixelCentroid>(0, 0);
-    AssocModeTask assoc_mode_task(large_catalog, AssocModeConfig::AssocMode::SUM, 5000.0);
+    AssocModeTask assoc_mode_task( { large_catalog }, AssocModeConfig::AssocMode::SUM, 5000.0);
     assoc_mode_task.computeProperties(source);
 
     auto assoc_mode_property = source.getProperty<AssocMode>();
@@ -205,7 +209,7 @@ BOOST_FIXTURE_TEST_CASE(CheckLargeCatalog, AssocModeFixture) {
   }
   {
     source.setProperty<PixelCentroid>(55.0, 55.0);
-    AssocModeTask assoc_mode_task(large_catalog, AssocModeConfig::AssocMode::NEAREST, 20.0);
+    AssocModeTask assoc_mode_task( { large_catalog }, AssocModeConfig::AssocMode::NEAREST, 20.0);
     assoc_mode_task.computeProperties(source);
 
     auto assoc_mode_property = source.getProperty<AssocMode>();


### PR DESCRIPTION
New parameter `assoc-coord-type` that can be set to `WORLD` to use world coordinates in the assoc catalog (default remains `PIXEL`).

This should be compatible with MEF detection images.