### PR TITLE
Reference image for coordinate system

### DIFF
--- a/SEImplementation/SEImplementation/Configuration/DetectionImageConfig.h
+++ b/SEImplementation/SEImplementation/Configuration/DetectionImageConfig.h
@@ -54,6 +54,7 @@ class DetectionImageConfig : public Euclid::Configuration::Configuration {
 
   std::shared_ptr<DetectionImage> getDetectionImage(size_t index = 0) const;
   std::shared_ptr<CoordinateSystem> getCoordinateSystem(size_t index = 0) const;
+  bool isReferenceImage() const { return m_is_reference_image; }
   
   double getGain(size_t index = 0) const { return m_extensions.at(index).m_gain; }
   double getSaturation(size_t index = 0) const { return m_extensions.at(index).m_saturation; }
@@ -69,7 +70,11 @@ class DetectionImageConfig : public Euclid::Configuration::Configuration {
   }
 
   size_t getExtensionsNb() const {
-    return m_extensions.size();
+    if (m_is_reference_image) {
+      return 0;
+    } else {
+      return m_extensions.size();
+    }
   }
 
 private:
@@ -89,6 +94,7 @@ private:
 
   std::vector<DetectionImageExtension> m_extensions;
 
+  bool m_is_reference_image {false};
 }; /* End of DetectionImageConfig class */
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinatesTask.h
+++ b/SEImplementation/SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinatesTask.h
@@ -19,6 +19,7 @@
 #define _SEIMPLEMENTATION_PLUGIN_REFERENCECOORDINATES_REFERENCECOORDINATESTASK_H_
 
 #include "SEFramework/Task/SourceTask.h"
+#include "SEFramework/CoordinateSystem/CoordinateSystem.h"
 
 namespace SourceXtractor {
 
@@ -36,12 +37,15 @@ public:
   virtual ~ReferenceCoordinatesTask() = default;
 
   /// Constructor
-  explicit ReferenceCoordinatesTask(unsigned int instance) : m_instance(instance) {}
+  explicit ReferenceCoordinatesTask(unsigned int instance, std::shared_ptr<CoordinateSystem> coordinate_system)
+      : m_instance(instance), m_coordinate_system(coordinate_system) {
+  }
 
   void computeProperties(SourceInterface& source) const override;
 
 private:
   unsigned int m_instance;
+  std::shared_ptr<CoordinateSystem> m_coordinate_system;
 
 }; /* End of ReferenceCoordinatesTask class */
 

--- a/SEImplementation/SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinatesTaskFactory.h
+++ b/SEImplementation/SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinatesTaskFactory.h
@@ -39,6 +39,12 @@ public:
 
   // TaskFactory implementation
   std::shared_ptr<Task> createTask(const PropertyId& property_id) const override;
+
+  void reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const override;
+  void configure(Euclid::Configuration::ConfigManager& manager) override;
+
+private:
+  std::shared_ptr<CoordinateSystem> m_coordinate_system;
 };
 
 } /* namespace SourceXtractor */

