### PR TITLE
Make sources cloneable

### DIFF
--- a/SEFramework/SEFramework/Property/PropertyHolder.h
+++ b/SEFramework/SEFramework/Property/PropertyHolder.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -64,12 +65,14 @@ public:
 
   /// Returns true if the property is set
   bool isPropertySet(const PropertyId& property_id) const;
-  
+
   void clear();
+
+  void update(const PropertyHolder& other);
 
 private:
 
-  std::unordered_map<PropertyId, std::unique_ptr<Property>> m_properties;
+  std::unordered_map<PropertyId, std::shared_ptr<Property>> m_properties;
 
 }; /* End of ObjectWithProperties class */
 

--- a/SEFramework/SEFramework/Source/SimpleSource.h
+++ b/SEFramework/SEFramework/Source/SimpleSource.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -53,6 +54,12 @@ public:
 
   /// Constructor
   SimpleSource() {}
+
+  std::unique_ptr<SourceInterface> clone() const override {
+    auto cloned = std::make_unique<SimpleSource>();
+    cloned->m_property_holder.update(m_property_holder);
+    return std::move(cloned);
+  }
 
   // Note : Because the get/setProperty() methods of the SourceInterface are
   // templated, the overrides of the non-templated versions will hide them. For

--- a/SEFramework/SEFramework/Source/SimpleSourceGroup.h
+++ b/SEFramework/SEFramework/Source/SimpleSourceGroup.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -61,6 +62,8 @@ public:
   unsigned int size() const override;
 
   void merge(SourceGroupInterface&& other) override;
+
+  std::unique_ptr<SourceInterface> clone() const override;
 
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;

--- a/SEFramework/SEFramework/Source/SourceGroupInterface.h
+++ b/SEFramework/SEFramework/Source/SourceGroupInterface.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -23,6 +24,7 @@
 #define _SEFRAMEWORK_SOURCEGROUPINTERFACE_H
 
 #include "SEFramework/Source/SourceInterface.h"
+#include "AlexandriaKernel/memory_tools.h"
 
 namespace SourceXtractor {
 
@@ -34,7 +36,7 @@ namespace SourceXtractor {
  *
  */
 
-class SourceGroupInterface : protected SourceInterface {
+class SourceGroupInterface : public SourceInterface {
 
   template <typename Collection>
   using CollectionType = typename std::iterator_traits<typename Collection::iterator>::value_type;
@@ -56,6 +58,10 @@ public:
 
     void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) override {
       m_source->setProperty(std::move(property), property_id);
+    }
+
+    std::unique_ptr<SourceInterface> clone() const override {
+      return Euclid::make_unique<SourceWrapper>(m_source->clone());
     }
 
     bool operator<(const SourceWrapper& other) const {
@@ -107,6 +113,7 @@ public:
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;
   using SourceInterface::setIndexedProperty;
+  using SourceInterface::clone;
 
 }; // end of SourceGroupInterface class
 

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
@@ -99,7 +99,7 @@ class SourceGroupWithOnDemandProperties::EntangledSource : public SourceInterfac
 
 public:
 
-  EntangledSource(std::shared_ptr<SourceInterface> source, SourceGroupWithOnDemandProperties& group);
+  EntangledSource(std::unique_ptr<SourceInterface> source, SourceGroupWithOnDemandProperties& group);
 
   virtual ~EntangledSource() = default;
 
@@ -114,7 +114,7 @@ public:
 private:
 
   PropertyHolder m_property_holder;
-  std::shared_ptr<SourceInterface> m_source;
+  std::unique_ptr<SourceInterface> m_source;
   SourceGroupWithOnDemandProperties& m_group;
 
   friend void SourceGroupWithOnDemandProperties::clearGroupProperties();

--- a/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
+++ b/SEFramework/SEFramework/Source/SourceGroupWithOnDemandProperties.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -70,6 +71,8 @@ public:
 
   unsigned int size() const override;
 
+  std::unique_ptr<SourceInterface> clone() const override;
+
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;
 
@@ -104,6 +107,8 @@ public:
 
   void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) override;
 
+  std::unique_ptr<SourceInterface> clone() const override;
+
   bool operator<(const EntangledSource& other) const;
 
 private:
@@ -114,7 +119,7 @@ private:
 
   friend void SourceGroupWithOnDemandProperties::clearGroupProperties();
   friend void SourceGroupWithOnDemandProperties::merge(SourceGroupInterface&&);
-
+  friend std::unique_ptr<SourceInterface> SourceGroupWithOnDemandProperties::clone() const;
 };
 
 } /* namespace SourceXtractor */

--- a/SEFramework/SEFramework/Source/SourceInterface.h
+++ b/SEFramework/SEFramework/Source/SourceInterface.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -77,6 +78,8 @@ public:
   /// Throws a PropertyNotFoundException if the property cannot be provided.
   virtual const Property& getProperty(const PropertyId& property_id) const = 0;
   virtual void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) = 0;
