### PR TITLE
Fix use of deprecated function

### DIFF
--- a/SEImplementation/src/lib/CheckImages/CheckImages.cpp
+++ b/SEImplementation/src/lib/CheckImages/CheckImages.cpp
@@ -156,7 +156,7 @@ void CheckImages::configure(Euclid::Configuration::ConfigManager& manager) {
   const auto& frames = manager.getConfiguration<MeasurementFrameConfig>().getFrames();
   for (auto& info : measurement_images_info) {
     std::stringstream label;
-    label << boost::filesystem::basename(info.m_path) << "_" << info.m_image_hdu;
+    label << boost::filesystem::path(info.m_path).stem().string() << "_" << info.m_image_hdu;
     if (info.m_is_data_cube) {
       label << "_" << info.m_image_layer;
     }
@@ -388,6 +388,7 @@ void CheckImages::saveImages() {
       auto filename = m_residual_filename.stem();
       filename += "_" + frame_info.m_label;
       filename += m_residual_filename.extension();
+
       auto frame_filename = m_residual_filename.parent_path() / filename;
       FitsWriter::writeFile(*residual_image, frame_filename.native(), frame_info.m_coordinate_system);
     }

--- a/SEImplementation/src/lib/Configuration/DetectionFrameConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/DetectionFrameConfig.cpp
@@ -62,7 +62,7 @@ void DetectionFrameConfig::initialize(const UserValues& ) {
     auto detection_frame = std::make_shared<DetectionImageFrame>(detection_image, weight_image,
         weight_threshold, detection_image_coordinate_system, detection_image_gain,
         detection_image_saturation, interpolation_gap);
-    detection_frame->setLabel(boost::filesystem::basename(detection_image_path));
+    detection_frame->setLabel(boost::filesystem::path(detection_image_path).stem().string());
 
     auto background_analyzer = getDependency<BackgroundAnalyzerFactory>().createBackgroundAnalyzer();
     auto background_model = background_analyzer->analyzeBackground(detection_frame->getOriginalImage(), weight_image,

--- a/SEImplementation/src/lib/Configuration/MeasurementFrameConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/MeasurementFrameConfig.cpp
@@ -64,7 +64,7 @@ void MeasurementFrameConfig::initialize(const UserValues&) {
     }
 
     std::stringstream label;
-    label << boost::filesystem::basename(image_info.m_path) << "_" << image_info.m_image_hdu;
+    label << boost::filesystem::path(image_info.m_path).stem().string() << "_" << image_info.m_image_hdu;
     measurement_frame->setLabel(label.str());
 
     if (image_info.m_weight_image != nullptr) {


### PR DESCRIPTION
Fix use of deprecated function from boost in creation of checkimages filenames. This version correctly uses .string() to avoid the quotation mark in the filename
