### PR TITLE
Fix for a bug in quadtree causing moffat grouping crash

### DIFF
--- a/SEImplementation/src/lib/Grouping/MoffatGrouping.cpp
+++ b/SEImplementation/src/lib/Grouping/MoffatGrouping.cpp
@@ -62,12 +62,14 @@ void MoffatGrouping::receiveSource(std::unique_ptr<SourceInterface> source) {
   // Encapsulates the source unique_ptr
   auto& centroid = source->getProperty<PixelCentroid>();
 
+  // Creates a SourceInfo to contain the unique_ptr to the source, coordinates and group_id
   auto source_info = std::make_shared<SourceInfo>();
   source_info->m_source = std::move(source);
   source_info->m_x = centroid.getCentroidX();
   source_info->m_y = centroid.getCentroidY();
   source_info->m_group_id = m_group_counter++;
 
+  // Make a group containing only the source
   auto group = std::make_shared<Group>();
   group->push_back(source_info);
   m_groups[source_info->m_group_id] = group;

--- a/SEUtils/SEUtils/_impl/QuadTree.icpp
+++ b/SEUtils/SEUtils/_impl/QuadTree.icpp
@@ -64,9 +64,10 @@ template<typename T>
 void QuadTree<T>::remove(const T& data) {
   if (m_is_divided) {
     auto c = Coord { Traits::getCoord(data, 0), Traits::getCoord(data, 1) };
-    auto quad = getQuadrant(c);
-    if (m_sub_trees[quad] != nullptr) {
-      m_sub_trees[quad]->remove(data);
+    for (int i=0; i<4; i++) {
+      if (m_sub_trees[i] != nullptr && m_sub_trees[i]->isContained(c)) {
+        m_sub_trees[i]->remove(data);
+      }
     }
   } else {
     auto it = std::find(m_data.begin(), m_data.end(), data);


### PR DESCRIPTION
The quad tree remove function wasn't working properly causing left over SourceInfo containing null ptrs to be left.

