### PR TITLE
DataCube support

### DIFF
--- a/SEFramework/SEFramework/FITS/FitsFile.h
+++ b/SEFramework/SEFramework/FITS/FitsFile.h
@@ -53,6 +53,7 @@ public:
   const std::vector<int>& getImageHdus() const;
 
   std::map<std::string, MetadataEntry>& getHDUHeaders(int hdu);
+  std::vector<int> getDimensions(int hdu) const;
 
   void refresh();
 

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -81,6 +81,13 @@ public:
     return m_height;
   }
 
+  /// Returns the depth of the image in pixels
+  int getDepth() const {
+    return m_depth;
+  }
+
+  void setLayer(int layer);
+
   std::shared_ptr<ImageTile> getImageTile(int x, int y, int width, int height) const override;
 
   void saveTile(ImageTile& tile) override;
@@ -124,7 +131,10 @@ private:
 
   int m_width;
   int m_height;
+  int m_depth;
   ImageTile::ImageType m_image_type;
+
+  int m_current_layer;
 };
 
 }

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -42,6 +42,33 @@
 namespace SourceXtractor {
 
 namespace {
+
+ImageTile::ImageType convertImageType(int bitpix) {
+  ImageTile::ImageType image_type;
+
+  switch (bitpix) {
+  case FLOAT_IMG:
+    image_type = ImageTile::FloatImage;
+    break;
+  case DOUBLE_IMG:
+    image_type = ImageTile::DoubleImage;
+    break;
+  case LONG_IMG:
+    image_type = ImageTile::IntImage;
+    break;
+  case ULONG_IMG:
+    image_type = ImageTile::UIntImage;
+    break;
+  case LONGLONG_IMG:
+    image_type = ImageTile::LongLongImage;
+    break;
+  default:
+    throw Elements::Exception() << "Unsupported FITS image type: " << bitpix;
+  }
+
+  return image_type;
+}
+
 }
 
 FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number,
@@ -75,25 +102,7 @@ FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number,
   m_depth = naxis >= 3 ? naxes[2] : 1;
 
   if (image_type < 0) {
-    switch (bitpix) {
-    case FLOAT_IMG:
-      m_image_type = ImageTile::FloatImage;
-      break;
-    case DOUBLE_IMG:
-      m_image_type = ImageTile::DoubleImage;
-      break;
-    case LONG_IMG:
-      m_image_type = ImageTile::IntImage;
-      break;
-    case ULONG_IMG:
-      m_image_type = ImageTile::UIntImage;
-      break;
-    case LONGLONG_IMG:
-      m_image_type = ImageTile::LongLongImage;
-      break;
-    default:
-      throw Elements::Exception() << "Unsupported FITS image type: " << bitpix;
-    }
+    m_image_type = convertImageType(bitpix);
   }
   else {
     m_image_type = image_type;

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -50,7 +50,7 @@ FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number,
     : m_filename(filename), m_handler(manager->getFileHandler(filename)), m_hdu_number(hdu_number) {
   int status = 0;
   int bitpix, naxis;
-  long naxes[2] = {1, 1};
+  long naxes[3] = {1, 1, 1};
 
   auto acc = m_handler->getAccessor<FitsFile>();
   auto fptr = acc->m_fd.getFitsFilePtr();
@@ -65,12 +65,14 @@ FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number,
   }
 
   fits_get_img_param(fptr, 2, &bitpix, &naxis, naxes, &status);
-  if (status != 0 || naxis != 2) {
-    throw Elements::Exception() << "Can't find 2D image in FITS file: " << filename << "[" << m_hdu_number << "]";
+  if (status != 0 || (naxis != 2 && naxis != 3)) {
+    throw Elements::Exception()
+        << "Can't find 2D image or data cube in FITS file: " << filename << "[" << m_hdu_number << "]";
   }
 
   m_width = naxes[0];
   m_height = naxes[1];
+  m_depth = naxis >= 3 ? naxes[2] : 1;
 
   if (image_type < 0) {
     switch (bitpix) {
@@ -189,9 +191,9 @@ std::shared_ptr<ImageTile> FitsImageSource::getImageTile(int x, int y, int width
   auto tile = ImageTile::create(m_image_type, x, y, width, height,
                                 std::const_pointer_cast<ImageSource>(shared_from_this()));
 
-  long first_pixel[2] = {x + 1, y + 1};
-  long last_pixel[2] = {x + width, y + height};
-  long increment[2] = {1, 1};
+  long first_pixel[3] = {x + 1, y + 1, m_current_layer+1};
+  long last_pixel[3] = {x + width, y + height, m_current_layer+1};
+  long increment[3] = {1, 1, 1};
   int status = 0;
 
   fits_read_subset(fptr, getDataType(), first_pixel, last_pixel, increment,
@@ -239,6 +241,12 @@ void FitsImageSource::switchHdu(fitsfile *fptr, int hdu_number) const {
   }
 }
 
+void FitsImageSource::setLayer(int layer) {
+  if (layer < 0 && layer >= m_depth) {
+    throw Elements::Exception() << "Trying to access an inexistent data cube layer (" << layer << ") in " << m_filename;
+  }
+  m_current_layer = layer;
+}
 
 std::unique_ptr<std::vector<char>> FitsImageSource::getFitsHeaders(int& number_of_records) const {
   number_of_records = 0;

--- a/SEImplementation/SEImplementation/Configuration/MeasurementImageConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/MeasurementImageConfig.h
@@ -61,6 +61,10 @@ public:
     int m_image_hdu;
     int m_psf_hdu;
     int m_weight_hdu;
+
+    bool m_is_data_cube;
+    int m_image_layer;
+    int m_weight_layer;
   };
 
   explicit MeasurementImageConfig(long manager_id);

--- a/SEImplementation/SEImplementation/PythonConfig/PyFitsFile.h
+++ b/SEImplementation/SEImplementation/PythonConfig/PyFitsFile.h
@@ -40,6 +40,7 @@ public:
   std::vector<int> getImageHdus() const;
 
   std::map<std::string, std::string> getHeaders(int hdu) const;
+  std::vector<int> getDimensions(int hdu) const;
 
 private:
   std::string m_filename;

--- a/SEImplementation/SEImplementation/PythonConfig/PyMeasurementImage.h
+++ b/SEImplementation/SEImplementation/PythonConfig/PyMeasurementImage.h
@@ -50,6 +50,10 @@ public:
   int image_hdu;
   int psf_hdu;
   int weight_hdu;
+
+  bool is_data_cube;
+  int image_layer;
+  int weight_layer;
 };
 
 }

--- a/SEImplementation/python/sourcextractor/config/__init__.py
+++ b/SEImplementation/python/sourcextractor/config/__init__.py
@@ -17,7 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 from .measurement_images import (load_fits_images, print_measurement_images, load_fits_image,
                                  ImageGroup, ByKeyword, ByPattern, MeasurementImage,
-                                 MeasurementGroup, FitsFile)
+                                 MeasurementGroup, FitsFile, DataCubeSlice, load_fits_data_cube)
 from .model_fitting import (RangeType, Range, Unbounded, print_parameters, ConstantParameter,
                             FreeParameter, DependentParameter,get_pos_parameters,
                             FluxParameterType, get_flux_parameter, add_model,

--- a/SEImplementation/python/sourcextractor/config/measurement_images.py
+++ b/SEImplementation/python/sourcextractor/config/measurement_images.py
@@ -538,7 +538,7 @@ def load_fits_data_cube(image, psf=None, weight=None, image_cube_hdu=-1, weight_
             weight_layer_list = range(cube_size)
         else:
             # weight is a FITS without a datacube, assume MEF
-            weight_file_list = [weight_hdu_list] * cube_size
+            weight_file_list = [weight_fits_file] * cube_size
             weight_hdu_list = weight_hdu_list.hdu_list
             weight_layer_list = [0] * cube_size
 

--- a/SEImplementation/src/lib/CheckImages/CheckImages.cpp
+++ b/SEImplementation/src/lib/CheckImages/CheckImages.cpp
@@ -154,6 +154,9 @@ void CheckImages::configure(Euclid::Configuration::ConfigManager& manager) {
   for (auto& info : measurement_images_info) {
     std::stringstream label;
     label << boost::filesystem::basename(info.m_path) << "_" << info.m_image_hdu;
+    if (info.m_is_data_cube) {
+      label << "_" << info.m_image_layer;
+    }
 
     m_measurement_frames[info.m_id] = FrameInfo {
       label.str(),

--- a/SEImplementation/src/lib/Configuration/MeasurementImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MeasurementImageConfig.cpp
@@ -119,6 +119,9 @@ std::shared_ptr<WeightImage> createWeightMap(const PyMeasurementImage& py_image)
   auto weight_image_source =
       std::make_shared<FitsImageSource>(py_image.weight_file, py_image.weight_hdu+1, ImageTile::FloatImage);
   std::shared_ptr<WeightImage> weight_map = BufferedImage<WeightImage::PixelType>::create(weight_image_source);
+  if (py_image.is_data_cube) {
+    weight_image_source->setLayer(py_image.weight_layer);
+  }
 
   logger.debug() << "w: " << weight_map->getWidth() << " h: " << weight_map->getHeight()
       << " t: " << py_image.weight_type << " s: " << py_image.weight_scaling;
@@ -189,9 +192,17 @@ void MeasurementImageConfig::initialize(const UserValues&) {
       info.m_path = py_image.file;
       info.m_psf_path = py_image.psf_file;
 
+      info.m_is_data_cube = py_image.is_data_cube;
+      info.m_image_layer = py_image.image_layer;
+      info.m_weight_layer = py_image.weight_layer;
 
       auto fits_image_source =
           std::make_shared<FitsImageSource>(py_image.file, py_image.image_hdu+1, ImageTile::FloatImage);
+
+      if (py_image.is_data_cube) {
+        fits_image_source->setLayer(py_image.image_layer);
+      }
+
       info.m_measurement_image = createMeasurementImage(fits_image_source, py_image.flux_scale);
       info.m_coordinate_system = std::make_shared<WCS>(*fits_image_source);
 

--- a/SEImplementation/src/lib/PythonConfig/PyFitsFile.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PyFitsFile.cpp
@@ -35,6 +35,11 @@ std::vector<int> PyFitsFile::getImageHdus() const {
   return v;
 }
 
+std::vector<int> PyFitsFile::getDimensions(int hdu) const {
+  return m_file->getDimensions(hdu+1);
+}
+
+
 std::map<std::string, std::string> PyFitsFile::getHeaders(int hdu) const {
   const auto& headers = m_file->getHDUHeaders(hdu+1);
   std::map<std::string, std::string> headers_str;

--- a/SEImplementation/src/lib/PythonConfig/PyMeasurementImage.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PyMeasurementImage.cpp
@@ -26,7 +26,8 @@ namespace SourceXtractor {
 PyMeasurementImage::PyMeasurementImage(std::string file, std::string psf_file, std::string weight_file)
   : file(file), gain(0.), saturation(0.), flux_scale(1.), psf_file(psf_file), weight_file(weight_file),
     weight_absolute(false), weight_scaling(0.), has_weight_threshold(false), weight_threshold(0.),
-    is_background_constant(false), constant_background_value(0.), image_hdu(0), psf_hdu(0), weight_hdu(0) {
+    is_background_constant(false), constant_background_value(0.), image_hdu(0), psf_hdu(0), weight_hdu(0),
+    is_data_cube(false), image_layer(0), weight_layer(0) {
 }
 
 }

--- a/SEImplementation/src/lib/PythonConfig/PythonModule.cpp
+++ b/SEImplementation/src/lib/PythonConfig/PythonModule.cpp
@@ -75,7 +75,11 @@ BOOST_PYTHON_MODULE(_SourceXtractorPy) {
       .def_readwrite("constant_background_value", &PyMeasurementImage::constant_background_value)
       .def_readwrite("image_hdu", &PyMeasurementImage::image_hdu)
       .def_readwrite("psf_hdu", &PyMeasurementImage::psf_hdu)
-      .def_readwrite("weight_hdu", &PyMeasurementImage::weight_hdu);
+      .def_readwrite("weight_hdu", &PyMeasurementImage::weight_hdu)
+      .def_readwrite("is_data_cube", &PyMeasurementImage::is_data_cube)
+      .def_readwrite("image_layer", &PyMeasurementImage::image_layer)
+      .def_readwrite("weight_layer", &PyMeasurementImage::weight_layer)
+      ;
 
   bp::class_<PyId>("Id", bp::init<>())
     .def_readonly("id", &PyId::id);
@@ -125,7 +129,9 @@ BOOST_PYTHON_MODULE(_SourceXtractorPy) {
   bp::class_<PyFitsFile>("FitsFile", "A FITS file opened by SourceXtractor++", bp::init<const std::string&>())
     .def_readonly("filename", &PyFitsFile::getFilename)
     .def_readonly("image_hdus", &PyFitsFile::getImageHdus)
-    .def("get_headers", &PyFitsFile::getHeaders, "get headers for hdu");
+    .def("get_headers", &PyFitsFile::getHeaders, "get headers for hdu")
+    .def("get_dimensions", &PyFitsFile::getDimensions, "get dimensions for hdu");
+
 }
 
 } // namespace SourceXtractor


### PR DESCRIPTION
Example to load a whole data cube (with matching psf files in this case):

`g1 = load_fits_data_cube('cube.fits', sorted(glob('sim11_g_??.psf')))`

to load individual slices:
`DataCubeSlice('cube.fits', "nopsf", image_layer=3)`
