### PR TITLE
Disable the prefetcher when there is no need

### DIFF
--- a/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
+++ b/SEImplementation/SEImplementation/Prefetcher/Prefetcher.h
@@ -1,4 +1,4 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -74,7 +74,7 @@ public:
    *    PropertyId instances
    */
   template<typename Container>
-  void requestProperties(Container&& properties) {
+  void requestProperties(const Container& properties) {
     for (auto& p : properties) {
       requestProperty(p);
     }


### PR DESCRIPTION
I have been meaning to do this for a while. The `Prefetcher` adds a performance penalty when no properties are necessary before the measurements (i.e., no cleaning or no grouping, or not using Moffat).