+
+  virtual std::unique_ptr<SourceInterface> clone() const = 0;
 
 }; /* End of SourceInterface class */
 

--- a/SEFramework/SEFramework/Source/SourceWithOnDemandProperties.h
+++ b/SEFramework/SEFramework/Source/SourceWithOnDemandProperties.h
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -50,8 +51,6 @@ public:
   virtual ~SourceWithOnDemandProperties() = default;
 
   // removes copy/move constructors and assignment operators
-
-  SourceWithOnDemandProperties(const SourceWithOnDemandProperties&) = delete;
   SourceWithOnDemandProperties& operator=(const SourceWithOnDemandProperties&) = delete;
   SourceWithOnDemandProperties(SourceWithOnDemandProperties&&) = delete;
   SourceWithOnDemandProperties& operator=(SourceWithOnDemandProperties&&) = delete;
@@ -65,6 +64,8 @@ public:
   // done by the using statements below.
   using SourceInterface::getProperty;
   using SourceInterface::setProperty;
+
+  std::unique_ptr<SourceInterface> clone() const override;
   
 protected:
   
@@ -73,6 +74,8 @@ protected:
   void setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) override;
 
 private:
+  SourceWithOnDemandProperties(const SourceWithOnDemandProperties& other);
+
   std::shared_ptr<const TaskProvider> m_task_provider;
   PropertyHolder m_property_holder;
 }; /* End of Source class */

--- a/SEFramework/src/lib/Property/PropertyHolder.cpp
+++ b/SEFramework/src/lib/Property/PropertyHolder.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -47,6 +48,10 @@ bool PropertyHolder::isPropertySet(const PropertyId& property_id) const {
 
 void PropertyHolder::clear() {
   m_properties.clear();
+}
+
+void PropertyHolder::update(const SourceXtractor::PropertyHolder& other) {
+  std::copy(other.m_properties.begin(), other.m_properties.end(), std::inserter(m_properties, m_properties.begin()));
 }
 
 } // SEFramework namespace

