### PR TITLE
Iterative fitting bug with ranges

### DIFF
--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.h
@@ -56,6 +56,7 @@ public:
 
 private:
   struct SourceState {
+    std::unordered_map<int, double> parameters_initial_values;
     std::unordered_map<int, double> parameters_values;
     std::unordered_map<int, double> parameters_sigmas;
     std::unordered_map<int, bool> parameters_fitted;

--- a/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingParameter.h
+++ b/SEImplementation/SEImplementation/Plugin/FlexibleModelFitting/FlexibleModelFittingParameter.h
@@ -113,7 +113,7 @@ public:
                                   FlexibleModelFittingParameterManager& parameter_manager,
                                   ModelFitting::EngineParameterManager& engine_manager,
                                   const SourceInterface& source,
-                                  double initial_value) const;
+                                  double initial_value, double current_value) const;
 
   double getSigma(FlexibleModelFittingParameterManager& parameter_manager, const SourceInterface& source,
       const std::vector<double>& free_parameter_sigmas) const override;

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingIterativeTask.cpp
@@ -195,9 +195,11 @@ void FlexibleModelFittingIterativeTask::computeProperties(SourceGroupInterface& 
     for (auto parameter : m_parameters) {
       auto free_parameter = std::dynamic_pointer_cast<FlexibleModelFittingFreeParameter>(parameter);
       if (free_parameter != nullptr) {
-        initial_state.parameters_values[free_parameter->getId()] = free_parameter->getInitialValue(source);
+        initial_state.parameters_initial_values[free_parameter->getId()] =
+            initial_state.parameters_values[free_parameter->getId()] = free_parameter->getInitialValue(source);
       } else {
-        initial_state.parameters_values[parameter->getId()] = 0.0;
+        initial_state.parameters_initial_values[parameter->getId()] =
+            initial_state.parameters_values[parameter->getId()] = 0.0;
       }
       // Make sure we have a default value for sigmas in case we cannot do the fit
       initial_state.parameters_sigmas[parameter->getId()] = std::numeric_limits<double>::quiet_NaN();
@@ -293,6 +295,7 @@ std::shared_ptr<VectorImage<SeFloat>> FlexibleModelFittingIterativeTask::createD
           // Initial with the values from the current iteration run
           parameter_manager.addParameter(src, parameter,
               free_parameter->create(parameter_manager, engine_parameter_manager, src,
+                  state.source_states[index].parameters_initial_values.at(free_parameter->getId()),
                   state.source_states[index].parameters_values.at(free_parameter->getId())));
 
         } else {
@@ -337,6 +340,7 @@ int FlexibleModelFittingIterativeTask::fitSourcePrepareParameters(
       // Initial with the values from the current iteration run
       parameter_manager.addParameter(source, parameter,
           free_parameter->create(parameter_manager, engine_parameter_manager, source,
+              state.source_states[index].parameters_initial_values.at(free_parameter->getId()),
               state.source_states[index].parameters_values.at(free_parameter->getId())));
     } else {
       parameter_manager.addParameter(source, parameter,
@@ -573,6 +577,7 @@ void FlexibleModelFittingIterativeTask::updateCheckImages(SourceGroupInterface& 
         // Initialize with the values from the current iteration run
         parameter_manager.addParameter(src, parameter,
             free_parameter->create(parameter_manager, engine_parameter_manager, src,
+                state.source_states[index].parameters_initial_values.at(free_parameter->getId()),
                 state.source_states[index].parameters_values.at(free_parameter->getId())));
       } else {
         parameter_manager.addParameter(src, parameter,

--- a/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingParameter.cpp
+++ b/SEImplementation/src/lib/Plugin/FlexibleModelFitting/FlexibleModelFittingParameter.cpp
@@ -91,9 +91,9 @@ std::shared_ptr<ModelFitting::BasicParameter> FlexibleModelFittingFreeParameter:
                                                             FlexibleModelFittingParameterManager& /*parameter_manager*/,
                                                             ModelFitting::EngineParameterManager& engine_manager,
                                                             const SourceInterface& source,
-                                                            double initial_value) const {
+                                                            double initial_value, double current_value) const {
   auto converter = m_converter_factory->getConverter(initial_value, source);
-  auto parameter = std::make_shared<EngineParameter>(initial_value, std::move(converter));
+  auto parameter = std::make_shared<EngineParameter>(current_value, std::move(converter));
   engine_manager.registerParameter(parameter);
 
   return parameter;


### PR DESCRIPTION
Fixes a bug with iterative fitting using the current value of parameters for the range instead of initial value.

The range was reinitialized each meta iteration using the current value of the fit instead of the initial value. This would allow some parameters to diverge outside the expected range.
