### PR TITLE
Couple of fixes for assoc mode

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeConfig.h
@@ -75,6 +75,10 @@ public:
     return m_catalogs;
   }
 
+  const std::vector<int>& getColumnsIdx() const {
+    return m_columns_idx;
+  }
+
 private:
   void readConfig(const UserValues& args);
   void readCatalogs(const UserValues& args);
@@ -86,6 +90,7 @@ private:
   double m_assoc_radius;
 
   std::vector<std::vector<CatalogEntry>> m_catalogs;
+  std::vector<int> m_columns_idx;
 };
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/AssocMode/AssocModeTaskFactory.h
@@ -38,6 +38,7 @@ public:
 
   // TaskFactory implementation
   std::shared_ptr<Task> createTask(const PropertyId& property_id) const override;
+  void                  registerPropertyInstances(OutputRegistry& registry) override;
 
 private:
   std::vector<std::pair<std::string, unsigned int>> m_auto_names;
@@ -45,6 +46,7 @@ private:
   AssocModeConfig::AssocMode m_assoc_mode;
   double m_assoc_radius;
   std::vector<std::vector<AssocModeConfig::CatalogEntry>> m_catalogs;
+  bool m_add_property_instances = false;
 };
 
 }

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -191,7 +191,7 @@ void AssocModeConfig::readCatalogs(const UserValues& args) {
       std::shared_ptr<Euclid::Table::TableReader> reader;
       try {
         reader = std::make_shared<Euclid::Table::FitsReader>(filename);
-      } catch(...) {
+      } catch (...) {
         // If FITS not successful try reading as ascii
         reader = std::make_shared<Euclid::Table::AsciiReader>(filename);
       }
@@ -205,7 +205,8 @@ void AssocModeConfig::readCatalogs(const UserValues& args) {
           m_catalogs.emplace_back(readTable(table, columns, m_columns_idx, nullptr));
         }
       }
-
+    } catch (const std::exception& e) {
+      throw Elements::Exception() << "Can't either open or read assoc catalog: " << filename << " (" << e.what() << ")";
     } catch(...) {
       throw Elements::Exception() << "Can't either open or read assoc catalog: " << filename;
     }
@@ -245,6 +246,9 @@ std::vector<AssocModeConfig::CatalogEntry> AssocModeConfig::readTable(
       catalog.back().weight = boost::get<double>(row[columns.at(2)]);
     }
     for (auto column : copy_columns) {
+      if (column >= static_cast<int>(row.size())) {
+        throw Elements::Exception() << "Column index " << column << " is out of bounds";
+      }
       if (row[column].type() == typeid(int)) {
         catalog.back().assoc_columns.emplace_back(boost::get<int>(row[column]));
       } else if (row[column].type() == typeid(double)) {

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -173,7 +173,7 @@ void AssocModeConfig::readCatalogs(const UserValues& args) {
     throw Elements::Exception() << "Maximum 3 columns for x, y and weight must be specified in the assoc catalog";
   }
 
-  auto copy_columns = parseColumnList(args.at(ASSOC_COPY).as<std::string>());
+  m_columns_idx = parseColumnList(args.at(ASSOC_COPY).as<std::string>());
 
   AssocCoordType assoc_coord_type = AssocCoordType::PIXEL;
   if (args.find(ASSOC_COORD_TYPE) != args.end()) {
@@ -200,9 +200,9 @@ void AssocModeConfig::readCatalogs(const UserValues& args) {
       for (size_t i = 0; i < getDependency<DetectionImageConfig>().getExtensionsNb(); i++) {
         if (assoc_coord_type == AssocCoordType::WORLD) {
           auto coordinate_system = getDependency<DetectionImageConfig>().getCoordinateSystem(i);
-          m_catalogs.emplace_back(readTable(table, columns, copy_columns, coordinate_system));
+          m_catalogs.emplace_back(readTable(table, columns, m_columns_idx, coordinate_system));
         } else {
-          m_catalogs.emplace_back(readTable(table, columns, copy_columns, nullptr));
+          m_catalogs.emplace_back(readTable(table, columns, m_columns_idx, nullptr));
         }
       }
 

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModePlugin.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModePlugin.cpp
@@ -42,15 +42,6 @@ void AssocModePlugin::registerPlugin(PluginAPI& plugin_api) {
     "Assoc match"
   );
 
-  plugin_api.getOutputRegistry().registerColumnConverter<AssocMode, NdArray<SeFloat>>(
-    "assoc_values",
-    [](const AssocMode &prop) {
-      return prop.getAssocValues();
-    },
-    "",
-    "Assoc catalog values"
-  );
-
   plugin_api.getOutputRegistry().enableOutput<AssocMode>("AssocMode");
 }
 


### PR DESCRIPTION
While writing a test for the assoc mode I hit these two errors (or opaque errors).

1. `AssocMode` may be specified as output, but no columns copied (makes sense if `assoc-filter` is all)
2. When the columns given on `assoc-copy` are out of bounds, the error just said "can not read assoc catalog". Now it is more explicit:

```
2022-07-11T13:54:46CEST SourceXtractor FATAL : Can't either open or read assoc catalog: /home/aalvarez/Work/Projects/SourceXtractor-litmus/tests/../data/sim12/sim12_assoc.fits (Column index 4 is out of bounds)
```