### PR TITLE
Use rng seed instead of time()

### DIFF
--- a/SEImplementation/SEImplementation/Configuration/RngConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/RngConfig.h
@@ -1,0 +1,38 @@
+/*
+ * RngConfig.h
+ *
+ *  Created on: Mar 21, 2024
+ *      Author: mschefer
+ */
+
+#ifndef _SEIMPLEMENTATION_CONFIGURATION_RNGCONFIG_H_
+#define _SEIMPLEMENTATION_CONFIGURATION_RNGCONFIG_H_
+
+#include "Configuration/Configuration.h"
+#include "AlexandriaKernel/ThreadPool.h"
+
+namespace SourceXtractor {
+
+class RngConfig : public Euclid::Configuration::Configuration {
+public:
+  explicit RngConfig(long manager_id);
+
+  virtual ~RngConfig() = default;
+
+  std::map<std::string, OptionDescriptionList> getProgramOptions() override;
+
+  void initialize(const UserValues& args) override;
+
+  unsigned int getSeed() const {
+    return m_seed;
+  }
+
+private:
+  unsigned int m_seed;
+};
+
+
+}
+
+
+#endif /* _SEIMPLEMENTATION_CONFIGURATION_RNGCONFIG_H_ */

--- a/SEImplementation/SEImplementation/Partition/MultiThresholdPartitionStep.h
+++ b/SEImplementation/SEImplementation/Partition/MultiThresholdPartitionStep.h
@@ -24,6 +24,8 @@
 #ifndef _SEIMPLEMENTATION_PARTITION_MULTITHRESHOLDPARTITIONSTEP_H_
 #define _SEIMPLEMENTATION_PARTITION_MULTITHRESHOLDPARTITIONSTEP_H_
 
+#include <boost/random.hpp>
+
 #include "SEUtils/Types.h"
 
 #include "SEImplementation/Property/PixelCoordinateList.h"
@@ -48,7 +50,7 @@ class MultiThresholdPartitionStep : public PartitionStep {
 public:
 
   MultiThresholdPartitionStep(std::shared_ptr<SourceFactory> source_factory, SeFloat contrast,
-      unsigned int thresholds_nb, unsigned int min_deblend_area);
+      unsigned int thresholds_nb, unsigned int min_deblend_area, unsigned int seed);
 
   virtual ~MultiThresholdPartitionStep() = default;
 
@@ -67,6 +69,8 @@ private:
   SeFloat m_contrast;
   unsigned int m_thresholds_nb;
   unsigned int m_min_deblend_area;
+  unsigned int m_seed;
+  boost::random::mt19937 m_rng;
 };
 
 

--- a/SEImplementation/src/lib/Configuration/MultiThresholdPartitionConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MultiThresholdPartitionConfig.cpp
@@ -24,6 +24,7 @@
 #include "SEImplementation/Configuration/MultiThresholdPartitionConfig.h"
 #include "SEImplementation/Configuration/MinAreaPartitionConfig.h"
 #include "SEImplementation/Configuration/PartitionStepConfig.h"
+#include "SEImplementation/Configuration/RngConfig.h"
 
 #include "SEImplementation/Partition/MultiThresholdPartitionStep.h"
 
@@ -39,6 +40,7 @@ static const std::string MTHRESH_MIN_CONTRAST {"partition-minimum-contrast"};
 
 MultiThresholdPartitionConfig::MultiThresholdPartitionConfig(long manager_id) : Configuration(manager_id) {
   declareDependency<PartitionStepConfig>();
+  declareDependency<RngConfig>();
 
   ConfigManager::getInstance(manager_id).registerDependency<MultiThresholdPartitionConfig, MinAreaPartitionConfig>();
 }
