### PR TITLE
Fix assoc source size configuration

### DIFF
--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -82,6 +82,16 @@ const std::map<std::string, AssocModeConfig::AssocCoordType> assoc_coord_type_ta
   std::make_pair("WORLD", AssocModeConfig::AssocCoordType::WORLD)
 };
 
+const std::string COLUMN_X = "x";
+const std::string COLUMN_Y = "y";
+const std::string COLUMN_RA = "ra";
+const std::string COLUMN_DEC = "dec";
+const std::string COLUMN_WEIGHT = "weight";
+const std::string COLUMN_GROUP_ID = "group_id";
+const std::string COLUMN_PIXEL_SIZE = "pixel_size";
+const std::string COLUMN_PIXEL_HALF_WIDTH = "pixel_half_width";
+const std::string COLUMN_PIXEL_HALF_HEIGHT = "pixel_half_height";
+
 std::vector<int> parseColumnList(const std::string& arg) {
   if (arg.size() > 0) {
     try {
@@ -233,60 +243,60 @@ void AssocModeConfig::readConfigFromParams(const UserValues& args) {
 void AssocModeConfig::readConfigFromFile(const std::string& filename) {
   m_assoc_columns = parseConfigFile(filename);
 
-  if (m_assoc_columns.find("x") != m_assoc_columns.end() && m_assoc_columns.find("y") != m_assoc_columns.end()) {
+  if (m_assoc_columns.find(COLUMN_X) != m_assoc_columns.end() && m_assoc_columns.find(COLUMN_Y) != m_assoc_columns.end()) {
     m_assoc_coord_type = AssocCoordType::PIXEL;
 
-    m_columns.push_back(m_assoc_columns.at("x"));
-    m_assoc_columns.erase("x");
-    m_columns.push_back(m_assoc_columns.at("y"));
-    m_assoc_columns.erase("y");
+    m_columns.push_back(m_assoc_columns.at(COLUMN_X));
+    m_assoc_columns.erase(COLUMN_X);
+    m_columns.push_back(m_assoc_columns.at(COLUMN_Y));
+    m_assoc_columns.erase(COLUMN_Y);
 
-    if (m_assoc_columns.find("ra") != m_assoc_columns.end() ||
-          m_assoc_columns.find("dec") != m_assoc_columns.end()) {
+    if (m_assoc_columns.find(COLUMN_RA) != m_assoc_columns.end() ||
+        m_assoc_columns.find(COLUMN_DEC) != m_assoc_columns.end()) {
       throw Elements::Exception() << "Use either X/Y or RA/DEC coordinates in assoc config file but not both";
     }
-  } else if (m_assoc_columns.find("ra") != m_assoc_columns.end() &&
-      m_assoc_columns.find("dec") != m_assoc_columns.end()) {
+  } else if (m_assoc_columns.find(COLUMN_RA) != m_assoc_columns.end() &&
+             m_assoc_columns.find(COLUMN_DEC) != m_assoc_columns.end()) {
 
     m_assoc_coord_type = AssocCoordType::WORLD;
 
-    m_columns.push_back(m_assoc_columns.at("ra"));
-    m_assoc_columns.erase("ra");
-    m_columns.push_back(m_assoc_columns.at("dec"));
-    m_assoc_columns.erase("dec");
+    m_columns.push_back(m_assoc_columns.at(COLUMN_RA));
+    m_assoc_columns.erase(COLUMN_RA);
+    m_columns.push_back(m_assoc_columns.at(COLUMN_DEC));
+    m_assoc_columns.erase(COLUMN_DEC);
 
-    if (m_assoc_columns.find("x") != m_assoc_columns.end() ||
-          m_assoc_columns.find("y") != m_assoc_columns.end()) {
+    if (m_assoc_columns.find(COLUMN_X) != m_assoc_columns.end() ||
+        m_assoc_columns.find(COLUMN_Y) != m_assoc_columns.end()) {
       throw Elements::Exception() << "Use either X/Y or RA/DEC coordinates in assoc config file but not both";
     }
   } else {
     throw Elements::Exception() << "Missing X/Y or RA/DEC coordinates in assoc config file";
   }
 
-  if (m_assoc_columns.find("weight") != m_assoc_columns.end()) {
-    m_columns.push_back(m_assoc_columns.at("weight"));
-    m_assoc_columns.erase("weight");
+  if (m_assoc_columns.find(COLUMN_WEIGHT) != m_assoc_columns.end()) {
+    m_columns.push_back(m_assoc_columns.at(COLUMN_WEIGHT));
+    m_assoc_columns.erase(COLUMN_WEIGHT);
   }
 
-  if (m_assoc_columns.find("pixel_size") != m_assoc_columns.end()) {
-    m_pixel_width_column = m_assoc_columns.at("pixel_size");
-    m_pixel_height_column = m_assoc_columns.at("pixel_size");
-    m_assoc_columns.erase("pixel_size");
+  if (m_assoc_columns.find(COLUMN_PIXEL_SIZE) != m_assoc_columns.end()) {
+    m_pixel_width_column = m_assoc_columns.at(COLUMN_PIXEL_SIZE);
+    m_pixel_height_column = m_assoc_columns.at(COLUMN_PIXEL_SIZE);
+    m_assoc_columns.erase(COLUMN_PIXEL_SIZE);
   }
 
-  if (m_assoc_columns.find("pixel_half_width") != m_assoc_columns.end()) {
-    m_pixel_width_column = m_assoc_columns.at("pixel_half_width");
-    m_assoc_columns.erase("pixel_half_width");
+  if (m_assoc_columns.find(COLUMN_PIXEL_HALF_WIDTH) != m_assoc_columns.end()) {
+    m_pixel_width_column = m_assoc_columns.at(COLUMN_PIXEL_HALF_WIDTH);
+    m_assoc_columns.erase(COLUMN_PIXEL_HALF_WIDTH);
   }
 
-  if (m_assoc_columns.find("pixel_half_height") != m_assoc_columns.end()) {
-    m_pixel_height_column = m_assoc_columns.at("pixel_half_height");
-    m_assoc_columns.erase("pixel_half_height");
+  if (m_assoc_columns.find(COLUMN_PIXEL_HALF_HEIGHT) != m_assoc_columns.end()) {
+    m_pixel_height_column = m_assoc_columns.at(COLUMN_PIXEL_HALF_HEIGHT);
+    m_assoc_columns.erase(COLUMN_PIXEL_HALF_HEIGHT);
   }
 
-  if (m_assoc_columns.find("group_id") != m_assoc_columns.end()) {
-    m_group_id_column = m_assoc_columns.at("group_id");
-    m_assoc_columns.erase("group_id");
+  if (m_assoc_columns.find(COLUMN_GROUP_ID) != m_assoc_columns.end()) {
+    m_group_id_column = m_assoc_columns.at(COLUMN_GROUP_ID);
+    m_assoc_columns.erase(COLUMN_GROUP_ID);
   }
 
   for (auto& column_info : m_assoc_columns) {
@@ -429,7 +439,8 @@ std::map<std::string, unsigned int>  AssocModeConfig::parseConfigFile(const std:
     std::map<std::string, unsigned int> columns;
 
     const std::vector<std::string> reserved_names {
-      "x", "y", "ra", "dec", "weight", "group_id", "pixel_size", "pixel_half_width", "pixel_half_height"
+      COLUMN_X, COLUMN_Y, COLUMN_RA, COLUMN_DEC, COLUMN_WEIGHT,
+      COLUMN_GROUP_ID, COLUMN_PIXEL_SIZE, COLUMN_PIXEL_HALF_WIDTH, COLUMN_PIXEL_HALF_HEIGHT
     };
 
     std::ifstream config_file(filename);

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -50,8 +50,8 @@ static const std::string ASSOC_COPY { "assoc-copy" };
 static const std::string ASSOC_COLUMNS { "assoc-columns" };
 static const std::string ASSOC_COORD_TYPE { "assoc-coord-type" };
 static const std::string ASSOC_SOURCE_SIZES { "assoc-source-sizes" };
-static const std::string ASSOC_SOURCE_WIDTHS { "assoc-source-widths" };
-static const std::string ASSOC_SOURCE_HEIGHTS { "assoc-source-heights" };
+static const std::string ASSOC_SOURCE_HALF_WIDTHS { "assoc-source-half-widths" };
+static const std::string ASSOC_SOURCE_HALF_HEIGHTS { "assoc-source-half-heights" };
 static const std::string ASSOC_DEFAULT_PIXEL_SIZE { "assoc-default-pixel-size" };
 static const std::string ASSOC_GROUP_ID { "assoc-group-id" };
 static const std::string ASSOC_CONFIG { "assoc-config" };
@@ -131,11 +131,11 @@ std::map<std::string, Configuration::OptionDescriptionList> AssocModeConfig::get
       {ASSOC_COORD_TYPE.c_str(), po::value<std::string>()->default_value("PIXEL"),
           "Assoc coordinates type: PIXEL, WORLD"},
       {ASSOC_SOURCE_SIZES.c_str(), po::value<int>()->default_value(-1),
-          "Column containing the source sizes (in reference frame pixels)"},
-      {ASSOC_SOURCE_WIDTHS.c_str(), po::value<int>()->default_value(-1),
-          "Column containing the source widths (in reference frame pixels)"},
-      {ASSOC_SOURCE_HEIGHTS.c_str(), po::value<int>()->default_value(-1),
-          "Column containing the source heights (in reference frame pixels)"},
+          "Column containing the source radius (in reference frame pixels)"},
+      {ASSOC_SOURCE_HALF_WIDTHS.c_str(), po::value<int>()->default_value(-1),
+          "Column containing the source half width (in reference frame pixels)"},
+      {ASSOC_SOURCE_HALF_HEIGHTS.c_str(), po::value<int>()->default_value(-1),
+          "Column containing the source half height (in reference frame pixels)"},
       {ASSOC_DEFAULT_PIXEL_SIZE.c_str(), po::value<double>()->default_value(5.0),
           "Default source size (in reference frame pixels)"},
       {ASSOC_GROUP_ID.c_str(), po::value<int>()->default_value(-1),
@@ -218,11 +218,11 @@ void AssocModeConfig::readConfigFromParams(const UserValues& args) {
   m_pixel_width_column = args.at(ASSOC_SOURCE_SIZES).as<int>() - 1; // config uses 1 as first column
   m_pixel_height_column = args.at(ASSOC_SOURCE_SIZES).as<int>() - 1; // config uses 1 as first column
 
-  if (args.find(ASSOC_SOURCE_WIDTHS) != args.end() && args.at(ASSOC_SOURCE_WIDTHS).as<int>() > 0) {
-    m_pixel_width_column = args.at(ASSOC_SOURCE_WIDTHS).as<int>() - 1; // config uses 1 as first column
+  if (args.find(ASSOC_SOURCE_HALF_WIDTHS) != args.end() && args.at(ASSOC_SOURCE_HALF_WIDTHS).as<int>() > 0) {
+    m_pixel_width_column = args.at(ASSOC_SOURCE_HALF_WIDTHS).as<int>() - 1; // config uses 1 as first column
   }
-  if (args.find(ASSOC_SOURCE_HEIGHTS) != args.end() && args.at(ASSOC_SOURCE_HEIGHTS).as<int>() > 0) {
-    m_pixel_height_column = args.at(ASSOC_SOURCE_HEIGHTS).as<int>() - 1; // config uses 1 as first column
+  if (args.find(ASSOC_SOURCE_HALF_HEIGHTS) != args.end() && args.at(ASSOC_SOURCE_HALF_HEIGHTS).as<int>() > 0) {
+    m_pixel_height_column = args.at(ASSOC_SOURCE_HALF_HEIGHTS).as<int>() - 1; // config uses 1 as first column
   }
 
   m_group_id_column = args.at(ASSOC_GROUP_ID).as<int>() - 1; // config uses 1 as first column

--- a/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
+++ b/SEImplementation/src/lib/Plugin/AssocMode/AssocModeConfig.cpp
@@ -274,14 +274,14 @@ void AssocModeConfig::readConfigFromFile(const std::string& filename) {
     m_assoc_columns.erase("pixel_size");
   }
 
-  if (m_assoc_columns.find("pixel_width") != m_assoc_columns.end()) {
-    m_pixel_width_column = m_assoc_columns.at("pixel_width");
-    m_assoc_columns.erase("pixel_width");
+  if (m_assoc_columns.find("pixel_half_width") != m_assoc_columns.end()) {
+    m_pixel_width_column = m_assoc_columns.at("pixel_half_width");
+    m_assoc_columns.erase("pixel_half_width");
   }
 
-  if (m_assoc_columns.find("pixel_height") != m_assoc_columns.end()) {
-    m_pixel_height_column = m_assoc_columns.at("pixel_height");
-    m_assoc_columns.erase("pixel_height");
+  if (m_assoc_columns.find("pixel_half_height") != m_assoc_columns.end()) {
+    m_pixel_height_column = m_assoc_columns.at("pixel_half_height");
+    m_assoc_columns.erase("pixel_half_height");
   }
 
   if (m_assoc_columns.find("group_id") != m_assoc_columns.end()) {
@@ -429,7 +429,7 @@ std::map<std::string, unsigned int>  AssocModeConfig::parseConfigFile(const std:
     std::map<std::string, unsigned int> columns;
 
     const std::vector<std::string> reserved_names {
-      "x", "y", "ra", "dec", "weight", "group_id", "pixel_size", "pixel_width", "pixel_height"
+      "x", "y", "ra", "dec", "weight", "group_id", "pixel_size", "pixel_half_width", "pixel_half_height"
     };
 
     std::ifstream config_file(filename);
@@ -493,10 +493,10 @@ void AssocModeConfig::printConfig() {
   }
 
   if (m_pixel_width_column >= 0) {
-    std::cout << "PIXEL_WIDTH" << "\t";
+    std::cout << "PIXEL_HALF_WIDTH" << "\t";
   }
   if (m_pixel_height_column >= 0) {
-    std::cout << "PIXEL_HEIGHT" << "\t";
+    std::cout << "PIXEL_HALF_HEIGHT" << "\t";
   }
   if (m_group_id_column >= 0) {
     std::cout << "GROUP_ID" << "\t";

--- a/SEImplementation/src/lib/Plugin/MeasurementFrameRectangle/MeasurementFrameRectangleTaskNoDetect.cpp
+++ b/SEImplementation/src/lib/Plugin/MeasurementFrameRectangle/MeasurementFrameRectangleTaskNoDetect.cpp
@@ -40,8 +40,8 @@ void MeasurementFrameRectangleTaskNoDetect::computeProperties(SourceInterface& s
   bool bad_coordinates = false;
   ImageCoordinate coord1, coord2, coord3, coord4;
   try {
-    int w = assoc_mode.getRefFramePixelWidth() / 2.0;
-    int h = assoc_mode.getRefFramePixelHeight() / 2.0;
+    int w = assoc_mode.getRefFramePixelWidth();
+    int h = assoc_mode.getRefFramePixelHeight();
 
     auto c = measurement_frame_coordinates->worldToImage(coord);
     coord1 = ImageCoordinate(c.m_x - w, c.m_y - h);


### PR DESCRIPTION
fix change in how assoc size column (`--assoc-source-sizes`) was interpreted,  (should be radius like in 0.22)

`--assoc-source-widths` changed to `--assoc-source-half-widths`
`--assoc-source-heights` changed to `--assoc-source-half-heights`

to reflect the changed behavior for those new parameters to be consistent.