--- a/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
+++ b/SEImplementation/src/lib/Configuration/DetectionImageConfig.cpp
@@ -40,6 +40,7 @@ namespace po = boost::program_options;
 namespace SourceXtractor {
 
 static const std::string DETECTION_IMAGE { "detection-image" };
+static const std::string REFERENCE_IMAGE { "reference-image" };
 static const std::string DETECTION_IMAGE_GAIN { "detection-image-gain" };
 static const std::string DETECTION_IMAGE_FLUX_SCALE {"detection-image-flux-scale"};
 static const std::string DETECTION_IMAGE_SATURATION { "detection-image-saturation" };
@@ -53,6 +54,8 @@ std::map<std::string, Configuration::OptionDescriptionList> DetectionImageConfig
   return { {"Detection image", {
       {DETECTION_IMAGE.c_str(), po::value<std::string>(),
           "Path to a fits format image to be used as detection image."},
+      {REFERENCE_IMAGE.c_str(), po::value<std::string>(),
+          "Path to a fits format image to be used as coordinates reference only."},
       {DETECTION_IMAGE_GAIN.c_str(), po::value<double>(),
           "Detection image gain in e-/ADU (0 = infinite gain)"},
       {DETECTION_IMAGE_FLUX_SCALE.c_str(), po::value<double>(),
@@ -67,13 +70,27 @@ std::map<std::string, Configuration::OptionDescriptionList> DetectionImageConfig
 }
 
 void DetectionImageConfig::initialize(const UserValues& args) {
-  // Normally we would define this one as required, but then --list-output-properties would be
-  // unusable unless we also specify --detection-image, which is not very intuitive.
-  // For this reason, we check for its existence here
 
   if (args.find(DETECTION_IMAGE) == args.end()) {
     // Running without a detection image
+
+    // Check if a reference image is provided
+    if (args.find(REFERENCE_IMAGE) != args.end()) {
+      DetectionImageExtension extension;
+
+      auto reference_image_source = std::make_shared<FitsImageSource>(
+          args.find(REFERENCE_IMAGE)->second.as<std::string>(), 0, ImageTile::FloatImage);
+      extension.m_coordinate_system = std::make_shared<WCS>(*reference_image_source);
+      m_extensions.emplace_back(std::move(extension));
+
+      m_is_reference_image = true;
+    }
+
     return;
+  }
+
+  if (args.find(REFERENCE_IMAGE) != args.end()) {
+    throw Elements::Exception() << "Either detection or reference image can be provided, not both";
   }
 
   m_detection_image_path = args.find(DETECTION_IMAGE)->second.as<std::string>();
@@ -188,6 +205,9 @@ std::string DetectionImageConfig::getDetectionImagePath() const {
 std::shared_ptr<DetectionImage> DetectionImageConfig::getDetectionImage(size_t index) const {
   if (getCurrentState() < State::INITIALIZED) {
     throw Elements::Exception() << "getDetectionImage() call on not initialized DetectionImageConfig";
+  }
+  if (m_is_reference_image) {
+    throw Elements::Exception() << "Trying to access detection image but only a reference image was provided";
   }
   return m_extensions.at(index).m_detection_image;
 }

--- a/SEImplementation/src/lib/Plugin/ReferenceCoordinates/ReferenceCoordinatesTask.cpp
+++ b/SEImplementation/src/lib/Plugin/ReferenceCoordinates/ReferenceCoordinatesTask.cpp
@@ -32,7 +32,11 @@ void ReferenceCoordinatesTask::computeProperties(SourceInterface& source) const 
     ref_coords = source.getProperty<DetectionFrameCoordinates>().getCoordinateSystem();
   }
   catch (PropertyNotFoundException&) {
-    ref_coords = source.getProperty<MeasurementFrameCoordinates>(0).getCoordinateSystem();
+    if (m_coordinate_system) {
+      ref_coords = m_coordinate_system;
+    } else {
+      ref_coords = source.getProperty<MeasurementFrameCoordinates>(0).getCoordinateSystem();
+    }
   }
 
   source.setProperty<ReferenceCoordinates>(ref_coords);

--- a/SEImplementation/src/lib/Plugin/ReferenceCoordinates/ReferenceCoordinatesTaskFactory.cpp
+++ b/SEImplementation/src/lib/Plugin/ReferenceCoordinates/ReferenceCoordinatesTaskFactory.cpp
@@ -16,6 +16,8 @@
  */
 
 
+#include "SEImplementation/Configuration/DetectionImageConfig.h"
+
 #include "SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinates.h"
 #include "SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinatesTask.h"
 #include "SEImplementation/Plugin/ReferenceCoordinates/ReferenceCoordinatesTaskFactory.h"
@@ -24,9 +26,20 @@ using namespace Euclid::Configuration;
 
 namespace SourceXtractor {
 
+void ReferenceCoordinatesTaskFactory::reportConfigDependencies(Euclid::Configuration::ConfigManager& manager) const {
+  manager.registerConfiguration<DetectionImageConfig>();
+}
+
+void ReferenceCoordinatesTaskFactory::configure(Euclid::Configuration::ConfigManager& manager) {
+  auto& detection_image_config = manager.getConfiguration<DetectionImageConfig>();
+  if (detection_image_config.isReferenceImage()) {
+    m_coordinate_system = detection_image_config.getCoordinateSystem();
+  }
+}
+
 std::shared_ptr<Task> ReferenceCoordinatesTaskFactory::createTask(const PropertyId& property_id) const {
   if (property_id.getTypeId() == PropertyId::create<ReferenceCoordinates>().getTypeId()) {
-    return std::make_shared<ReferenceCoordinatesTask>(property_id.getIndex());
+    return std::make_shared<ReferenceCoordinatesTask>(property_id.getIndex(), m_coordinate_system);
   } else {
     return nullptr;
   }


### PR DESCRIPTION
Allows specifying a reference image with the commande line option  `--reference-image`. It's used when no detection image is provided to specify the reference coordinate system used during model fitting. (By default we use the first measurement image as reference coordinate system but this is not always ideal)