### PR TITLE
Keep the FileManager alive

### DIFF
--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -125,6 +126,7 @@ private:
   int getImageType() const;
 
   std::string m_filename;
+  std::shared_ptr<FileManager> m_file_manager;
   std::shared_ptr<FileHandler> m_handler;
 
   int m_hdu_number;

--- a/SEFramework/SEFramework/FITS/FitsImageSource.h
+++ b/SEFramework/SEFramework/FITS/FitsImageSource.h
@@ -114,9 +114,9 @@ public:
 
   std::unique_ptr<std::vector<char>> getFitsHeaders(int& number_of_records) const;
 
-  const std::map<std::string, MetadataEntry> getMetadata() const override;
+  const std::map<std::string, MetadataEntry>& getMetadata() const override;
 
-  void setMetadata(std::string key, MetadataEntry value) override;
+  void setMetadata(const std::string& key, const MetadataEntry& value) override;
 
 private:
   void switchHdu(fitsfile *fptr, int hdu_number) const;

--- a/SEFramework/SEFramework/Image/ImageSource.h
+++ b/SEFramework/SEFramework/Image/ImageSource.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -74,12 +75,14 @@ public:
   /**
    * @return A copy of the metadata set
    */
-  virtual const std::map<std::string, MetadataEntry> getMetadata() const { return {}; };
+  virtual const std::map<std::string, MetadataEntry>& getMetadata() const { return m_metadata; }
 
-  virtual void setMetadata(std::string /*key*/, MetadataEntry /*value*/) {}
+  virtual void setMetadata(const std::string& key, const MetadataEntry& value) {
+    m_metadata[key] = value;
+  }
 
 private:
-
+  std::map<std::string, MetadataEntry> m_metadata;
 };
 
 }  // namespace SourceXtractor

--- a/SEFramework/src/lib/FITS/FitsImageSource.cpp
+++ b/SEFramework/src/lib/FITS/FitsImageSource.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -74,7 +75,10 @@ ImageTile::ImageType convertImageType(int bitpix) {
 FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number,
                                  ImageTile::ImageType image_type,
                                  std::shared_ptr<FileManager> manager)
-    : m_filename(filename), m_handler(manager->getFileHandler(filename)), m_hdu_number(hdu_number) {
+    : m_filename(filename)
+    , m_file_manager(std::move(manager))
+    , m_handler(m_file_manager->getFileHandler(filename))
+    , m_hdu_number(hdu_number) {
   int status = 0;
   int bitpix, naxis;
   long naxes[3] = {1, 1, 1};
@@ -109,14 +113,12 @@ FitsImageSource::FitsImageSource(const std::string& filename, int hdu_number,
   }
 }
 
-
-FitsImageSource::FitsImageSource(const std::string& filename, int width, int height,
-                                 ImageTile::ImageType image_type,
-                                 const std::shared_ptr<CoordinateSystem> coord_system, bool append,
-                                 bool empty_primary,
+FitsImageSource::FitsImageSource(const std::string& filename, int width, int height, ImageTile::ImageType image_type,
+                                 const std::shared_ptr<CoordinateSystem> coord_system, bool append, bool empty_primary,
                                  std::shared_ptr<FileManager> manager)
     : m_filename(filename)
-    , m_handler(manager->getFileHandler(filename))
+    , m_file_manager(std::move(manager))
+    , m_handler(m_file_manager->getFileHandler(filename))
     , m_width(width)
     , m_height(height)
     , m_image_type(image_type) {
@@ -189,7 +191,7 @@ FitsImageSource::FitsImageSource(const std::string& filename, int width, int hei
   // after we created the file
 
   m_handler = nullptr;
-  m_handler = manager->getFileHandler(filename);
+  m_handler = m_file_manager->getFileHandler(filename);
 }
 
 std::shared_ptr<ImageTile> FitsImageSource::getImageTile(int x, int y, int width, int height) const {


### PR DESCRIPTION
The crash that Martin reported happened at exiting. The `FileManager` was getting destroyed first, and then the `CheckImages`. When the latter tried to flush the tiles, the program crashed when trying to obtain a file descriptor.

 `FitsImageSource` should keep the manager alive as long as it exists so it can flush the tiles into disk.