### PR TITLE
Feature/remove flag parameters

### DIFF
--- a/SEImplementation/src/lib/Configuration/AttractorsPartitionConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/AttractorsPartitionConfig.cpp
@@ -40,7 +40,7 @@ AttractorsPartitionConfig::AttractorsPartitionConfig(long manager_id) : Configur
 
 auto AttractorsPartitionConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
   return { {"Extraction", {
-      {USE_ATTRACTORS_PARTITION.c_str(), po::bool_switch(),
+      {USE_ATTRACTORS_PARTITION.c_str(), po::value<bool>()->default_value(false),
               "Enables the use of attractors for partitioning"}
   }}};
 }

--- a/SEImplementation/src/lib/Configuration/CleaningConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/CleaningConfig.cpp
@@ -42,7 +42,7 @@ CleaningConfig::CleaningConfig(long manager_id) : Configuration(manager_id) {
 
 std::map<std::string, Configuration::OptionDescriptionList> CleaningConfig::getProgramOptions() {
   return { {"Cleaning", {
-      {USE_CLEANING.c_str(), po::bool_switch(),
+      {USE_CLEANING.c_str(), po::value<bool>()->default_value(false),
          "Enables the cleaning of sources (removes false detections near bright objects)"},
       {CLEANING_MINAREA.c_str(), po::value<int>()->default_value(3), "min. # of pixels above threshold"}
   }}};

--- a/SEImplementation/src/lib/Configuration/OutputConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/OutputConfig.cpp
@@ -40,7 +40,7 @@ static const std::string OUTPUT_FILE {"output-catalog-filename"};
 static const std::string OUTPUT_FILE_FORMAT {"output-catalog-format"};
 static const std::string OUTPUT_PROPERTIES {"output-properties"};
 static const std::string OUTPUT_FLUSH_SIZE {"output-flush-size"};
-static const std::string OUTPUT_UNSORTED {"output-flush-unsorted"};
+static const std::string OUTPUT_SORTED {"output-flush-sorted"};
 
 static std::map<std::string, OutputConfig::OutputFileFormat> format_map{
   {"ASCII",     OutputConfig::OutputFileFormat::ASCII},
@@ -62,8 +62,8 @@ std::map<std::string, Configuration::OptionDescriptionList> OutputConfig::getPro
           "The output properties to add in the output catalog"},
       {OUTPUT_FLUSH_SIZE.c_str(), po::value<int>()->default_value(100),
          "Write to the catalog after this number of sources have been processed (0 means once at the end)"},
-      {OUTPUT_UNSORTED.c_str(), po::bool_switch(),
-         "Write finished sources to the catalog without waiting for previously detected unfinished sources"}
+      {OUTPUT_SORTED.c_str(), po::value<bool>()->default_value(true),
+         "Delay the output of some sources to ensure a deterministic order"}
   }}};
 }
 
@@ -89,7 +89,7 @@ void OutputConfig::initialize(const UserValues& args) {
   int flush_size = args.at(OUTPUT_FLUSH_SIZE).as<int>();
   m_flush_size = (flush_size >= 0) ? flush_size : 0;
 
-  m_unsorted = args.at(OUTPUT_UNSORTED).as<bool>();
+  m_unsorted = !args.at(OUTPUT_SORTED).as<bool>();
 }
 
 std::string OutputConfig::getOutputFile() {

--- a/SEImplementation/src/lib/Configuration/SE2BackgroundConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/SE2BackgroundConfig.cpp
@@ -45,9 +45,7 @@ std::map<std::string, Configuration::OptionDescriptionList> SE2BackgroundConfig:
       {CELLSIZE_VALUE.c_str(), po::value<std::string>()->default_value(std::string("64")),
           "Background mesh cell size to determine a value."},
       {SMOOTHINGBOX_VALUE.c_str(), po::value<std::string>()->default_value(std::string("3")),
-          "Background median filter size"},
-      {LEGACY_BACKGROUND.c_str(), po::bool_switch(),
-          "Deprecated, kept for compatibility"}
+          "Background median filter size"}
   }}};
 }
 