@@ -57,6 +59,7 @@ void MultiThresholdPartitionConfig::initialize(const UserValues& args) {
     auto threshold_nb = args.at(MTHRESH_THRESHOLDS_NB).as<int>();
     auto min_area = args.at(MTHRESH_MIN_AREA).as<int>();
     auto min_contrast = args.at(MTHRESH_MIN_CONTRAST).as<double>();
+    auto seed = getDependency<RngConfig>().getSeed();
 
     if (min_area <= 0) {
         throw Elements::Exception() << "Invalid " << MTHRESH_MIN_AREA << " value: " << min_area;
@@ -67,7 +70,8 @@ void MultiThresholdPartitionConfig::initialize(const UserValues& args) {
 
     getDependency<PartitionStepConfig>().addPartitionStepCreator(
       [=](std::shared_ptr<SourceFactory> source_factory) {
-        return std::make_shared<MultiThresholdPartitionStep>(source_factory, min_contrast, threshold_nb, min_area);
+        return std::make_shared<MultiThresholdPartitionStep>(
+            source_factory, min_contrast, threshold_nb, min_area, seed);
       }
     );
   }

--- a/SEImplementation/src/lib/Configuration/RngConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/RngConfig.cpp
@@ -1,0 +1,42 @@
+/** Copyright © 2019-2024 Université de Genève, LMU Munich - Faculty of Physics, IAP-CNRS/Sorbonne Université
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <boost/thread.hpp>
+
+#include "SEImplementation/Configuration/RngConfig.h"
+
+using namespace Euclid::Configuration;
+namespace po = boost::program_options;
+
+namespace SourceXtractor {
+
+static const std::string RNG_SEED {"rng-seed"};
+
+RngConfig::RngConfig(long manager_id) : Configuration(manager_id), m_seed(42) {}
+
+auto RngConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
+  return { {"Random number generation", {
+      {RNG_SEED.c_str(), po::value<unsigned int>()->default_value(42), "Random number generator seed"},
+  }}};
+}
+
+void RngConfig::initialize(const UserValues& args) {
+  m_seed = args.at(RNG_SEED).as<unsigned int>();
+}
+
+} // SourceXtractor namespace
+

--- a/SEImplementation/src/lib/Partition/MultiThresholdPartitionStep.cpp
+++ b/SEImplementation/src/lib/Partition/MultiThresholdPartitionStep.cpp
@@ -21,8 +21,6 @@
  *      Author: mschefer
  */
 
-#include <boost/random.hpp>
-
 #include "SEImplementation/Measurement/MultithreadedMeasurement.h"
 #include "SEImplementation/Partition/MultiThresholdPartitionStep.h"
 
@@ -43,7 +41,6 @@
 namespace SourceXtractor {
 
 namespace {
-  boost::random::mt19937 rng { ((unsigned int) time(NULL)) };
 }
 
 class MultiThresholdNode : public std::enable_shared_from_this<MultiThresholdNode> {
@@ -313,7 +310,8 @@ std::vector<std::unique_ptr<SourceInterface>> MultiThresholdPartitionStep::reass
       }
 
       if (probabilities.back() > 1.0e-31) {
-        auto drand = double(probabilities.back()) * boost::random::uniform_01<double>()(rng);
+        auto drand = double(probabilities.back()) * boost::random::uniform_01<double>()
+            (const_cast<MultiThresholdPartitionStep*>(this)->m_rng);
 
         unsigned int i=0;
         for (; i<probabilities.size() && drand >= probabilities[i]; i++);
@@ -353,8 +351,8 @@ std::vector<std::unique_ptr<SourceInterface>> MultiThresholdPartitionStep::reass
 }
 
 MultiThresholdPartitionStep::MultiThresholdPartitionStep(std::shared_ptr<SourceFactory> source_factory, SeFloat contrast,
-    unsigned int thresholds_nb, unsigned int min_deblend_area) :
+    unsigned int thresholds_nb, unsigned int min_deblend_area, unsigned int seed) :
   m_source_factory(source_factory), m_contrast(contrast), m_thresholds_nb(thresholds_nb),
-  m_min_deblend_area(min_deblend_area) {}
+  m_min_deblend_area(min_deblend_area), m_seed(seed), m_rng(seed) {}
 
 } // namespace

--- a/SEImplementation/tests/src/Partition/MultiThresholdPartitionStep_test.cpp
+++ b/SEImplementation/tests/src/Partition/MultiThresholdPartitionStep_test.cpp
@@ -72,7 +72,8 @@ struct MultiThresholdPartitionFixture {
   std::shared_ptr<TaskProvider> task_provider {new TaskProvider(task_factory_registry)};
   std::unique_ptr<SourceWithOnDemandProperties> source {new SourceWithOnDemandProperties(task_provider)};
   std::shared_ptr<MultiThresholdPartitionStep> multithreshold_step {
-    new MultiThresholdPartitionStep(std::make_shared<SourceWithOnDemandPropertiesFactory>(task_provider), 0.005, 32, 1)
+    new MultiThresholdPartitionStep(
+        std::make_shared<SourceWithOnDemandPropertiesFactory>(task_provider), 0.005, 32, 1, 42)
   };
 
   MultiThresholdPartitionFixture() {


### PR DESCRIPTION
New parameter option --rng-seed. Default is 42 instead of using the system timer to generate a new one on each run.
