### PR TITLE
fix cryptic errors when running sx++ without parameters

### DIFF
--- a/SEImplementation/src/lib/Configuration/MeasurementImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MeasurementImageConfig.cpp
@@ -223,11 +223,14 @@ void MeasurementImageConfig::initialize(const UserValues&) {
       m_image_infos.emplace_back(std::move(info));
     }
   } else {
-    logger.debug() << "No measurement image provided, using the detection image for measurements";
-
     auto detection_image = getDependency<DetectionImageConfig>();
     auto weight_image = getDependency<WeightImageConfig>();
 
+    if (detection_image.getExtensionsNb() < 1) {
+      throw Elements::Exception() << "No measurement or detection image";
+    }
+
+    logger.debug() << "No measurement image provided, using the detection image for measurements";
     // note: flux scale was already applied
 
     m_image_infos.emplace_back(MeasurementImageInfo {

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -153,16 +153,16 @@ void AssocModeConfig::initialize(const UserValues& args) {
   }
 
   // sanity check that the configuration is coherent
-  checkConfig();
 
   // read the catalogs
   if (m_filename != "") {
+    checkConfig();
     readCatalogs(m_filename, m_columns, m_assoc_coord_type);
-  }
 
-  if (args.at(ASSOC_TEST).as<bool>()) {
-    printConfig();
-    throw Elements::Exception() << "Exiting by user request";
+    if (args.at(ASSOC_TEST).as<bool>()) {
+      printConfig();
+      throw Elements::Exception() << "Exiting by user request";
+    }
   }
 }
 

--- a/SEMain/src/program/SourceXtractor.cpp
+++ b/SEMain/src/program/SourceXtractor.cpp
@@ -454,6 +454,14 @@ public:
       }
     } else {
       // Running detection-less
+
+      auto assoc_mode_config = config_manager.getConfiguration<AssocModeConfig>();
+      if (assoc_mode_config.getCatalogs().size() < 1) {
+        logger.error() << "No detection image and no assoc catalog";
+        measurement->stopThreads();
+        return Elements::ExitCode::NOT_OK;
+      }
+
       try {
         // Process the catalog
         logger.info() << "Processing assoc catalog (no detection image)\n";


### PR DESCRIPTION
Since implementing no detection image mode, running sourcextractor++ with no parameters or configuration provided could result in cryptic error messages...