@@ -70,10 +68,6 @@ void SE2BackgroundConfig::initialize(const UserValues& args) {
   }
   if (std::find_if(m_smoothing_box.begin(), m_smoothing_box.end(), less_0) != m_smoothing_box.end()) {
     throw Elements::Exception() << "There are value(s) < 0 in smoothing-box-size: " << smoothing_box_str;
-  }
-  if (args.find(LEGACY_BACKGROUND) != args.end()) {
-    logger.warn() << "The option "
-                  << LEGACY_BACKGROUND << " is deprecated and has no effect starting at version 0.17";
   }
 }
 

--- a/SEImplementation/src/lib/Configuration/SE2BackgroundConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/SE2BackgroundConfig.cpp
@@ -34,7 +34,6 @@ static Elements::Logging logger = Elements::Logging::getLogger("BackgroundConfig
 
 static const std::string CELLSIZE_VALUE {"background-cell-size" };
 static const std::string SMOOTHINGBOX_VALUE {"smoothing-box-size" };
-static const std::string LEGACY_BACKGROUND {"background-legacy"};
 
 SE2BackgroundConfig::SE2BackgroundConfig(long manager_id) :
   Configuration(manager_id), m_cell_size(), m_smoothing_box() {

--- a/SEImplementation/src/lib/Configuration/SegmentationConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/SegmentationConfig.cpp
@@ -45,7 +45,7 @@ namespace SourceXtractor {
 static Elements::Logging segConfigLogger = Elements::Logging::getLogger("Config");
 
 static const std::string SEGMENTATION_ALGORITHM {"segmentation-algorithm" };
-static const std::string SEGMENTATION_DISABLE_FILTERING {"segmentation-disable-filtering" };
+static const std::string SEGMENTATION_USE_FILTERING {"segmentation-use-filtering" };
 static const std::string SEGMENTATION_FILTER {"segmentation-filter" };
 static const std::string SEGMENTATION_LUTZ_WINDOW_SIZE {"segmentation-lutz-window-size" };
 static const std::string SEGMENTATION_BFS_MAX_DELTA {"segmentation-bfs-max-delta" };
@@ -61,8 +61,8 @@ std::map<std::string, Configuration::OptionDescriptionList> SegmentationConfig::
   return { {"Detection image", {
       {SEGMENTATION_ALGORITHM.c_str(), po::value<std::string>()->default_value("LUTZ"),
           "Segmentation algorithm to be used (LUTZ, TILES or ML (a ONNX-format model must be provided))"},
-      {SEGMENTATION_DISABLE_FILTERING.c_str(), po::bool_switch(),
-          "Disables filtering"},
+      {SEGMENTATION_USE_FILTERING.c_str(), po::value<bool>()->default_value(true),
+          "Is filtering used"},
       {SEGMENTATION_FILTER.c_str(), po::value<std::string>()->default_value(""),
           "Loads a filter"},
       {SEGMENTATION_LUTZ_WINDOW_SIZE.c_str(), po::value<int>()->default_value(0),
@@ -92,9 +92,7 @@ void SegmentationConfig::preInitialize(const UserValues& args) {
     throw Elements::Exception() << "Unknown segmentation algorithm : " << algorithm_name;
   }
 
-  if (args.at(SEGMENTATION_DISABLE_FILTERING).as<bool>()) {
-    m_filter = nullptr;
-  } else {
+  if (args.at(SEGMENTATION_USE_FILTERING).as<bool>()) {
     auto filter_filename = args.at(SEGMENTATION_FILTER).as<std::string>();
     if (filter_filename != "") {
       m_filter = loadFilter(filter_filename);
@@ -103,6 +101,8 @@ void SegmentationConfig::preInitialize(const UserValues& args) {
     } else {
       m_filter = getDefaultFilter();
     }
+  } else {
+    m_filter = nullptr;
   }
 
   m_lutz_window_size = args.at(SEGMENTATION_LUTZ_WINDOW_SIZE).as<int>();

--- a/SEImplementation/src/lib/Plugin/CoreThresholdPartition/CoreThresholdPartitionConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/CoreThresholdPartition/CoreThresholdPartitionConfig.cpp
@@ -50,7 +50,7 @@ std::map<std::string, Configuration::OptionDescriptionList> CoreThresholdPartiti
   return {{"Core threshold partitioning", {
       {CORE_THRESHOLD.c_str(), po::value<double>()->default_value(0.0), "The core threshold level"},
       {CORE_MINAREA.c_str(), po::value<int>()->default_value(0), "The minimum pixel area for partitioning"},
-      {CORE_THRESH_USE.c_str(), po::bool_switch(), "Activate core threshold partitioning"}
+      {CORE_THRESH_USE.c_str(), po::value<bool>()->default_value(false), "Activate core threshold partitioning"}
   }}};
 }
 
@@ -65,8 +65,7 @@ void CoreThresholdPartitionConfig::initialize(const UserValues &args) {
     throw Elements::Exception() << "Invalid " << CORE_MINAREA << " value: " << m_core_minarea;
   }
 
-  if (m_core_threshold > 0.0 && m_core_minarea > 0 && args.at(CORE_THRESH_USE).as<bool>()){
-
+  if (m_core_threshold > 0.0 && m_core_minarea > 0 && args.at(CORE_THRESH_USE).as<bool>()) {
     double core_threshold = m_core_threshold;
     int core_minarea      = m_core_minarea;
     getDependency<PartitionStepConfig>().addPartitionStepCreator([core_threshold, core_minarea](std::shared_ptr<SourceFactory>)

--- a/SEMain/src/lib/ProgressReporterFactory.cpp
+++ b/SEMain/src/lib/ProgressReporterFactory.cpp
@@ -23,7 +23,7 @@ namespace SourceXtractor {
 namespace po = boost::program_options;
 
 static const std::string PROGRESS_MIN_INTERVAL{"progress-min-interval"};
-static const std::string PROGRESS_BAR_DISABLED{"progress-bar-disable"};
+static const std::string PROGRESS_BAR {"progress-bar"};
 
 ProgressReporterFactory::ProgressReporterFactory() : m_min_interval{std::chrono::seconds(5)},
                                                      m_disable_progress_bar{false} {}
@@ -31,13 +31,13 @@ ProgressReporterFactory::ProgressReporterFactory() : m_min_interval{std::chrono:
 void ProgressReporterFactory::addOptions(boost::program_options::options_description& options) const {
   options.add_options() (PROGRESS_MIN_INTERVAL.c_str(), po::value<int>()->default_value(5),
      "Minimal interval to wait before printing a new log entry with the progress report");
-  options.add_options() (PROGRESS_BAR_DISABLED.c_str(), po::bool_switch(),
-          "Disable progress bar display");
+  options.add_options() (PROGRESS_BAR.c_str(), po::value<bool>()->default_value(true),
+          "Show/Hide progress bar display");
 }
 
 void ProgressReporterFactory::configure(const std::map<std::string, boost::program_options::variable_value> &args) {
   m_min_interval = std::chrono::seconds(args.at(PROGRESS_MIN_INTERVAL).as<int>());
-  m_disable_progress_bar = args.at(PROGRESS_BAR_DISABLED).as<bool>();
+  m_disable_progress_bar = !args.at(PROGRESS_BAR).as<bool>();
   // If the output is written to stdout, we can't use the terminal for the fancy ncurses interface
   if (args.at("output-catalog-filename").as<std::string>().empty()) {
     m_disable_progress_bar = true;


### PR DESCRIPTION
#513 as discussed the following parameters have been modified:

`use-cleaning` becomes a boolean (off by default)
`use-attractors-partition` becomes a boolean (off by default)
`partition-corethreshold` becomes a boolean (off by default)

And to avoid double negatives:
`segmentation-disable-filtering` becomes the boolean `segmentation-use-filtering` (on by default)
`output-flush-unsorted` becomes the boolean `output-flush-sorted` (on by default)
**EDIT**:
`progress-bar-disable` becomes the boolean `progress-bar` (on by default)

Also 
`background-legacy` is removed (it was already deprecated and doing nothing)
