### PR TITLE
The percentage of masked pixels is written out.

### DIFF
--- a/SEFramework/SEFramework/Image/MaskedImage.h
+++ b/SEFramework/SEFramework/Image/MaskedImage.h
@@ -46,7 +46,7 @@ class MaskedImage : public Image<T> {
 private:
   MaskedImage(const std::shared_ptr<Image<T>>& image, const std::shared_ptr<Image<M>>& mask,
               T replacement, M mask_flag) : m_image{image}, m_mask{mask}, m_replacement{replacement},
-                                            m_mask_flag{mask_flag} {
+                                            m_mask_flag{mask_flag}, m_n_masked{0}, m_n_unmasked{0} {
   }
 
   std::shared_ptr<Image<T>> m_image;
@@ -54,6 +54,9 @@ private:
   T m_replacement;
   M m_mask_flag;
   Operator<M> m_operator;
+
+  mutable std::size_t m_n_masked;
+  mutable std::size_t m_n_unmasked;
 
 public:
   virtual ~MaskedImage() = default;
@@ -79,7 +82,10 @@ public:
   }
 
   std::string getRepr() const final {
-    return std::string("Masked(" + m_image->getRepr() + ")");
+    char char_fract[8];
+    // determine the percentage of masked pixels
+    std::snprintf(char_fract, 7, "%.1f%", 100.0*this->getNMasked()/(m_image->getWidth()*m_image->getHeight()));
+    return std::string("Masked(" + m_image->getRepr() + ") with "+std::string(char_fract)+" masked pixels");
   }
 
   int getWidth() const final {
@@ -90,13 +96,26 @@ public:
     return m_image->getHeight();
   }
 
+  std::size_t getNMasked() const {
+    return m_n_masked;
+  }
+
+  std::size_t getNUnMasked() const {
+    return m_n_unmasked;
+  }
+
   std::shared_ptr<ImageChunk<T>> getChunk(int x, int y, int width, int height) const final {
     auto chunk = UniversalImageChunk<T>::create(std::move(*m_image->getChunk(x, y, width, height)));
     auto mask_chunk = m_mask->getChunk(x, y, width, height);
     for (int iy = 0; iy < height; ++iy) {
       for (int ix = 0; ix < width; ++ix) {
-        if (m_operator(mask_chunk->getValue(ix, iy), m_mask_flag))
+        if (m_operator(mask_chunk->getValue(ix, iy), m_mask_flag)){
           chunk->setValue(ix, iy, m_replacement);
+          m_n_masked+=1;
+        }
+        else {
+          m_n_unmasked+=1;
+        }
       }
     }
     return chunk;


### PR DESCRIPTION
The output is now such as:
`2022-08-24T16:13:13CEST BackgroundModel  INFO : Background for image: Masked(Masked(BufferedImage(jw02736-o001_t001_nircam_clear-f444w_i2d.fits[1])) with 0.0% masked pixels) with 57.1% masked pixels median: 0.255467 rms: 0.00261305!`

which means the NAN's or thresholded pixels from the weight image are taken into account. 