--- a/SEFramework/src/lib/Source/EntangledSource.cpp
+++ b/SEFramework/src/lib/Source/EntangledSource.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -78,6 +79,10 @@ const Property& SourceGroupWithOnDemandProperties::EntangledSource::getProperty(
 
 void SourceGroupWithOnDemandProperties::EntangledSource::setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) {
   m_property_holder.setProperty(std::move(property), property_id);
+}
+
+std::unique_ptr<SourceInterface> SourceGroupWithOnDemandProperties::EntangledSource::clone() const {
+  throw Elements::Exception("Can not clone an entangled source");
 }
 
 bool SourceGroupWithOnDemandProperties::EntangledSource::operator<(const EntangledSource& other) const {

--- a/SEFramework/src/lib/Source/EntangledSource.cpp
+++ b/SEFramework/src/lib/Source/EntangledSource.cpp
@@ -25,16 +25,16 @@
 
 namespace SourceXtractor {
 
-SourceGroupWithOnDemandProperties::EntangledSource::EntangledSource(std::shared_ptr<SourceInterface> source, SourceGroupWithOnDemandProperties& group)
-        : m_source(source), m_group(group) {
+SourceGroupWithOnDemandProperties::EntangledSource::EntangledSource(std::unique_ptr<SourceInterface> source, SourceGroupWithOnDemandProperties& group)
+        : m_source(std::move(source)), m_group(group) {
   // Normally, it should not be possible that the given source is of type
   // EntangledSource, because the entangled sources of a group can only be
   // accessed via the iterator as references. Nevertheless, to be sure that
   // future changes will not change the behavior, we do a check to the given
   // source and if it is an EntangledSource we use its encapsulated source instead.
-  auto entangled_ptr = std::dynamic_pointer_cast<EntangledSource>(m_source);
+  auto entangled_ptr = dynamic_cast<EntangledSource*>(m_source.get());
   if (entangled_ptr != nullptr) {
-    m_source = entangled_ptr->m_source;
+    m_source = std::move(entangled_ptr->m_source);
   }
 }
 

--- a/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
+++ b/SEFramework/src/lib/Source/SimpleSourceGroup.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -20,6 +21,9 @@
  */
 
 #include "SEFramework/Source/SimpleSourceGroup.h"
+#include "AlexandriaKernel/memory_tools.h"
+
+using Euclid::make_unique;
 
 namespace SourceXtractor {
 
@@ -77,4 +81,13 @@ unsigned int SimpleSourceGroup::size() const {
   return m_sources.size();
 }
 
-} // SourceXtractor namespace
+std::unique_ptr<SourceInterface> SimpleSourceGroup::clone() const {
+  auto cloned = make_unique<SimpleSourceGroup>();
+  for (const auto& src : m_sources) {
+    cloned->addSource(src.getRef().clone());
+  }
+  cloned->m_property_holder.update(m_property_holder);
+  return cloned;
+}
+
+}  // namespace SourceXtractor

--- a/SEFramework/src/lib/Source/SourceGroupWithOnDemandProperties.cpp
+++ b/SEFramework/src/lib/Source/SourceGroupWithOnDemandProperties.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -22,6 +23,9 @@
 
 #include "SEFramework/Source/SourceGroupWithOnDemandProperties.h"
 #include "SEFramework/Task/GroupTask.h"
+#include "AlexandriaKernel/memory_tools.h"
+
+using Euclid::make_unique;
 
 namespace SourceXtractor {
 
@@ -107,6 +111,16 @@ void SourceGroupWithOnDemandProperties::clearGroupProperties() {
 
 unsigned int SourceGroupWithOnDemandProperties::size() const {
   return m_sources.size();
+}
+
+std::unique_ptr<SourceInterface> SourceGroupWithOnDemandProperties::clone() const {
+  auto cloned = make_unique<SourceGroupWithOnDemandProperties>(m_task_provider);
+  for (const auto& source : m_sources) {
+    auto& entangled_source = dynamic_cast<EntangledSource&>(source.getRef());
+    cloned->m_sources.emplace_back(Euclid::make_unique<EntangledSource>(entangled_source.m_source, *cloned));
+  }
+  cloned->m_property_holder.update(this->m_property_holder);
+  return cloned;
 }
 
 } // SourceXtractor namespace

--- a/SEFramework/src/lib/Source/SourceGroupWithOnDemandProperties.cpp
+++ b/SEFramework/src/lib/Source/SourceGroupWithOnDemandProperties.cpp
@@ -117,7 +117,7 @@ std::unique_ptr<SourceInterface> SourceGroupWithOnDemandProperties::clone() cons
   auto cloned = make_unique<SourceGroupWithOnDemandProperties>(m_task_provider);
   for (const auto& source : m_sources) {
     auto& entangled_source = dynamic_cast<EntangledSource&>(source.getRef());
-    cloned->m_sources.emplace_back(Euclid::make_unique<EntangledSource>(entangled_source.m_source, *cloned));
+    cloned->m_sources.emplace_back(Euclid::make_unique<EntangledSource>(entangled_source.m_source->clone(), *cloned));
   }
   cloned->m_property_holder.update(this->m_property_holder);
   return cloned;

--- a/SEFramework/src/lib/Source/SourceWithOnDemandProperties.cpp
+++ b/SEFramework/src/lib/Source/SourceWithOnDemandProperties.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -23,13 +24,17 @@
 #include "SEFramework/Task/TaskProvider.h"
 #include "SEFramework/Task/SourceTask.h"
 #include "SEFramework/Property/PropertyNotFoundException.h"
-
 #include "SEFramework/Source/SourceWithOnDemandProperties.h"
 
 namespace SourceXtractor {
 
 SourceWithOnDemandProperties::SourceWithOnDemandProperties(std::shared_ptr<const TaskProvider> task_provider) :
             m_task_provider(task_provider) {
+}
+
+SourceWithOnDemandProperties::SourceWithOnDemandProperties(const SourceXtractor::SourceWithOnDemandProperties& other)
+    : m_task_provider(other.m_task_provider) {
+  m_property_holder.update(other.m_property_holder);
 }
 
 const Property& SourceWithOnDemandProperties::getProperty(const PropertyId& property_id) const {
@@ -52,6 +57,10 @@ const Property& SourceWithOnDemandProperties::getProperty(const PropertyId& prop
 void SourceWithOnDemandProperties::setProperty(std::unique_ptr<Property> property, const PropertyId& property_id) {
   // just forward to the ObjectWithProperties implementation
   m_property_holder.setProperty(std::move(property), property_id);
+}
+
+std::unique_ptr<SourceInterface> SourceWithOnDemandProperties::clone() const {
+  return std::unique_ptr<SourceInterface>(new SourceWithOnDemandProperties(*this));
 }
 
 

--- a/SEFramework/tests/src/Source/SourceInterface_test.cpp
+++ b/SEFramework/tests/src/Source/SourceInterface_test.cpp
@@ -1,4 +1,5 @@
-/** Copyright © 2019 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+/**
+ * Copyright © 2019-2022 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -52,6 +53,10 @@ public:
 
   MOCK_CONST_METHOD1(getProperty, Property& (const PropertyId& property_id));
   void setProperty(std::unique_ptr<Property>, const PropertyId& ) {}
+
+  std::unique_ptr<SourceInterface> clone() const override {
+    return nullptr;
+  }
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is needed so the Python wrapper can make copies of the sources if needed: for instance, if the Python code calling the C++ one is keeping hold of a source we can not move it, so we need to clone it.

Note that the properties already computed are *not* copied, since they are immutable we can just share a pointer to them. However, the map itself must be copied to avoid potential race conditions.